### PR TITLE
Drop tier curation field and trim home TOC strip

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -117,7 +117,6 @@
 | `name` | string | 한글 표기 (en 파일은 영문) |
 | `slug` | string | URL 안전, 공통 (한·영 동일) |
 | `category` | enum | `finance` / `messenger` / `commerce` / `delivery` / `mobility` / `content` / `community` / `travel` / `etc` 중 1 |
-| `tier` | 1 \| 2 \| 3 | 1 시그니처 / 2 대표주자 / 3 보조 |
 | `last_updated` | YYYY-MM-DD | 본문 마지막 갱신일 |
 | `sources` | URL[] | 공식 발표·테크블로그·참고 자료 |
 | `related_services` | slug[] | 관련 서비스 slug 목록 |
@@ -284,7 +283,7 @@
 | Q1 | 1차 타겟 사용자 | AI 빌더 (1차) + 디자이너·프론트엔드 (2차 흡수) — getdesign.md 본가와 동일 포지션 |
 | Q2 | Primary action | Copy & paste from 정적 사이트, MCP는 V1.x로 미룸, schema는 미리 호환 가능하게 |
 | Q3 | 콘텐츠 단위 | Service per file |
-| Q4 | MVP 라인업 규모 (방향) | 10~12개 수준 (Tier 1 expanded) — V0 launch 최소 N은 OQ-1 |
+| Q4 | MVP 라인업 규모 (방향) | 10~12개 수준 (시그니처 중심 라인업) — V0 launch 최소 N은 OQ-1 |
 | Q5 | Quality bar | Balanced (~5k tokens, 철학·시각언어·UX패턴·시그니처 컴포넌트·대표 화면·WHY·References) |
 | Q6 | 이중 언어 전략 | 서비스당 두 파일 (`{slug}.md` 한 default + `{slug}.en.md` 영) |
 | Q7 | 큐레이션 모델 | Maintainer-only V0 (PR은 V1.x) |
@@ -306,7 +305,6 @@
 name: <서비스명, 한글 표기>
 slug: <kebab-case-slug>
 category: <finance | messenger | commerce | delivery | mobility | content | community | travel | etc>
-tier: <1 | 2 | 3>
 last_updated: <YYYY-MM-DD>
 sources:
   - <공식 발표·테크블로그·디자인 시스템 URL>
@@ -367,7 +365,6 @@ estimated_tokens: <빌드 시 자동 계산>
 name: <Service name in English>
 slug: <same kebab-case-slug as Korean file>
 category: <same enum>
-tier: <same>
 last_updated: <YYYY-MM-DD>
 sources:
   - <same URL list>

--- a/scripts/build-og.ts
+++ b/scripts/build-og.ts
@@ -51,9 +51,6 @@ function buildServiceJob(doc: ServiceDoc): OgJob {
     { text: `${cat.koIndex}.`, brand: true },
     { text: cat.label },
   ]
-  if (doc.frontmatter.tier === 1) {
-    breadcrumb.push({ text: "/" }, { text: "★ TIER 1", brand: true })
-  }
   return {
     outputName: `${doc.frontmatter.slug}.png`,
     breadcrumb,

--- a/services/_demo-courier.md
+++ b/services/_demo-courier.md
@@ -2,7 +2,6 @@
 name: Demo Courier
 slug: demo-courier
 category: delivery
-tier: 2
 last_updated: 2026-05-07
 sources:
   - https://example.com/demo-courier/design

--- a/services/_demo-pay.md
+++ b/services/_demo-pay.md
@@ -2,7 +2,6 @@
 name: Demo Pay
 slug: demo-pay
 category: finance
-tier: 1
 last_updated: 2026-05-07
 sources:
   - https://example.com/demo-pay/design

--- a/src/features/home/components/service-card-grid.tsx
+++ b/src/features/home/components/service-card-grid.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router"
-import type { CategoryStyle } from "@/lib/category-style"
 import type { ServiceDoc } from "@/lib/content-types"
 import { getCategoryStyle } from "@/lib/category-style"
 
@@ -22,16 +21,6 @@ export function ServiceCardGrid({ services }: Props) {
     )
   }
 
-  // Build TOC entries from unique categories present in services (preserve first-seen order)
-  const tocEntries: Array<CategoryStyle> = []
-  const seen = new Set<string>()
-  for (const doc of services) {
-    if (!seen.has(doc.frontmatter.category)) {
-      seen.add(doc.frontmatter.category)
-      tocEntries.push(getCategoryStyle(doc.frontmatter.category))
-    }
-  }
-
   return (
     <section className="mx-auto max-w-[1400px] px-8 pb-32">
       {/* TOC strip */}
@@ -40,15 +29,6 @@ export function ServiceCardGrid({ services }: Props) {
         style={{ borderColor: "var(--rule-strong)" }}
       >
         <span className="text-meta-caps">Contents</span>
-        {tocEntries.map((meta) => (
-          <span key={meta.koIndex} className="inline-flex items-baseline gap-1.5 text-sm">
-            <span className="hangul-idx text-base">{meta.koIndex}.</span>
-            <span className="font-medium">
-              {meta.koLabel}{" "}
-              <span className="text-muted-foreground">({meta.label})</span>
-            </span>
-          </span>
-        ))}
         <span className="ml-auto text-meta-caps tabular-nums">
           {services.length} {services.length === 1 ? "ENTRY" : "ENTRIES"}
         </span>
@@ -88,13 +68,6 @@ export function ServiceCardGrid({ services }: Props) {
                   <div className="mb-4 inline-flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium tracking-wide">
                     <span className="hangul-idx text-base">{meta.koIndex}.</span>
                     <span>{meta.label.toUpperCase()}</span>
-                    {doc.frontmatter.tier === 1 ? (
-                      <span className="text-brand ml-3 font-bold">★ TIER 1</span>
-                    ) : (
-                      <span className="ml-3 text-muted-foreground">
-                        TIER {doc.frontmatter.tier}
-                      </span>
-                    )}
                   </div>
                   <h3 className="text-display mb-3.5 text-3xl font-black leading-[1.05] sm:text-4xl lg:text-5xl">
                     {doc.frontmatter.name}

--- a/src/features/service-detail/components/service-meta.tsx
+++ b/src/features/service-detail/components/service-meta.tsx
@@ -19,12 +19,6 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
         <span aria-hidden>/</span>
         <span className="text-brand font-bold">{meta.koIndex}.</span>
         <span>{meta.label.toUpperCase()}</span>
-        {frontmatter.tier === 1 && (
-          <>
-            <span aria-hidden>/</span>
-            <span className="text-brand font-bold">★ TIER 1</span>
-          </>
-        )}
         {frontmatter.last_updated && (
           <span className="ml-auto tabular-nums">
             UPDATED · {frontmatter.last_updated}

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -73,10 +73,14 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
   }
 }
 
+// ISO 8601 dates (YYYY-MM-DD) sort lexicographically the same as chronologically,
+// so a direct string compare is enough — no need for collation-aware localeCompare.
+// localeCompare is reserved for `name`, where Korean character ordering matters.
 export function sortDocs(docs: Array<ServiceDoc>): Array<ServiceDoc> {
-  return [...docs].sort(
-    (a, b) =>
-      b.frontmatter.last_updated.localeCompare(a.frontmatter.last_updated) ||
-      a.frontmatter.name.localeCompare(b.frontmatter.name),
-  )
+  return [...docs].sort((a, b) => {
+    const aDate = a.frontmatter.last_updated
+    const bDate = b.frontmatter.last_updated
+    if (aDate !== bDate) return aDate < bDate ? 1 : -1
+    return a.frontmatter.name.localeCompare(b.frontmatter.name)
+  })
 }

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -56,7 +56,6 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
     name: fm.name ?? slug,
     slug,
     category: fm.category ?? "etc",
-    tier: fm.tier ?? 3,
     last_updated: normalizeDateField(fm.last_updated),
     sources: fm.sources ?? [],
     related_services: fm.related_services ?? [],
@@ -77,7 +76,7 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
 export function sortDocs(docs: Array<ServiceDoc>): Array<ServiceDoc> {
   return [...docs].sort(
     (a, b) =>
-      a.frontmatter.tier - b.frontmatter.tier ||
+      b.frontmatter.last_updated.localeCompare(a.frontmatter.last_updated) ||
       a.frontmatter.name.localeCompare(b.frontmatter.name),
   )
 }

--- a/src/lib/content-types.ts
+++ b/src/lib/content-types.ts
@@ -9,14 +9,12 @@ export type Category =
   | "travel"
   | "etc"
 
-export type Tier = 1 | 2 | 3
 export type Lang = "ko" | "en"
 
 export interface ServiceFrontmatter {
   name: string
   slug: string
   category: Category
-  tier: Tier
   last_updated: string
   sources: Array<string>
   related_services: Array<string>


### PR DESCRIPTION
## Summary

- Remove `tier` (1/2/3) frontmatter field — a self-introduced curation grade not present in the upstream getdesign.md schema. The 2/3 boundary was subjective enough to add contributor friction, while the "signature" intent is already carried by the body's Korean-context (WHY) section.
- Sort key replaced: was `tier asc → name asc`; now `last_updated desc → name asc`. Catalog reads as "most recently touched first" with name as a stable fallback.
- ★ TIER 1 visual badges removed from home cards and detail page breadcrumb.
- Home TOC strip simplified: keeps the `CONTENTS` label and entry count, removes the inline category list. Cards still render their own category label (`ㄹ. DELIVERY`, `ㄱ. FINANCE`, …).

## Files

| Layer | Files |
|---|---|
| Types | `src/lib/content-types.ts` |
| Content collection | `src/lib/content-collection.ts` |
| Home grid | `src/features/home/components/service-card-grid.tsx` |
| Detail header | `src/features/service-detail/components/service-meta.tsx` |
| Demo content | `services/_demo-pay.md`, `services/_demo-courier.md` |
| PRD | `docs/PRD.md` (schema table, Q4, Appendix B ko/en templates) |

## Notes for reviewer

- `docs/superpowers/specs/` and `docs/superpowers/plans/` are intentionally **not** touched. They're history snapshots from when tier was designed in; the canonical source of truth is the new PRD + git log.
- The sort-order change is only observable once a date has more than one service, so the two demo md files (same `last_updated`) currently fall back to name asc — `Demo Courier` precedes `Demo Pay`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces `.output/*` (verified locally, 6.41s)
- [x] Home: TOC strip renders only `CONTENTS / 2 ENTRIES`; cards still show their category label
- [x] Detail: breadcrumb is `CATALOG / ㄱ. FINANCE / UPDATED · YYYY-MM-DD` with no ★ TIER 1
- [x] Sort: with equal `last_updated`, fallback to name asc works (Courier → Pay)