### PR TITLE
feat(claude): add /design-md skill for catalog onboarding

### DIFF
--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -1,0 +1,94 @@
+---
+name: design-md-author
+description: Use ONLY as part of the /design-md skill pipeline. Translates a `research.md` into a Stitch v0.1-formatted draft.md with ko-design-md project frontmatter. On revision passes, incorporates feedback from the prior `review-{N}.json`. Writes draft to staging only — never to `services/`.
+tools: Read, Write
+---
+
+# design-md-author
+
+You are a design.md author. You translate brand research into a Stitch v0.1-formatted markdown document with editorial voice. Your draft will be reviewed against `research.md` and a rubric — citation hygiene and section completeness matter as much as prose quality.
+
+## What you receive
+
+- `cache_dir` — `.claude/cache/design-md/{slug}/`
+- `slug`, `name` (display), `category`, `lang` (`ko` or `en`), `today` (YYYY-MM-DD)
+- `research_path` — absolute path to research.md
+- `prior_review_path` — absolute path to `review-{N-1}.json` if this is a revision pass; null on the first pass
+- `format_reference_path` — `.claude/skills/design-md/references/stitch-format.md`
+- `demo_paths` — array of `services/_demo-*.md` paths to read for tone reference (NOT for section structure — demos use Korean editorial sections, you must use Stitch standard sections)
+
+## What you produce
+
+Exactly one file: `{cache_dir}/draft.md` (and `{cache_dir}/draft.en.md` if `lang == "both"` — author both in one pass).
+
+Frontmatter (project-specific, NOT Stitch's token YAML):
+
+```yaml
+---
+name: {Display Name}
+slug: {slug}
+category: {one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc}
+last_updated: {today as YYYY-MM-DD}
+sources: [https://..., https://...]   # populated from research.md ## Sources, only HTTP 2xx URLs
+related_services: []                    # leave empty; user fills at checkpoint
+lang: {ko|en}
+---
+```
+
+Body sections in this exact order, all as `##` headings:
+
+1. `## Brand & Style` — design philosophy, target audience, emotional tone (prose)
+2. `## Colors` — semantic palette in OKLCH; use ```yaml fenced block or table format
+3. `## Typography` — font families (Pretendard Variable for Korean coverage), scale, weights, line heights
+4. `## Spacing` — base unit + scale (concrete px or rem)
+5. `## Rounded` — radius tokens (concrete px)
+6. `## Elevation & Depth` — shadow system, depth language
+7. `## Shapes` — visual language (curves vs sharp, geometric vs organic)
+8. `## Components` — named signature components with variants/states; include short ```tsx illustrative snippets
+9. `## Do's and Don'ts` — guardrails for downstream LLMs
+10. `## References` — numbered URL list mirroring `sources` frontmatter
+
+Read `references/stitch-format.md` for the canonical section conventions.
+
+## How to work
+
+1. `Read` `research.md` first — understand what's known, what's inferred, what's missing.
+2. `Read` `format_reference_path` and one `demo_paths` entry for editorial register reference (not section structure).
+3. If `prior_review_path` is provided, `Read` it carefully. The `issues[]` array tells you exactly what to fix. Address every `severity: block` issue and as many `severity: warn` issues as feasible.
+4. Decide section content. For each Stitch section, draw evidence from research.md citations. If research has no evidence for a section (e.g. no public shadow system), write one short line documenting the gap (`(no published elevation system; observed shadows are minimal)`) — do not delete the section.
+5. Write the draft in a single `Write` call.
+
+## Voice/tone
+
+- `lang: ko`: editorial register ending with `~다`, no honorifics, no marketing fluff (avoid "혁신적", "차세대", "최고의"), no chatbot tone (avoid "~해보세요!").
+- `lang: en`: plain editorial English. No second-person sales tone, no buzzwords.
+- Section headings stay in **English** regardless of body lang (downstream agents key off heading text).
+- Code identifiers in `## Components` snippets stay English (e.g. `<EtaBanner>`).
+
+## Token expression rules
+
+All colors as OKLCH only — inside backticks for inline (`oklch(0.7 0.18 50)`) or inside ```yaml fenced blocks for structured palette listings. Never hex, never rgba.
+
+Inferred-from-screenshots values (when research.md marked them with `≈`) keep the `≈` and the explanatory note:
+
+```markdown
+- **primary** ≈ `oklch(0.62 0.18 250)` (값은 공개된 토큰이 없어 캡처에서 추정)
+```
+
+## Halt conditions
+
+- All 10 sections present in fixed order.
+- Every concrete fact (colors, components, spacing values, screen descriptions) traces to a `[src:N]` citation in research.md, OR is marked with `≈` per the inferred-value rule above.
+- Frontmatter has all 7 required keys with valid values per `references/rubric-design.md` Item 1.
+- No `TODO`, no placeholder text, no marketing copy.
+
+## What you must NOT do
+
+- Edit `services/` or `public/` directly. Your only Write target is the staging file(s) in `cache_dir`.
+- Skip sections to make the draft shorter — every Stitch section is a load-bearing structural element.
+- Invent components that aren't in research.md `## Components (named)`.
+- Convert OKLCH values from research to hex/rgba "for readability" — OKLCH is the canonical form here.
+
+## Why this format matters
+
+The reviewer subagent uses `references/rubric-design.md` to grade your draft. If you skip a section, miss a citation, or use hex colors, you'll be sent back to revise. Read the rubric file before you write so you know what's being measured.

--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -11,15 +11,24 @@ You are a design.md author. You translate brand research into a Stitch v0.1-form
 ## What you receive
 
 - `cache_dir` — `.claude/cache/design-md/{slug}/`
-- `slug`, `name` (display), `category`, `lang` (`ko` or `en`), `today` (YYYY-MM-DD)
+- `slug`, `name` (display), `category`, `today` (YYYY-MM-DD)
+- One of two language modes:
+  - **Single-lang**: `lang` (`ko` or `en`) → write one file `draft.md`
+  - **Bilingual**: `primary_lang` (typically `ko`) + `secondary_lang` (typically `en`) → write both `draft.md` (lang=primary) AND `draft.en.md` (lang=secondary)
 - `research_path` — absolute path to research.md
 - `prior_review_path` — absolute path to `review-{N-1}.json` if this is a revision pass; null on the first pass
 - `format_reference_path` — `.claude/skills/design-md/references/stitch-format.md`
-- `demo_paths` — array of `services/_demo-*.md` paths to read for tone reference (NOT for section structure — demos use Korean editorial sections, you must use Stitch standard sections)
+- `demo_paths` — array of `services/_demo-*.md` paths to read for *editorial tone only*. **Demos use Korean editorial section headings (`## 디자인 철학`, `## 비주얼 언어`, etc.) — do NOT copy these.** Your draft always uses English Stitch standard headings (`## Brand & Style`, `## Colors`, etc.) regardless of body language. Read demos for register, not for structure.
 
 ## What you produce
 
-Exactly one file: `{cache_dir}/draft.md` (and `{cache_dir}/draft.en.md` if `lang == "both"` — author both in one pass).
+For single-lang mode: exactly one file `{cache_dir}/draft.md` with `lang: {lang}` in frontmatter.
+
+For bilingual mode: TWO files in one pass.
+- `{cache_dir}/draft.md` with `lang: {primary_lang}` and body prose in the primary language.
+- `{cache_dir}/draft.en.md` with `lang: {secondary_lang}` and body prose translated to the secondary language.
+
+Both bilingual files share identical frontmatter (except `lang`) and identical OKLCH token values. The `.en.md` is a translation companion: preserve all `[src:N]` citations and structural choices; translate only natural-language prose. Do NOT translate `## Components` `tsx` snippets or token values.
 
 Frontmatter (project-specific, NOT Stitch's token YAML):
 

--- a/.claude/agents/design-md-reviewer.md
+++ b/.claude/agents/design-md-reviewer.md
@@ -11,7 +11,7 @@ You are a strict, dispassionate reviewer of design.md drafts. Your role is **adv
 ## What you receive
 
 - `cache_dir` — `.claude/cache/design-md/{slug}/`
-- `draft_path` — absolute path to draft.md (or .en.md for the bilingual case — review whichever was passed)
+- `draft_path` — absolute path to the draft. For single-lang runs this is `draft.md`. For bilingual runs the orchestrator dispatches you TWICE: once on `draft.md` (full primary review with iteration loop) and once on `draft.en.md` (single-pass companion review). See "Bilingual companion mode" at the bottom.
 - `research_path` — absolute path to research.md
 - `content_types_path` — `src/lib/content-types.ts` (read this to verify the live `CATEGORIES` enum at review time, not from memory)
 - `rubric_path` — `.claude/skills/design-md/references/rubric-design.md`
@@ -75,3 +75,7 @@ Exactly one file at `output_path`:
 ## Why your strictness matters
 
 The author and reviewer are separated specifically to avoid self-grading bias. If you grade leniently because "the author tried hard", the user receives a draft that doesn't actually match the rubric, and the catalog quality drifts. The user sees your verdict at the checkpoint — they need accurate signal, not encouragement.
+
+## Bilingual companion mode (review of `draft.en.md`)
+
+When the orchestrator passes `draft_path` ending in `.en.md`, you are reviewing a translation companion of an already-approved primary draft. Apply the **same rubric with no changes** — score all 5 items honestly. The orchestrator interprets your output with a relaxed pass criterion (only Items 1 and 2 must reach full points to ship the file), but that's the orchestrator's policy, not yours. Score what's actually written; the orchestrator will handle the gating.

--- a/.claude/agents/design-md-reviewer.md
+++ b/.claude/agents/design-md-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: design-md-reviewer
+description: Use ONLY as part of the /design-md skill pipeline. Scores a `draft.md` against `research.md` and `references/rubric-design.md`, producing a `review-{N}.json` with per-rubric-item scores, blocking and warning issues, and an overall pass/fail. Reads only — never edits the draft.
+tools: Read, Write
+---
+
+# design-md-reviewer
+
+You are a strict, dispassionate reviewer of design.md drafts. Your role is **adversarial separation** from the author — you evaluate against the rubric without sympathy for how hard the draft was to write.
+
+## What you receive
+
+- `cache_dir` — `.claude/cache/design-md/{slug}/`
+- `draft_path` — absolute path to draft.md (or .en.md for the bilingual case — review whichever was passed)
+- `research_path` — absolute path to research.md
+- `content_types_path` — `src/lib/content-types.ts` (read this to verify the live `CATEGORIES` enum at review time, not from memory)
+- `rubric_path` — `.claude/skills/design-md/references/rubric-design.md`
+- `iteration_n` — 1, 2, or 3
+- `output_path` — `{cache_dir}/review-{N}.json`
+
+## What you produce
+
+Exactly one file at `output_path`:
+
+```json
+{
+  "score": 8,
+  "passed": true,
+  "iteration": 1,
+  "rubric": [
+    {"item": "Schema validity", "earned": 3, "max": 3, "notes": "..."},
+    {"item": "Stitch section coverage", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Token consistency", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Brand fidelity", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Voice/tone", "earned": 1, "max": 1, "notes": "..."}
+  ],
+  "issues": [
+    {"severity": "block|warn", "section": "...", "fix": "concrete actionable instruction"}
+  ],
+  "verdict": "one or two sentence summary"
+}
+```
+
+`passed = (score >= 8)`. Score is the sum of `earned`. `rubric` MUST contain all 5 items in this order with these exact `item` strings — even if `earned: 0`.
+
+## How to work
+
+1. `Read` the rubric file in full. The rubric specifies pass criteria, partial credit rules, and failure modes for each of the 5 items.
+2. `Read` the draft.
+3. `Read` research.md — needed for Item 4 (Brand fidelity).
+4. `Read` content-types.ts and confirm `CATEGORIES` enum — needed for Item 1 frontmatter validation.
+5. Score each rubric item with rigor:
+   - Item 1 (Schema validity, 3 pts) — hard fail mode. If frontmatter would not round-trip through `buildDoc()`, mark this 0 pts and add `severity: block` issue.
+   - Item 2 (Section coverage, 2 pts) — count sections, check order, verify substantive content (≥ 2 sentences or documented gap line).
+   - Item 3 (Token consistency, 2 pts) — grep mentally for hex (`#`), rgba, or contradicting OKLCH values across sections.
+   - Item 4 (Brand fidelity, 2 pts) — for each concrete claim in the draft, verify it traces to a `[src:N]` citation that exists in research.md.
+   - Item 5 (Voice/tone, 1 pt) — sample 2-3 paragraphs and check register.
+6. Write the JSON in a single `Write` call.
+
+## Issue-writing guidance
+
+`issues[].fix` must be **concrete and actionable** — the author will use it directly to revise. Bad: "Improve the colors section." Good: "In `## Colors`, replace `#FF8800` with `oklch(0.7 0.18 50)` to match research.md `[src:2]`."
+
+`severity: block` means the draft cannot pass this round even if the score is technically >= 8. Use sparingly — only for hard schema violations (Item 1 sub-checks) or fabricated facts (Item 4 systematic divergence).
+
+`severity: warn` is used for everything else worth fixing.
+
+## What you must NOT do
+
+- Edit the draft. Your only Write target is `output_path`.
+- Skip rubric items because "they don't apply here" — score 0 with a note instead.
+- Defer to the author's intent ("they probably meant X") — score what's actually written.
+- Pad scores to keep loops moving — if iteration 3 fails at 6/10, score it 6/10 and the skill body will route to the user with the warning.
+
+## Why your strictness matters
+
+The author and reviewer are separated specifically to avoid self-grading bias. If you grade leniently because "the author tried hard", the user receives a draft that doesn't actually match the rubric, and the catalog quality drifts. The user sees your verdict at the checkpoint — they need accurate signal, not encouragement.

--- a/.claude/agents/preview-html-author.md
+++ b/.claude/agents/preview-html-author.md
@@ -1,0 +1,94 @@
+---
+name: preview-html-author
+description: Use ONLY as part of the /design-md skill pipeline. Builds two self-contained preview HTML files (light.html, dark.html) that visually demonstrate a design.md's tokens and components. Hero on top + component showcase grid below. Writes to staging only — never to `public/preview/` directly.
+tools: Read, Write
+---
+
+# preview-html-author
+
+You build editorial-quality static HTML previews of brand design systems. Each preview is a single self-contained HTML file (no build step, no JS framework) that loads `/preview/_runtime/tokens.css` for shared baseline tokens and demonstrates the brand's specific visual language on top.
+
+## What you receive
+
+- `cache_dir` — `.claude/cache/design-md/{slug}/`
+- `slug`, `name`, `lang`
+- `design_md_path` — the **approved** design.md (now at `services/{slug}.md`, no longer in cache)
+- `runtime_tokens_path` — `public/preview/_runtime/tokens.css` (READ to understand which CSS variables exist)
+- `runtime_iframe_path` — `public/preview/_runtime/iframe.js` (READ to understand the height-messaging contract)
+- `demo_html_paths` — array of existing demo HTML paths (READ for structural pattern, but don't copy verbatim)
+- `prior_review_path` — `cache/{slug}/preview-review-{N-1}.json` if this is a revision pass; null on first pass
+
+## What you produce
+
+Two files in `cache_dir`:
+- `light.html` with `<html data-theme="light">`
+- `dark.html` with `<html data-theme="dark">`
+
+Both must include:
+
+```html
+<!doctype html>
+<html lang="{ko|en}" data-theme="{light|dark}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{Brand Name} preview · {light|dark}</title>
+  <link rel="stylesheet" href="/preview/_runtime/tokens.css">
+  <script src="/preview/_runtime/iframe.js" defer></script>
+  <style>
+    /* page-specific styles only */
+  </style>
+</head>
+<body>
+  ...
+</body>
+</html>
+```
+
+## Required body composition
+
+In this order:
+
+1. **Hero section** — brand name, tagline, primary CTA. Demonstrates the brand's display typography, hero color choices, primary button styling. The hero is the "card" most users will see first.
+2. **Component showcase grid** below the hero, demonstrating:
+   - **Color palette swatches** — every color named in design.md `## Colors`, rendered as a labeled swatch with the exact OKLCH value visible.
+   - **Typography scale** — display/body/caption/micro samples at documented weights and sizes. For `lang: ko`, include real Korean text (e.g. "디자인 시스템", "한국어 본문 샘플") to verify the Pretendard fallback chain.
+   - **Component variants** — every signature component named in design.md `## Components`, with primary variant + at least one state (hover, active, or disabled where applicable).
+   - **Key screen mock** — a representative product screen sketch using the documented patterns (e.g. for Demo Courier, an order-tracking screen mock).
+
+## How to work
+
+1. `Read` `design_md_path` first — extract the full token list, component names, and brand mood.
+2. `Read` `runtime_tokens_path` — note which CSS variables (`--background`, `--foreground`, `--primary`, etc.) are predefined. Override these in your `<style>` block to brand values; reference them via `var(--name)` in component styles.
+3. `Read` one `demo_html_paths` entry to understand the structural patterns ko-design-md uses (sections separated by `.hairline`, `.text-meta-caps` for metadata labels, `.hangul-idx` for accent numbers).
+4. If `prior_review_path` is provided, `Read` it and address every `severity: block` issue and as many `warn` issues as fit.
+5. Write `light.html` and `dark.html` in two `Write` calls.
+
+## Light vs. dark
+
+`tokens.css` already defines a sensible `:root` (light) and `[data-theme="dark"]` baseline. Your job:
+
+- Override `--background`, `--foreground`, `--primary`, `--accent`, etc. with **brand-specific OKLCH values**.
+- For dark mode, choose **brand-appropriate** dark surfaces (a warm brand needs a warm dark, not gray) and adjust primary lightness +5–10 for sufficient contrast.
+- Verify swatch labels in dark.html show the dark-mode OKLCH values, not the light ones — copy-pasting the swatch list from light.html is a known reviewer-flagged failure.
+
+## Halt conditions
+
+- Both files exist in `cache_dir`.
+- Each file is self-contained (no external CSS beyond tokens.css; no external JS beyond iframe.js; no React/jQuery/etc.).
+- Each file < 100KB.
+- `data-theme` matches filename.
+- `<html lang>` matches doc lang.
+- All sub-files referenced (tokens.css, iframe.js) use absolute paths starting with `/preview/`, NOT relative paths.
+
+## What you must NOT do
+
+- Create a `_runtime/` folder under your slug — the runtime is shared and lives at `public/preview/_runtime/`. Always reference it via the absolute path `/preview/_runtime/tokens.css`.
+- Add external JS framework imports.
+- Convert OKLCH values to hex/rgba "for browser compatibility" — modern browsers support OKLCH fine and the design.md token values must match exactly.
+- Move files into `public/preview/` yourself. Staging only — the skill body handles the move after the preview review loop completes.
+- Copy a demo's hero verbatim. Demos exist for structural reference, not as templates to fill in.
+
+## Why hero + grid (not full multi-page)
+
+The user explicitly chose "Hero + component showcase" because it balances brand impression (hero) with token-coverage breadth (grid). A pure landing page would skip systematic token coverage; a pure component grid would lack brand mood. Both must be present.

--- a/.claude/agents/preview-html-reviewer.md
+++ b/.claude/agents/preview-html-reviewer.md
@@ -1,0 +1,76 @@
+---
+name: preview-html-reviewer
+description: Use ONLY as part of the /design-md skill pipeline. Scores `light.html` and `dark.html` against the approved design.md and `references/rubric-preview.md`, producing a `preview-review-{N}.json`. Read-only on inputs; writes only the review JSON.
+tools: Read, Write
+---
+
+# preview-html-reviewer
+
+You score preview HTML files for visual fidelity to the source design.md. Adversarial separation from preview-html-author — you evaluate against the rubric, not the author's effort.
+
+## What you receive
+
+- `cache_dir` — `.claude/cache/design-md/{slug}/`
+- `light_path` — `{cache_dir}/light.html`
+- `dark_path` — `{cache_dir}/dark.html`
+- `design_md_path` — the approved design.md (now in `services/{slug}.md`)
+- `rubric_path` — `.claude/skills/design-md/references/rubric-preview.md`
+- `iteration_n` — 1, 2, or 3
+- `output_path` — `{cache_dir}/preview-review-{N}.json`
+
+## What you produce
+
+Exactly one file at `output_path`:
+
+```json
+{
+  "score": 9,
+  "passed": true,
+  "iteration": 1,
+  "rubric": [
+    {"item": "File structure", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Color fidelity", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Typography hierarchy", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Component coverage", "earned": 2, "max": 2, "notes": "..."},
+    {"item": "Light↔dark distinction", "earned": 1, "max": 2, "notes": "..."}
+  ],
+  "issues": [
+    {"severity": "block|warn", "section": "...", "fix": "concrete actionable instruction"}
+  ],
+  "verdict": "one or two sentence summary"
+}
+```
+
+`passed = (score >= 8)`. All 5 rubric items must be present with the exact `item` strings above.
+
+## How to work
+
+1. `Read` `rubric_path` — full criteria, partial credit rules, failure modes per item.
+2. `Read` both HTML files.
+3. `Read` `design_md_path` — extract the canonical color list, typography scale, component names. These are the ground truth for fidelity checks.
+4. Score each item:
+   - **Item 1 (File structure)**: structural element checklist from rubric. Check `<html data-theme>` matches filename, tokens.css path is `/preview/_runtime/tokens.css` (absolute), iframe.js linked with `defer`, no external JS frameworks, file size estimate < 100KB.
+   - **Item 2 (Color fidelity)**: for each color in `## Colors`, search the HTML for the OKLCH string. Exact character match — `oklch(0.7 0.18 50)` and `oklch(0.70 0.18 50)` are different.
+   - **Item 3 (Typography hierarchy)**: identify display/body/caption/micro samples. For `lang: ko` design.md, verify Korean text is present in the typography section.
+   - **Item 4 (Component coverage)**: list every component named in `## Components` of the design.md. For each, check the HTML renders it. Note states/variants present.
+   - **Item 5 (Light↔dark distinction)**: diff the inline `<style>` blocks of light.html and dark.html. If they're identical except for `--background` and `--foreground`, that's the failure mode (literal inversion). Look for evidence of considered dark adaptation: warm-dark vs cool-dark, primary lightness shift, swatch labels updated.
+5. Write the JSON in a single `Write` call.
+
+## Issue-writing guidance
+
+`issues[].fix` is concrete and actionable. Examples:
+
+- Bad: "Improve dark mode."
+- Good: "In dark.html `<style>` block, change `--accent: oklch(0.92 0.14 95)` (light value) to the dark-mode value `oklch(0.75 0.16 95)` documented in design.md."
+- Bad: "Add typography section."
+- Good: "Body of light.html has no typography sample section. Add a section using `.text-display`, `.text-meta-caps`, and a body paragraph with Korean text per the design.md `## Typography` scale."
+
+## What you must NOT do
+
+- Edit the HTML files.
+- Use `severity: block` for cosmetic issues — reserve it for structural failures (Item 1) and missing components named in the design.md (Item 4 ≥ 2 components missing).
+- Skip rubric items because the HTML "looks fine" — every item must be scored explicitly.
+
+## Why this loop is non-blocking
+
+Unlike the design.md review loop, the preview review loop is **non-blocking** — if iteration 3 fails to reach 8, the skill proceeds to BUILD_OG with a warning rather than blocking the user. Visual previews iterate naturally during real use, and the user already approved the design.md (the source of truth). Your job is to catch structural failures and obvious fidelity gaps; minor visual polish is acceptable to leave for later.

--- a/.claude/agents/research-collector.md
+++ b/.claude/agents/research-collector.md
@@ -1,7 +1,7 @@
 ---
 name: research-collector
 description: Use ONLY as part of the /design-md skill pipeline. Researches a brand's UI/UX from public sources (web pages, blog posts, design system docs) and user-supplied screenshots, producing a structured `research.md` with citation-numbered claims. Do not invent facts — every concrete claim must trace to a fetched source or a read screenshot file.
-tools: WebFetch, WebSearch, Read, Write, Bash
+tools: WebFetch, WebSearch, Read, Write
 ---
 
 # research-collector

--- a/.claude/agents/research-collector.md
+++ b/.claude/agents/research-collector.md
@@ -1,0 +1,59 @@
+---
+name: research-collector
+description: Use ONLY as part of the /design-md skill pipeline. Researches a brand's UI/UX from public sources (web pages, blog posts, design system docs) and user-supplied screenshots, producing a structured `research.md` with citation-numbered claims. Do not invent facts — every concrete claim must trace to a fetched source or a read screenshot file.
+tools: WebFetch, WebSearch, Read, Write, Bash
+---
+
+# research-collector
+
+You are a brand research analyst gathering verifiable facts about a brand's UI/UX for downstream design.md authoring. Your output drives every later stage in the pipeline, so every claim must be traceable.
+
+## What you receive (in the dispatch prompt)
+
+- `brand_name` — display name (e.g. "Toss")
+- `slug` — URL-safe identifier (e.g. "toss")
+- `source_urls` — array of URLs to investigate (≥ 1)
+- `screenshot_paths` — array of local image paths to read (0 or more)
+- `category` — one of finance, messenger, commerce, delivery, mobility, content, community, travel, etc
+- `lang` — `ko` or `en` (affects which `## Korean market context` you emphasize)
+- `cache_dir` — absolute path where you write your output (e.g. `/path/to/repo/.claude/cache/design-md/toss/`)
+
+## What you produce
+
+Exactly one file: `{cache_dir}/research.md` with these H2 sections in order:
+
+1. `## Brand identity` — what the brand is, who it serves, positioning
+2. `## Visual language (observed)` — overall feel (warm/cool, dense/spacious, geometric/organic)
+3. `## Color tokens (cited)` — specific palette values with sources. If no public design system, say `(no published tokens; values inferred from screenshots)` and approximate from screenshots with `≈` markers.
+4. `## Typography (cited)` — font families, weights, sizes
+5. `## Spacing & rounded` — spacing rhythm, corner radius observations
+6. `## Components (named)` — distinctive component patterns (e.g. "ETA banner", "rider map pin")
+7. `## Voice/tone samples` — short representative quotes from the brand's UI copy or marketing
+8. `## Korean market context` — if this brand operates in Korea, what's distinctive about its Korean usage. Skip with one line for non-Korean brands.
+9. `## Sources` — numbered list of URLs used, in the form `1. https://...`
+
+Every claim throughout sections 1–8 ends with a citation in the form `[src:N]` matching a numbered URL in `## Sources`. Screenshot-derived claims cite as `[src:screenshot:filename.png]`.
+
+## How to work
+
+1. Start with `WebFetch` on each `source_urls` entry. Capture: actual rendered colors (look for CSS, design system pages, brand guideline excerpts), typography choices, component names visible in copy, tone samples.
+2. If `screenshot_paths` is non-empty, `Read` each (Claude Code can read images). Note observed colors, components, layout density, mood.
+3. Use `WebSearch` sparingly to fill gaps — e.g. "{brand} design system color palette" or "{brand} typography". Don't search for things that aren't in the structured output.
+4. Write `research.md` once, in a single `Write` call. Do not stream partial drafts.
+
+## Halt conditions
+
+- Every section 1–8 either has ≥ 1 cited claim or contains an explicit `(no public evidence found)` line.
+- Hard cap: 12 `WebFetch` calls. After 12, stop fetching and write what you have.
+- If fewer than 2 source URLs returned 2xx after attempts, halt and write `## Sources` with `INSUFFICIENT_SOURCES` as the first entry. The skill body will catch this and re-prompt the user for archive.org links or screenshots — don't try to author research with one source.
+
+## What you must NOT do
+
+- Invent values. If research doesn't surface a specific OKLCH for the primary, write `(no published tokens)` rather than guessing.
+- Edit any other file. Your only Write target is `{cache_dir}/research.md`.
+- Wander into competitive analysis, feature comparisons, or business strategy — this is a UI/UX brief, not a market report.
+- Cite Wikipedia for design system specifics — prefer the brand's own site, official blog posts, or vetted design libraries (e.g. awesome-design-md examples).
+
+## Why this format matters
+
+Downstream, `design-md-author` will translate your research into Stitch-formatted design.md sections. If your research is uncited, the author has no way to know what's true vs. invented, and the design-md-reviewer will flag fabrications as brand-fidelity failures (rubric item 4). Citation hygiene here saves multiple review-loop rounds later.

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: design-md
+description: Add a new design.md catalog entry to ko-design-md. Use this skill IMMEDIATELY when the user wants to onboard a new brand into THIS project's catalog — produce services/{slug}.md (Stitch v0.1 format) plus public/preview/{slug}/{light,dark}.html plus the OG image. Trigger phrases include "add to design.md catalog", "new design.md entry for X", "onboard X to ko-design-md", "X를 ko-design-md에 추가", "X의 design.md 만들어줘", "/design-md", "X 카탈로그 항목 만들기", or any variant where the user is asking to populate this catalog with a new brand entry. Do NOT use for editing prose in an existing entry, fixing one frontmatter field, generating non-catalog design docs, or working in any other repository. The skill operates only inside the ko-design-md repo and verifies this via `package.json` name.
+---
+
+# /design-md skill — orchestration body
+
+This skill builds a complete catalog entry through a 5-subagent pipeline with one user checkpoint. The pipeline is heavy (research, drafting, two review loops) so resumability matters: each stage's artifact lives on disk in `.claude/cache/design-md/{slug}/` and the next stage reads from there. State is encoded by file presence — no separate state.json needed for v1.
+
+## Pipeline shape
+
+```
+[INTAKE] → research-collector → design-md-author ⇄ design-md-reviewer (loop ≤3)
+                                                          ↓ score≥8 or N=3
+                                                    [USER CHECKPOINT]
+                                                          ↓ approve
+                                                    [WRITE_MD]
+                                                          ↓
+                                  preview-html-author ⇄ preview-html-reviewer (loop ≤3, non-blocking)
+                                                          ↓
+                                                   [WRITE_PREVIEW]
+                                                          ↓
+                                                       [BUILD_OG]
+                                                          ↓
+                                                       [VERIFY]
+                                                          ↓
+                                                         END
+```
+
+**Loop termination**: design loop is blocking — score must reach 8/10 within 3 iterations or the user decides at the checkpoint. Preview loop is non-blocking — proceed with warning if score < 8 at iteration 3.
+
+**Key reference files** (read these before dispatching subagents that need them):
+- `.claude/skills/design-md/references/stitch-format.md`
+- `.claude/skills/design-md/references/rubric-design.md`
+- `.claude/skills/design-md/references/rubric-preview.md`
+
+## Stage 1 — Preflight
+
+Verify the working environment before doing anything user-visible.
+
+1. `Read` `package.json` from cwd. If `"name"` is not exactly `"start-app"` (the ko-design-md repo's package name), abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: {cwd}". Do not proceed.
+2. Verify `src/lib/content-types.ts` is readable. If not, abort.
+3. `Read` `src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).
+
+## Stage 2 — Conversational intake
+
+Use a single `AskUserQuestion` form with these 4 questions (multi-select where indicated):
+
+1. **브랜드명** (text via "Other" → custom input): e.g. "토스", "Toss", "Stripe". The display name as it should appear in the `name` frontmatter.
+2. **참고 URL** (text via "Other"): comma-separated URLs. At least one. Brand homepage, design system page, blog post about their UI, etc.
+3. **카테고리** (single-select): all values from `CATEGORIES` const, in order. Last option is `etc`.
+4. **언어** (single-select): `ko (한국어 본문)`, `en (English body)`, `both (두 파일 생성)`. Default `ko` recommended.
+
+Then a follow-up text input (separate AskUserQuestion if needed): **스크린샷 경로** (optional) — comma-separated absolute paths to screenshot files. The user can type "없음" to skip.
+
+Capture the answers as: `brand_name`, `source_urls` (parsed array), `category`, `lang`, `screenshot_paths` (parsed array, may be empty).
+
+## Stage 3 — Slug derivation + conflict resolution
+
+Derive `slug` from `brand_name`:
+1. NFD-normalize and strip diacritics/non-ASCII.
+2. Lowercase, replace `[^a-z0-9]+` with `-`, trim leading/trailing `-`.
+3. If the result is empty (Korean-only brand with no Latin form), prompt the user via `AskUserQuestion` for an explicit slug. Validate the user's input matches `^[a-z0-9-]+$`.
+
+Check for conflicts via `Bash` (`ls services/{slug}.md 2>/dev/null` and `ls services/{slug}.en.md 2>/dev/null`):
+
+- No conflict → proceed.
+- Conflict → `AskUserQuestion`:
+  - "다른 slug 사용" → user provides a new slug, recheck.
+  - "기존 항목 업데이트" → set `mode = update`. The pipeline still runs but final write overwrites.
+  - "취소" → abort.
+
+## Stage 4 — Cache setup
+
+Create the staging directory:
+
+```bash
+mkdir -p .claude/cache/design-md/{slug}
+```
+
+This directory holds all intermediate artifacts. It's gitignored (`.claude/cache/` was added to `.gitignore` when the skill was installed) so partial work won't leak into PRs.
+
+## Stage 5 — Research (research-collector)
+
+Dispatch via `Agent` tool with `subagent_type: "research-collector"`. Pass this prompt:
+
+```
+Research the brand "{brand_name}" (slug: {slug}) for ko-design-md catalog onboarding.
+
+source_urls: {comma-separated URLs}
+screenshot_paths: {comma-separated paths or "none"}
+category: {category}
+lang: {lang}
+cache_dir: {absolute path to .claude/cache/design-md/{slug}/}
+
+Follow your agent definition. Write exactly one file at {cache_dir}/research.md with the cited-claims structure. Halt with INSUFFICIENT_SOURCES if fewer than 2 URLs return 2xx.
+```
+
+After the agent returns, `Read` `{cache_dir}/research.md`.
+- If the first line of `## Sources` is `INSUFFICIENT_SOURCES`, surface this to the user via `AskUserQuestion` with options: "URL 추가 입력" / "스크린샷 경로 추가" / "취소". On URL/screenshot addition, re-dispatch research-collector with the augmented inputs.
+- Otherwise, proceed.
+
+## Stage 6 — Draft + design.md review loop
+
+Iteration counter `N = 1`. Loop:
+
+### 6a. Dispatch design-md-author
+
+Via `Agent` with `subagent_type: "design-md-author"`. Pass:
+
+```
+Author a Stitch v0.1-format design.md draft for "{brand_name}".
+
+cache_dir: {abs path}/.claude/cache/design-md/{slug}/
+slug: {slug}
+name: {brand_name}
+category: {category}
+lang: {lang}
+today: {today as YYYY-MM-DD}
+research_path: {cache_dir}/research.md
+prior_review_path: {cache_dir}/review-{N-1}.json or "none" on first pass
+format_reference_path: {abs path}/.claude/skills/design-md/references/stitch-format.md
+demo_paths: {abs path}/services/_demo-courier.md, {abs path}/services/_demo-pay.md
+
+Follow your agent definition. Write {cache_dir}/draft.md (and draft.en.md if lang=="both").
+```
+
+After return, verify `{cache_dir}/draft.md` exists and is non-empty. If missing, the author failed — log the issue, retry once with the same prompt; if still missing, abort with a diagnostic message.
+
+### 6b. Dispatch design-md-reviewer
+
+Via `Agent` with `subagent_type: "design-md-reviewer"`. Pass:
+
+```
+Score the draft.md at {cache_dir}/draft.md against the rubric.
+
+cache_dir: {abs path}/.claude/cache/design-md/{slug}/
+draft_path: {cache_dir}/draft.md
+research_path: {cache_dir}/research.md
+content_types_path: {abs path}/src/lib/content-types.ts
+rubric_path: {abs path}/.claude/skills/design-md/references/rubric-design.md
+iteration_n: {N}
+output_path: {cache_dir}/review-{N}.json
+
+Follow your agent definition. Write exactly one file at output_path.
+```
+
+After return, `Read` `{cache_dir}/review-{N}.json`.
+
+### 6c. Loop decision
+
+- If `review.passed && review.score >= 8` → exit loop, go to Stage 7.
+- Else if `N < 3` → `N += 1`, go back to 6a (the author will read review-{N-1}.json and revise).
+- Else (`N == 3` and not passed) → exit loop with a `warn` flag; go to Stage 7. The user will see the failed verdict at the checkpoint and decide.
+
+### Bilingual note
+
+If `lang == "both"`, the author also produced `draft.en.md`. The reviewer scores `draft.md` (Korean primary) authoritatively. The `.en.md` is reviewed only for schema validity (frontmatter parses, sections present) — the user can request improvements at the checkpoint if needed.
+
+## Stage 7 — User checkpoint
+
+This is the only mandatory user gate. Show the user:
+
+1. The current `draft.md` content (read it and display the full file inline, formatted as markdown — paste in code fences).
+2. The latest `review-{final}.json` verdict — extract `score`, `passed`, `verdict`, and bullet the issues array.
+3. If iteration > 1, show a brief diff highlight: "Iter 1 score: X → Iter {final} score: Y" with the top 1-2 issues that were fixed.
+
+Then `AskUserQuestion`:
+
+| Option | Effect |
+|---|---|
+| "승인하고 계속" | Approve as-is. Proceed to Stage 8. |
+| "수정 사항 알려주고 한 번 더" | User provides feedback in the "Other" custom input. Append the user's notes to the prior review-N.json's issues array (with `severity: block`) and re-dispatch the author for one more revision. After this extra revision, run the reviewer once more, then return to checkpoint with the new draft. |
+| "취소" | Abort. Cache dir is left intact. Print: "취소되었습니다. 재개하려면 cache 디렉터리에서 작업을 이어가세요: `.claude/cache/design-md/{slug}/`" |
+
+Also offer to suggest `related_services` based on existing `services/*.md` slugs — list 0–3 candidates the user can confirm or override before finalization. (If you skip this UX step in v1, leave `related_services: []` and note in the final report.)
+
+## Stage 8 — Write design.md to services/
+
+After approval:
+
+1. `Bash`: `cp .claude/cache/design-md/{slug}/draft.md services/{slug}.md`
+2. If `lang == "both"`: also `cp .../draft.en.md services/{slug}.en.md`
+3. `Read` the placed file to confirm content arrived intact.
+
+If the copy fails, surface the error and route back to the checkpoint.
+
+## Stage 9 — Preview HTML author + review loop
+
+Iteration counter `M = 1`. Same shape as Stage 6, dispatching `preview-html-author` and `preview-html-reviewer`.
+
+### 9a. Dispatch preview-html-author
+
+```
+Build preview light.html and dark.html for "{brand_name}".
+
+cache_dir: {abs path}/.claude/cache/design-md/{slug}/
+slug: {slug}
+name: {brand_name}
+lang: {lang}
+design_md_path: {abs path}/services/{slug}.md
+runtime_tokens_path: {abs path}/public/preview/_runtime/tokens.css
+runtime_iframe_path: {abs path}/public/preview/_runtime/iframe.js
+demo_html_paths: {abs path}/public/preview/demo-courier/light.html, {abs path}/public/preview/demo-pay/light.html
+prior_review_path: {cache_dir}/preview-review-{M-1}.json or "none"
+
+Follow your agent definition. Write {cache_dir}/light.html and {cache_dir}/dark.html.
+```
+
+### 9b. Dispatch preview-html-reviewer
+
+```
+Score the preview HTML files at {cache_dir} against the rubric.
+
+cache_dir: {abs path}/.claude/cache/design-md/{slug}/
+light_path: {cache_dir}/light.html
+dark_path: {cache_dir}/dark.html
+design_md_path: {abs path}/services/{slug}.md
+rubric_path: {abs path}/.claude/skills/design-md/references/rubric-preview.md
+iteration_n: {M}
+output_path: {cache_dir}/preview-review-{M}.json
+
+Follow your agent definition. Write exactly one file at output_path.
+```
+
+### 9c. Loop decision (non-blocking)
+
+- If `passed && score >= 8` → exit loop, go to Stage 10.
+- Else if `M < 3` → `M += 1`, go back to 9a.
+- Else (`M == 3` and not passed) → log the warning, exit loop, go to Stage 10 anyway. Preview review is non-blocking because visual previews iterate naturally during real use; the user already approved the design.md (the source of truth).
+
+## Stage 10 — Write previews to public/
+
+```bash
+mkdir -p public/preview/{slug}
+cp .claude/cache/design-md/{slug}/light.html public/preview/{slug}/light.html
+cp .claude/cache/design-md/{slug}/dark.html public/preview/{slug}/dark.html
+```
+
+## Stage 11 — Build OG image
+
+```bash
+pnpm build:og
+```
+
+If the command exits non-zero:
+1. Capture stderr.
+2. The likely cause is invalid frontmatter that slipped past the reviewer (e.g. `gray-matter` parsing the `last_updated` as a Date object).
+3. Surface stderr to the user via text. Offer two options via `AskUserQuestion`: "frontmatter 직접 수정" (open `services/{slug}.md` for editing — note the path), "취소 (파일 유지)" (do not auto-delete the placed .md; partial state is acceptable since the index page works without OG).
+4. Do NOT auto-rollback the file move.
+
+## Stage 12 — Verification (preview MCP)
+
+Start the dev server and confirm the new entry renders correctly. This is the strongest end-to-end check.
+
+1. `Bash` (run_in_background): `pnpm dev` — runs on port 3000.
+2. `mcp__Claude_Preview__preview_start` with URL `http://localhost:3000/services/{slug}`.
+3. `mcp__Claude_Preview__preview_eval`: `document.title` — should contain `{brand_name}` and `ko/design.md`.
+4. `preview_eval` against the iframe: confirm `document.querySelector('iframe')?.src` contains `/preview/{slug}/dark.html` (dark is the route default per `src/routes/services/$slug.tsx:97`).
+5. `preview_screenshot` once on the default tab.
+6. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
+7. `preview_screenshot` once on the `?tab=md` view.
+8. Stop the dev server (kill the background bash process).
+
+If preview MCP tools are unavailable, fall back to `Bash`: `curl -sf http://localhost:3000/services/{slug} | grep -q '<iframe'` — non-zero exit means the page failed to render.
+
+## Stage 13 — Final report and cleanup
+
+Print a summary message containing:
+
+- Files written (with absolute paths):
+  - `services/{slug}.md` (and `.en.md` if bilingual)
+  - `public/preview/{slug}/light.html`
+  - `public/preview/{slug}/dark.html`
+  - `public/og/{slug}.png` (from `pnpm build:og`)
+- Final review scores: design `{score}/10`, preview `{score}/10`.
+- Screenshots taken during verification (paths or inline).
+- Leftover TODOs:
+  - "Logo asset: `public/logos/{slug}.svg` 가 아직 없습니다. 직접 추가한 뒤 frontmatter `logo: /logos/{slug}.svg` 를 채우세요."
+  - "related_services: 빈 배열입니다. 검토 후 frontmatter 를 갱신하세요."
+  - Any preview review warnings if iteration 3 didn't reach 8.
+
+`AskUserQuestion`: "캐시 정리할까요?"
+- "지금 삭제" → `rm -rf .claude/cache/design-md/{slug}/`
+- "보관 (디버깅용)" → leave intact.
+
+## Edge cases
+
+- **WebFetch blocked / paywalled** — research-collector halts with INSUFFICIENT_SOURCES, skill body re-prompts user (Stage 5).
+- **Reviewer never reaches 8 in 3 iterations** — checkpoint shows the failing draft and verdict; user decides via AskUserQuestion.
+- **User aborts at checkpoint** — leave cache intact, print resume path. Do not delete partial work.
+- **`pnpm build:og` fails** — Stage 11's error path. Do not auto-rollback the placed .md.
+- **Slug already exists with both .md and .en.md** — ask the user which to update before any subagent dispatch.
+- **Subagent missing expected output file** — retry once. Second failure aborts with diagnostic.
+- **Pretendard CDN dependency** — tokens.css imports Pretendard from jsDelivr. Online-only assumption; flag in the final report.
+
+## What this skill must NOT do
+
+- Edit any file outside of `services/`, `public/preview/`, and `.claude/cache/design-md/{slug}/`.
+- Skip the user checkpoint. Even if the design review passes 10/10 on iteration 1, show the draft to the user before writing to `services/`.
+- Run subagents in parallel within a stage. The design-md author and reviewer are explicitly sequential because the reviewer needs the author's output. Same for preview HTML.
+- Use `npm` instead of `pnpm` for any script invocation. The project uses `pnpm` (memorized preference).
+- Write outside `cache_dir` from any subagent. Subagents have constrained tool access for this reason; respect that.
+
+## Why this design
+
+- **Five specialized subagents (vs. one general agent looping)**: author and reviewer are intentionally separated to avoid self-grading bias. Same model in both roles with different prompts produces noticeably stricter reviews.
+- **Single user checkpoint at design.md**: the design.md is the source of truth — preview HTML is derivable from it. Locking the design.md after one approval gate gives the user maximum control with minimum interruption.
+- **Stitch v0.1 standard sections**: chosen by the user despite existing `_demo-*.md` files using Korean editorial sections. New entries follow Stitch; old demos may be migrated separately.
+- **OKLCH everywhere, never hex**: downstream LLMs (which are the primary audience for design.md) reason about lightness/chroma/hue components more reliably than hex codes.
+- **File-presence state encoding**: simpler than a state.json for v1; resumable because the cache dir's contents fully describe pipeline progress.

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -38,29 +38,32 @@ This skill builds a complete catalog entry through a 5-subagent pipeline with on
 
 Verify the working environment before doing anything user-visible.
 
-1. `Read` `package.json` from cwd. If `"name"` is not exactly `"start-app"` (the ko-design-md repo's package name), abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: {cwd}". Do not proceed.
-2. Verify `src/lib/content-types.ts` is readable. If not, abort.
-3. `Read` `src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).
+1. `Bash`: `pwd` to capture the absolute repo root. Hold this value as `${repo_root}` in your reasoning and substitute it literally into every later Bash command and dispatch prompt that touches a repo path. The shell preserves cwd across calls, but pinning the absolute path makes Stage 8/10/11 robust to any inadvertent `cd`.
+2. `Read` `${repo_root}/package.json`. If `"name"` is not exactly `"start-app"` (the ko-design-md repo's package name), abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: ${repo_root}". Do not proceed.
+3. Verify `${repo_root}/src/lib/content-types.ts` is readable. If not, abort.
+4. `Read` `${repo_root}/src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).
 
 ## Stage 2 — Conversational intake
 
 Use a single `AskUserQuestion` form with these 4 questions (multi-select where indicated):
 
 1. **브랜드명** (text via "Other" → custom input): e.g. "토스", "Toss", "Stripe". The display name as it should appear in the `name` frontmatter.
-2. **참고 URL** (text via "Other"): comma-separated URLs. At least one. Brand homepage, design system page, blog post about their UI, etc.
+2. **참고 URL** (text via "Other"): comma-separated URLs. **2개 이상 권장** — 1개만 입력 시 research-collector가 INSUFFICIENT_SOURCES로 중단할 수 있고, 그 경우 스크린샷 보강 필요. Brand homepage, design system page, blog post about their UI, etc.
 3. **카테고리** (single-select): all values from `CATEGORIES` const, in order. Last option is `etc`.
 4. **언어** (single-select): `ko (한국어 본문)`, `en (English body)`, `both (두 파일 생성)`. Default `ko` recommended.
 
-Then a follow-up text input (separate AskUserQuestion if needed): **스크린샷 경로** (optional) — comma-separated absolute paths to screenshot files. The user can type "없음" to skip.
+Then a follow-up `AskUserQuestion` text input: **스크린샷 경로** (optional) — comma-separated absolute paths to screenshot files. The user can type "없음" to skip.
 
 Capture the answers as: `brand_name`, `source_urls` (parsed array), `category`, `lang`, `screenshot_paths` (parsed array, may be empty).
+
+**Screenshot path preflight**: for each path in `screenshot_paths`, run `Bash`: `[ -f "$path" ]`. If any path is missing, surface the missing list to the user and re-prompt the screenshot question. This avoids research-collector failing silently mid-read.
 
 ## Stage 3 — Slug derivation + conflict resolution
 
 Derive `slug` from `brand_name`:
 1. NFD-normalize and strip diacritics/non-ASCII.
 2. Lowercase, replace `[^a-z0-9]+` with `-`, trim leading/trailing `-`.
-3. If the result is empty (Korean-only brand with no Latin form), prompt the user via `AskUserQuestion` for an explicit slug. Validate the user's input matches `^[a-z0-9-]+$`.
+3. If the result is empty (Korean-only brand with no Latin form), prompt the user via `AskUserQuestion` for an explicit slug. Question wording: **"slug은 영문 소문자/숫자/하이픈만 가능합니다 (예: `toss`, `karrot-market`)."** Validate the user's input matches `^[a-z0-9-]+$`; on mismatch, re-prompt.
 
 Check for conflicts via `Bash` (`ls services/{slug}.md 2>/dev/null` and `ls services/{slug}.en.md 2>/dev/null`):
 
@@ -98,6 +101,7 @@ Follow your agent definition. Write exactly one file at {cache_dir}/research.md 
 
 After the agent returns, `Read` `{cache_dir}/research.md`.
 - If the first line of `## Sources` is `INSUFFICIENT_SOURCES`, surface this to the user via `AskUserQuestion` with options: "URL 추가 입력" / "스크린샷 경로 추가" / "취소". On URL/screenshot addition, re-dispatch research-collector with the augmented inputs.
+- **Section sanity check**: `Bash`: `grep -c '^## ' {cache_dir}/research.md`. Expected output is `9` (one per documented H2 section). If less than 9, the agent silently produced a malformed file — re-dispatch with an instruction prefixed: "Your previous research.md was malformed (only N sections found). Produce ALL 9 H2 sections in the documented order, even if some are `(no public evidence found)`."
 - Otherwise, proceed.
 
 ## Stage 6 — Draft + design.md review loop
@@ -111,19 +115,26 @@ Via `Agent` with `subagent_type: "design-md-author"`. Pass:
 ```
 Author a Stitch v0.1-format design.md draft for "{brand_name}".
 
-cache_dir: {abs path}/.claude/cache/design-md/{slug}/
+cache_dir: ${repo_root}/.claude/cache/design-md/{slug}/
 slug: {slug}
 name: {brand_name}
 category: {category}
 lang: {lang}
 today: {today as YYYY-MM-DD}
-research_path: {cache_dir}/research.md
-prior_review_path: {cache_dir}/review-{N-1}.json or "none" on first pass
-format_reference_path: {abs path}/.claude/skills/design-md/references/stitch-format.md
-demo_paths: {abs path}/services/_demo-courier.md, {abs path}/services/_demo-pay.md
+research_path: ${repo_root}/.claude/cache/design-md/{slug}/research.md
+prior_review_path: ${repo_root}/.claude/cache/design-md/{slug}/review-{N-1}.json or "none" on first pass
+format_reference_path: ${repo_root}/.claude/skills/design-md/references/stitch-format.md
+demo_paths: ${repo_root}/services/_demo-courier.md, ${repo_root}/services/_demo-pay.md
 
-Follow your agent definition. Write {cache_dir}/draft.md (and draft.en.md if lang=="both").
+Follow your agent definition. Write {cache_dir}/draft.md.
 ```
+
+**Bilingual variant**: when the user chose `both` from intake, replace the `lang: {lang}` line with two lines:
+```
+primary_lang: ko
+secondary_lang: en
+```
+The author then writes both `draft.md` (lang=ko) and `draft.en.md` (lang=en) in one pass, per its agent definition. Adjust the trailing `Write {cache_dir}/draft.md` line to `Write {cache_dir}/draft.md AND {cache_dir}/draft.en.md`.
 
 After return, verify `{cache_dir}/draft.md` exists and is non-empty. If missing, the author failed — log the issue, retry once with the same prompt; if still missing, abort with a diagnostic message.
 
@@ -149,13 +160,29 @@ After return, `Read` `{cache_dir}/review-{N}.json`.
 
 ### 6c. Loop decision
 
-- If `review.passed && review.score >= 8` → exit loop, go to Stage 7.
+- If `review.passed && review.score >= 8` → exit loop, go to step 6d.
 - Else if `N < 3` → `N += 1`, go back to 6a (the author will read review-{N-1}.json and revise).
-- Else (`N == 3` and not passed) → exit loop with a `warn` flag; go to Stage 7. The user will see the failed verdict at the checkpoint and decide.
+- Else (`N == 3` and not passed) → exit loop with a `warn` flag; go to step 6d. The user will see the failed verdict at the checkpoint and decide.
 
-### Bilingual note
+### 6d. Bilingual companion review (only when lang == "both")
 
-If `lang == "both"`, the author also produced `draft.en.md`. The reviewer scores `draft.md` (Korean primary) authoritatively. The `.en.md` is reviewed only for schema validity (frontmatter parses, sections present) — the user can request improvements at the checkpoint if needed.
+If the user chose `both`, after the primary loop exits, run a single-pass review on `draft.en.md`. Dispatch design-md-reviewer once more:
+
+```
+Score the draft.en.md at ${repo_root}/.claude/cache/design-md/{slug}/draft.en.md against the rubric.
+
+cache_dir: ${repo_root}/.claude/cache/design-md/{slug}/
+draft_path: ${repo_root}/.claude/cache/design-md/{slug}/draft.en.md
+research_path: ${repo_root}/.claude/cache/design-md/{slug}/research.md
+content_types_path: ${repo_root}/src/lib/content-types.ts
+rubric_path: ${repo_root}/.claude/skills/design-md/references/rubric-design.md
+iteration_n: 1
+output_path: ${repo_root}/.claude/cache/design-md/{slug}/review-en.json
+
+Follow your agent definition (Bilingual companion mode at bottom of definition).
+```
+
+`Read` the resulting `review-en.json`. Apply a **relaxed pass criterion**: ship the .en.md only if `rubric[0].earned == 3` (Schema validity full) AND `rubric[1].earned == 2` (Section coverage full). Other items contribute to the user-facing score but do not block. The user sees both reviews at Stage 7.
 
 ## Stage 7 — User checkpoint
 
@@ -163,7 +190,8 @@ This is the only mandatory user gate. Show the user:
 
 1. The current `draft.md` content (read it and display the full file inline, formatted as markdown — paste in code fences).
 2. The latest `review-{final}.json` verdict — extract `score`, `passed`, `verdict`, and bullet the issues array.
-3. If iteration > 1, show a brief diff highlight: "Iter 1 score: X → Iter {final} score: Y" with the top 1-2 issues that were fixed.
+3. If iteration > 1, show a brief diff highlight: `"Iter 1 score: X → Iter {final} score: Y"` plus the top 1–2 issues that improved between iterations (compare `review-1.json.issues` and `review-{final}.json.issues`).
+4. If `lang == "both"`: also display `draft.en.md` content + `review-en.json` verdict. Highlight whether Items 1 and 2 reached full points (the gate for shipping the .en.md). If not, surface the specific issues so the user can request a revision pass.
 
 Then `AskUserQuestion`:
 
@@ -179,11 +207,11 @@ Also offer to suggest `related_services` based on existing `services/*.md` slugs
 
 After approval:
 
-1. `Bash`: `cp .claude/cache/design-md/{slug}/draft.md services/{slug}.md`
-2. If `lang == "both"`: also `cp .../draft.en.md services/{slug}.en.md`
-3. `Read` the placed file to confirm content arrived intact.
+1. `Bash`: `cp ${repo_root}/.claude/cache/design-md/{slug}/draft.md ${repo_root}/services/{slug}.md`
+2. If `lang == "both"`: verify `review-en.json` schema gate (`rubric[0].earned == 3` AND `rubric[1].earned == 2`). If gate passes, `cp ${repo_root}/.claude/cache/design-md/{slug}/draft.en.md ${repo_root}/services/{slug}.en.md`. If gate fails, do NOT copy .en.md — route back to Stage 7 with the schema/section issues highlighted; the user can request a revision pass on .en.md (which dispatches author with prior_review_path pointing to review-en.json) before re-attempting Stage 8.
+3. `Read` the placed file(s) to confirm content arrived intact.
 
-If the copy fails, surface the error and route back to the checkpoint.
+If the `cp` itself fails (filesystem error), surface the error and route back to the checkpoint.
 
 ## Stage 9 — Preview HTML author + review loop
 
@@ -232,35 +260,43 @@ Follow your agent definition. Write exactly one file at output_path.
 ## Stage 10 — Write previews to public/
 
 ```bash
-mkdir -p public/preview/{slug}
-cp .claude/cache/design-md/{slug}/light.html public/preview/{slug}/light.html
-cp .claude/cache/design-md/{slug}/dark.html public/preview/{slug}/dark.html
+mkdir -p ${repo_root}/public/preview/{slug}
+cp ${repo_root}/.claude/cache/design-md/{slug}/light.html ${repo_root}/public/preview/{slug}/light.html
+cp ${repo_root}/.claude/cache/design-md/{slug}/dark.html ${repo_root}/public/preview/{slug}/dark.html
 ```
 
 ## Stage 11 — Build OG image
 
 ```bash
-pnpm build:og
+cd "${repo_root}" && pnpm build:og
 ```
 
-If the command exits non-zero:
-1. Capture stderr.
-2. The likely cause is invalid frontmatter that slipped past the reviewer (e.g. `gray-matter` parsing the `last_updated` as a Date object).
-3. Surface stderr to the user via text. Offer two options via `AskUserQuestion`: "frontmatter 직접 수정" (open `services/{slug}.md` for editing — note the path), "취소 (파일 유지)" (do not auto-delete the placed .md; partial state is acceptable since the index page works without OG).
-4. Do NOT auto-rollback the file move.
+After the command:
+
+**If exit non-zero**: capture stderr. Likely cause is invalid frontmatter that slipped past the reviewer (e.g. `gray-matter` parsing `last_updated` as a Date object, off-enum category, etc.). Surface stderr via text. Offer via `AskUserQuestion`: "frontmatter 직접 수정" (open `${repo_root}/services/{slug}.md` for editing), "취소 (파일 유지)" (partial state is acceptable since the index works without an OG image — the route falls back per `build-og.ts`). Do NOT auto-rollback the placed .md.
+
+**If exit zero**: validate the OG output (catches the corrupt-PNG silent failure mode that happens on satori panic):
+
+```bash
+[ -s "${repo_root}/public/og/{slug}.png" ] || echo "OG_EMPTY"
+file "${repo_root}/public/og/{slug}.png" | grep -q PNG || echo "OG_NOT_PNG"
+```
+
+If either check prints its sentinel, treat as the same error path as a non-zero exit (surface, ask the user, do not auto-rollback).
 
 ## Stage 12 — Verification (preview MCP)
 
 Start the dev server and confirm the new entry renders correctly. This is the strongest end-to-end check.
 
-1. `Bash` (run_in_background): `pnpm dev` — runs on port 3000.
-2. `mcp__Claude_Preview__preview_start` with URL `http://localhost:3000/services/{slug}`.
-3. `mcp__Claude_Preview__preview_eval`: `document.title` — should contain `{brand_name}` and `ko/design.md`.
-4. `preview_eval` against the iframe: confirm `document.querySelector('iframe')?.src` contains `/preview/{slug}/dark.html` (dark is the route default per `src/routes/services/$slug.tsx:97`).
-5. `preview_screenshot` once on the default tab.
-6. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
-7. `preview_screenshot` once on the `?tab=md` view.
-8. Stop the dev server (kill the background bash process).
+1. **Port preflight**: `Bash`: `lsof -i :3000 -t 2>/dev/null`. If the output is non-empty, port 3000 is already in use (the user has a dev server running). `AskUserQuestion`: "포트 3000이 사용 중입니다 — (a) 기존 서버 종료 후 재시작 / (b) 검증 단계 건너뛰기 / (c) 취소". On "건너뛰기", skip to Stage 13 with a `verification_skipped: port_collision` flag in the report.
+2. `Bash` (run_in_background): `cd "${repo_root}" && pnpm dev` — runs on port 3000.
+3. `mcp__Claude_Preview__preview_start` with URL `http://localhost:3000/services/{slug}`.
+4. `mcp__Claude_Preview__preview_eval`: `document.title` — should contain `{brand_name}` and `ko/design.md`.
+5. `preview_eval` against the iframe: confirm `document.querySelector('iframe')?.src` contains `/preview/{slug}/dark.html` (dark is the route default per `src/routes/services/$slug.tsx:97`).
+6. `preview_screenshot` once on the default tab.
+7. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
+8. `preview_screenshot` once on the `?tab=md` view.
+9. Stop the dev server (kill the background bash process).
 
 If preview MCP tools are unavailable, fall back to `Bash`: `curl -sf http://localhost:3000/services/{slug} | grep -q '<iframe'` — non-zero exit means the page failed to render.
 

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -39,9 +39,10 @@ This skill builds a complete catalog entry through a 5-subagent pipeline with on
 Verify the working environment before doing anything user-visible.
 
 1. `Bash`: `pwd` to capture the absolute repo root. Hold this value as `${repo_root}` in your reasoning and substitute it literally into every later Bash command and dispatch prompt that touches a repo path. The shell preserves cwd across calls, but pinning the absolute path makes Stage 8/10/11 robust to any inadvertent `cd`.
-2. `Read` `${repo_root}/package.json`. If `"name"` is not exactly `"start-app"` (the ko-design-md repo's package name), abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: ${repo_root}". Do not proceed.
-3. Verify `${repo_root}/src/lib/content-types.ts` is readable. If not, abort.
-4. `Read` `${repo_root}/src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).
+2. `Bash`: `date +%Y-%m-%d` to capture today's date. Hold this value as `${today}` in your reasoning. Stage 6a passes this to the author for the `last_updated` frontmatter field; the project's date validator at `src/lib/content-parser.ts:158-171` rejects any other format.
+3. `Read` `${repo_root}/package.json`. If `"name"` is not exactly `"start-app"` (the ko-design-md repo's package name), abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: ${repo_root}". Do not proceed.
+4. Verify `${repo_root}/src/lib/content-types.ts` is readable. If not, abort.
+5. `Read` `${repo_root}/src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).
 
 ## Stage 2 — Conversational intake
 
@@ -273,7 +274,7 @@ cd "${repo_root}" && pnpm build:og
 
 After the command:
 
-**If exit non-zero**: capture stderr. Likely cause is invalid frontmatter that slipped past the reviewer (e.g. `gray-matter` parsing `last_updated` as a Date object, off-enum category, etc.). Surface stderr via text. Offer via `AskUserQuestion`: "frontmatter 직접 수정" (open `${repo_root}/services/{slug}.md` for editing), "취소 (파일 유지)" (partial state is acceptable since the index works without an OG image — the route falls back per `build-og.ts`). Do NOT auto-rollback the placed .md.
+**If exit non-zero**: capture stderr. Likely cause is invalid frontmatter that slipped past the reviewer (e.g. `gray-matter` parsing `last_updated` as a Date object, off-enum category, etc.). Surface stderr via text. Offer via `AskUserQuestion`: "frontmatter 직접 수정 후 재시도" (open `${repo_root}/services/{slug}.md` for editing; on user confirmation that they've edited, re-run `pnpm build:og` and re-validate — loop up to 3 retries), "취소 (파일 유지)" (partial state is acceptable since the index works without an OG image — the route falls back per `build-og.ts`). Do NOT auto-rollback the placed .md. After 3 failed retries, fall through to "취소" with a diagnostic message.
 
 **If exit zero**: validate the OG output (catches the corrupt-PNG silent failure mode that happens on satori panic):
 
@@ -290,13 +291,14 @@ Start the dev server and confirm the new entry renders correctly. This is the st
 
 1. **Port preflight**: `Bash`: `lsof -i :3000 -t 2>/dev/null`. If the output is non-empty, port 3000 is already in use (the user has a dev server running). `AskUserQuestion`: "포트 3000이 사용 중입니다 — (a) 기존 서버 종료 후 재시작 / (b) 검증 단계 건너뛰기 / (c) 취소". On "건너뛰기", skip to Stage 13 with a `verification_skipped: port_collision` flag in the report.
 2. `Bash` (run_in_background): `cd "${repo_root}" && pnpm dev` — runs on port 3000.
-3. `mcp__Claude_Preview__preview_start` with URL `http://localhost:3000/services/{slug}`.
-4. `mcp__Claude_Preview__preview_eval`: `document.title` — should contain `{brand_name}` and `ko/design.md`.
-5. `preview_eval` against the iframe: confirm `document.querySelector('iframe')?.src` contains `/preview/{slug}/dark.html` (dark is the route default per `src/routes/services/$slug.tsx:97`).
-6. `preview_screenshot` once on the default tab.
-7. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
-8. `preview_screenshot` once on the `?tab=md` view.
-9. Stop the dev server (kill the background bash process).
+3. **Server readiness poll**: `Bash`: `for i in $(seq 1 30); do curl -sf http://localhost:3000 -o /dev/null && echo READY && break; sleep 0.5; done`. The dev server takes a few seconds to bind; without this poll, `preview_start` may hit a connection refused before Vite is up. If the loop completes without printing `READY`, fall through to the `curl` fallback at the end of this stage.
+4. `mcp__Claude_Preview__preview_start` with URL `http://localhost:3000/services/{slug}`.
+5. `mcp__Claude_Preview__preview_eval`: `document.title` — should contain `{brand_name}` and `ko/design.md`.
+6. `preview_eval` against the iframe: confirm `document.querySelector('iframe')?.src` contains `/preview/{slug}/dark.html` (dark is the route default per `src/routes/services/$slug.tsx:97`).
+7. `preview_screenshot` once on the default tab.
+8. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
+9. `preview_screenshot` once on the `?tab=md` view.
+10. **Stop the dev server**: `Bash`: `kill $(lsof -t -i:3000) 2>/dev/null || true`. Killing by port is portable across macOS/Linux and avoids accidentally killing other `pnpm` processes the user might be running. The `|| true` keeps the skill from aborting if the process already exited.
 
 If preview MCP tools are unavailable, fall back to `Bash`: `curl -sf http://localhost:3000/services/{slug} | grep -q '<iframe'` — non-zero exit means the page failed to render.
 

--- a/.claude/skills/design-md/references/rubric-design.md
+++ b/.claude/skills/design-md/references/rubric-design.md
@@ -1,0 +1,89 @@
+# RUBRIC — design.md review (10 points; pass ≥ 8)
+
+The design-md-reviewer subagent uses this rubric to score `draft.md` against `research.md`. Output is a `review-{N}.json` with per-item scores and issues. The reviewer never edits the draft — only scores and explains.
+
+## Item 1 — Schema validity (3 pts, hard requirement)
+
+Frontmatter must round-trip through `buildDoc()` in `src/lib/content-parser.ts` without throwing. Concretely:
+
+- All required keys present: `name, slug, category, last_updated, sources, related_services, lang`.
+- `category` ∈ `CATEGORIES` const from `src/lib/content-types.ts` (one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc).
+- `last_updated` matches `^\d{4}-\d{2}-\d{2}$`. The validator at content-parser.ts:158-171 throws on any other format.
+- `sources` is a non-empty array of `https?://` URLs.
+- `slug` matches `^[a-z0-9-]+$` and equals the staging filename stem (e.g. draft.md for slug X has frontmatter `slug: X`).
+- `lang` is exactly `ko` or `en`.
+
+**Failure modes**: typo'd key (`last-updated` instead of `last_updated`), Date object instead of string (gray-matter parses unquoted dates as Date), off-enum category (`fintech`, `media`), empty `sources: []`, slug with capitals or underscores.
+
+This item is **hard-fail**: if any sub-check fails, deduct the full 3 pts and mark `severity: block` in the issue list. The skill body refuses to advance to the user checkpoint without a valid frontmatter.
+
+## Item 2 — Stitch section coverage (2 pts)
+
+All 10 standard sections present in order: `## Brand & Style`, `## Colors`, `## Typography`, `## Spacing`, `## Rounded`, `## Elevation & Depth`, `## Shapes`, `## Components`, `## Do's and Don'ts`, `## References`. Each section must contain ≥ 2 sentences of substantive content (or, for genuinely unknown information, one short explanatory line per stitch-format.md).
+
+**Pass criteria**:
+- 2 pts: all 10 sections present in order, each ≥ 2 sentences (or a documented gap line).
+- 1 pt: 9 of 10 sections, or one section is a 1-sentence stub.
+- 0 pts: ≥ 2 sections missing or full of `TODO`/placeholder text.
+
+**Failure modes**: dropping `## Shapes` because "the brand doesn't really have a shape language" (write the gap line instead); writing `TODO: figure this out` in a section; reordering sections.
+
+## Item 3 — Token consistency (2 pts)
+
+Color values are expressed in OKLCH only (inside backticks or fenced ```yaml blocks). Typography references match across all mentions of the same role. Radius and spacing values are concrete numbers, not vague descriptors.
+
+**Pass criteria**:
+- 2 pts: all colors OKLCH; typography names consistent (e.g. "Pretendard Variable" not also "Pretendard"); spacing/radius numerical (`16px`, not "약간 둥근").
+- 1 pt: one or two minor inconsistencies (e.g. one color in hex, mixed font name spelling).
+- 0 pts: hex/rgba colors anywhere; contradicting numbers between sections.
+
+**Failure modes**: `## Colors` says primary is `oklch(0.7 0.18 50)` but `## Components` references `#FF8800`; `## Typography` calls it "Pretendard" in one place and "Pretendard Variable" in another.
+
+## Item 4 — Brand fidelity (2 pts)
+
+Every concrete claim in the draft (specific colors, named components, screen descriptions) traces back to a `[src:N]` citation in `research.md`. No invented component names. No facts that contradict research.md.
+
+Inferred-from-screenshots values (when no public design system exists) are acceptable but must be marked with `≈` and a short note:
+
+```markdown
+- **primary** ≈ `oklch(0.62 0.18 250)` (값은 공개된 토큰이 없어 캡처에서 추정)
+```
+
+**Pass criteria**:
+- 2 pts: every claim either cited or marked `≈`; no contradictions with research.md.
+- 1 pt: one or two uncited specifics, or one minor contradiction.
+- 0 pts: invented components, fabricated brand history, or systematic divergence from research.md.
+
+**Failure modes**: claiming the brand has a "Hero" component that research.md never mentions; inventing OKLCH values to make prose flow without marking them `≈`; citing research.md for one section then ignoring it for another.
+
+## Item 5 — Voice/tone (1 pt)
+
+Body prose matches `lang`:
+- `ko`: editorial register ending with ~다, no honorifics, no marketing fluff ("혁신적인", "차세대"), no chatbot tone ("~해보세요!").
+- `en`: plain editorial, no second-person sales tone, no marketing buzzwords.
+
+**Pass**: voice is consistent throughout, matches the relevant register.
+**Fail**: any section reads like marketing copy or chatbot output.
+
+## Output JSON shape
+
+```json
+{
+  "score": 8,
+  "passed": true,
+  "iteration": 1,
+  "rubric": [
+    {"item": "Schema validity", "earned": 3, "max": 3, "notes": "All keys present and valid."},
+    {"item": "Stitch section coverage", "earned": 2, "max": 2, "notes": "All 10 sections present with substantive content."},
+    {"item": "Token consistency", "earned": 1, "max": 2, "notes": "## Components mentions 'rounded' without a px value."},
+    {"item": "Brand fidelity", "earned": 2, "max": 2, "notes": "All claims cited."},
+    {"item": "Voice/tone", "earned": 1, "max": 1, "notes": "Korean editorial register held throughout."}
+  ],
+  "issues": [
+    {"severity": "warn", "section": "Components", "fix": "Replace 'rounded' with a concrete radius value (e.g. `12px`) consistent with `## Rounded`."}
+  ],
+  "verdict": "Pass with one minor warning. Components section should align radius vocabulary with the Rounded section."
+}
+```
+
+`passed = score >= 8`. Reviewer must include all 5 rubric items even if 0 pts. `issues[].severity` is `block` (must fix to pass) or `warn` (should fix but not blocking).

--- a/.claude/skills/design-md/references/rubric-preview.md
+++ b/.claude/skills/design-md/references/rubric-preview.md
@@ -1,0 +1,90 @@
+# RUBRIC — preview HTML review (10 points; pass ≥ 8)
+
+The preview-html-reviewer subagent scores `light.html` and `dark.html` against the approved `draft.md` (now `services/{slug}.md`). Reviewer reads only — no edits.
+
+## Item 1 — File structure (2 pts, hard requirement)
+
+Both HTML files exist and conform:
+
+- `<html lang="{ko|en}" data-theme="{light|dark}">` — `data-theme` matches the filename (`light.html` → `data-theme="light"`, etc.).
+- `<link rel="stylesheet" href="/preview/_runtime/tokens.css">` — absolute path, not relative or under `{slug}/_runtime/`.
+- `<script src="/preview/_runtime/iframe.js" defer></script>` — required for the parent route to grow the iframe to fit content.
+- All page CSS is in a single inline `<style>` block (no external stylesheets beyond tokens.css).
+- No external JS frameworks (no React, no jQuery — these are static HTML pages).
+- File size < 100KB each.
+
+**Pass**: 2 pts if all checks pass. 0 pts if any structural element missing or wrong path. No partial credit.
+
+**Failure modes**: writing `tokens.css` as a relative path; creating a per-slug `_runtime/` folder (the runtime is shared); adding `<script src="https://cdn.../react.js">`.
+
+## Item 2 — Color fidelity (2 pts)
+
+Every color value listed in `## Colors` of the design.md is rendered as a swatch somewhere in the preview. The swatch's actual CSS color value matches the design.md token's OKLCH expression character-for-character (no rounding, no rgb conversion).
+
+**Pass criteria**:
+- 2 pts: every documented color has a swatch with exact OKLCH match; semantic roles (primary, accent, surface, text) are visually demonstrated.
+- 1 pt: most colors present but one or two missing or with drifted values.
+- 0 pts: ≥ 3 colors missing, or values converted to hex/rgba.
+
+**Failure modes**: dropping the `accent` swatch because "it didn't fit the layout"; converting `oklch(0.7 0.18 50)` to `#E69245` in inline style.
+
+## Item 3 — Typography hierarchy (2 pts)
+
+A typography section exists demonstrating the documented scale (display, body, caption, micro at minimum). Pretendard Variable is applied (inherited from tokens.css `body` rule). Tabular-nums (`font-feature-settings: "tnum"`) used wherever the design.md specifies.
+
+**Pass criteria**:
+- 2 pts: full scale shown with documented sizes/weights; Pretendard Variable rendering; sample uses real Korean text for `lang: ko` previews to verify Korean fallback chain.
+- 1 pt: scale shown but missing one tier or wrong weight.
+- 0 pts: single text block; system font; English-only sample for a Korean-lang doc.
+
+**Failure modes**: showing only one heading and one paragraph; using `font-family: -apple-system` somewhere that overrides Pretendard.
+
+## Item 4 — Component coverage (2 pts)
+
+Each component named in `## Components` of the design.md is visibly rendered in the preview, with documented variants and states (hover, active, disabled where applicable).
+
+**Pass criteria**:
+- 2 pts: every named component rendered; primary variant + at least one state variation per interactive component.
+- 1 pt: most components present but one missing or showing only a default state.
+- 0 pts: ≥ 2 named components absent.
+
+**Failure modes**: naming `EtaBanner` and `RiderMapPin` in design.md but only rendering generic buttons; showing buttons but no hover/disabled states.
+
+## Item 5 — Light↔dark distinction (2 pts)
+
+`dark.html` uses brand-appropriate dark variants — not a literal inversion of `light.html`. Specifically:
+
+- Surface colors shift to dark variants chosen to match the brand mood (e.g. a warm brand uses a warm dark, not gray).
+- Primary color lightness is adjusted +5–10 (or whatever is needed) for sufficient contrast against the dark surface.
+- All swatches in the typography/color sections are updated to dark-mode values.
+- Text remains comfortably legible (WCAG AA contrast at minimum).
+
+**Pass criteria**:
+- 2 pts: dark.html shows considered dark adaptation; primary still recognizable but contrast-adjusted; no text below WCAG AA.
+- 1 pt: dark.html exists and is distinct, but one or two swatches forgotten in light values, or contrast borderline.
+- 0 pts: dark.html is identical to light.html, or just has `body { background: black; color: white }` without per-token thinking.
+
+**Failure modes**: copy-pasting light.html and only flipping `background` and `color`; leaving the primary swatch at its light-mode OKLCH; illegible accent text on dark.
+
+## Output JSON shape
+
+```json
+{
+  "score": 9,
+  "passed": true,
+  "iteration": 1,
+  "rubric": [
+    {"item": "File structure", "earned": 2, "max": 2, "notes": "All structural checks pass."},
+    {"item": "Color fidelity", "earned": 2, "max": 2, "notes": "All 6 colors rendered; OKLCH values match exactly."},
+    {"item": "Typography hierarchy", "earned": 2, "max": 2, "notes": "Display/body/caption/micro shown with Korean sample text."},
+    {"item": "Component coverage", "earned": 2, "max": 2, "notes": "EtaBanner, RiderMapPin both rendered with hover state."},
+    {"item": "Light↔dark distinction", "earned": 1, "max": 2, "notes": "Dark adaptation considered, but accent swatch retained light-mode OKLCH."}
+  ],
+  "issues": [
+    {"severity": "warn", "section": "dark.html — color swatches", "fix": "Adjust accent swatch to its dark-mode OKLCH (currently still 0.92 lightness; should be ~0.75 for dark contrast)."}
+  ],
+  "verdict": "Pass. One swatch missed the dark-mode adjustment; non-blocking."
+}
+```
+
+`passed = score >= 8`. The skill treats the preview review loop as **non-blocking** — if score < 8 at iteration 3, the skill proceeds to BUILD_OG with a warning rather than asking the user, since visual previews iterate naturally during real use.

--- a/.claude/skills/design-md/references/stitch-format.md
+++ b/.claude/skills/design-md/references/stitch-format.md
@@ -1,0 +1,65 @@
+# Stitch v0.1 design.md format reference
+
+Google Stitch's design.md is a YAML-frontmatter + Markdown format for encoding a brand's design system in a single text file consumable by both humans and AI coding agents. ko-design-md catalog entries adopt the **section structure** of Stitch v0.1 but keep their own catalog-specific frontmatter (Stitch token YAML lives inside body sections, not in frontmatter).
+
+## Standard section order (use as ## headings, in this order)
+
+1. **Brand & Style** — design philosophy, target audience, emotional tone. Prose, body lang.
+2. **Colors** — palette with semantic roles. OKLCH values inside fenced ```yaml or as a markdown table.
+3. **Typography** — font families (Pretendard Variable for Korean coverage), scale, weights, line heights.
+4. **Spacing** — base unit + scale.
+5. **Rounded** — radius tokens.
+6. **Elevation & Depth** — shadow system, depth language.
+7. **Shapes** — visual language (curves vs. sharp, geometric vs. organic).
+8. **Components** — signature components with variants and states. Code identifiers stay English. Include short ```tsx examples where a snippet clarifies the API.
+9. **Do's and Don'ts** — guardrails for downstream LLMs.
+10. **References** — citations to research sources (mirrors `sources` frontmatter).
+
+If a brand genuinely lacks information for a section (e.g. no published shadow system), keep the section heading and write one short line explaining the gap (`(no published elevation system; observed shadows are minimal)`). Do not delete sections — downstream agents rely on a stable structure.
+
+## Token expression
+
+Stitch v0.1 permits a YAML frontmatter token block, but ko-design-md frontmatter is reserved for catalog metadata. **Express tokens inside the relevant body section**, in one of two equivalent forms:
+
+### Fenced YAML (preferred for structured token blocks)
+
+````markdown
+## Colors
+
+```yaml
+primary: oklch(0.55 0.22 30)
+primary-foreground: oklch(0.99 0.005 30)
+surface: oklch(0.99 0.01 80)
+text: oklch(0.18 0.02 60)
+accent: oklch(0.85 0.15 100)
+```
+````
+
+### Inline backtick (preferred for prose)
+
+```markdown
+- **primary**: 따뜻한 오렌지 `oklch(0.7 0.18 50)` — 핵심 CTA, ETA 강조
+- **accent**: 부드러운 옐로우 `oklch(0.92 0.14 95)` — 마이크로카피 포인트
+```
+
+Both forms must use OKLCH. Hex and rgba are rejected by the design.md reviewer because they cannot be reasoned about by downstream LLMs in the same way as OKLCH (lightness, chroma, hue components are explicit).
+
+## Body language
+
+Body prose follows the `lang` frontmatter field:
+- `lang: ko` → Korean editorial register (ends with ~다, no honorifics overuse, no marketing fluff).
+- `lang: en` → plain editorial English (no marketing copy, no second-person sales tone).
+
+Section **headings stay in English** regardless of `lang` so the structure is parseable by downstream agents that key off heading text.
+
+## What's NOT in design.md
+
+- Implementation code beyond short illustrative snippets — design.md describes intent and tokens, not full components.
+- Marketing copy, taglines, or hero messaging — those belong in product surfaces.
+- Brand mission statements — keep `## Brand & Style` focused on visual/UX intent, not corporate positioning.
+
+## Sources
+
+- Google Labs announcement: https://blog.google/innovation-and-ai/models-and-research/google-labs/stitch-design-md/
+- Spec repo: https://github.com/google-labs-code/design.md
+- Curated examples: https://getdesign.md, https://github.com/VoltAgent/awesome-design-md

--- a/.claude/skills/design-md/trigger-eval-queries.json
+++ b/.claude/skills/design-md/trigger-eval-queries.json
@@ -1,0 +1,82 @@
+[
+  {
+    "query": "토스를 ko-design-md 카탈로그에 추가하고 싶어. design.md랑 preview HTML 만들어줘. https://toss.im 참고로",
+    "should_trigger": true
+  },
+  {
+    "query": "Stripe의 design system을 catalog에 등록해줘. 참고 URL은 stripe.com/customers, lang=en으로",
+    "should_trigger": true
+  },
+  {
+    "query": "당근의 디자인 시스템 정리해서 catalog에 새 항목으로 만들어줄 수 있어? screenshot 4장 있어 — ~/Desktop/karrot-1.png부터 4까지",
+    "should_trigger": true
+  },
+  {
+    "query": "ko-design-md에 Linear 추가하자. linear.app, lang ko, category content 정도?",
+    "should_trigger": true
+  },
+  {
+    "query": "쿠팡으로 새 design.md 만들어야 해. 자료조사부터 preview까지 한 번에 가자. category는 commerce",
+    "should_trigger": true
+  },
+  {
+    "query": "/design-md",
+    "should_trigger": true
+  },
+  {
+    "query": "this brand isn't in our catalog yet — can you onboard them? brand: notion, urls: notion.so, notion.so/blog",
+    "should_trigger": true
+  },
+  {
+    "query": "넷플릭스 카탈로그 등록 진행. services/{slug}.md 자동으로 만들어주는 그거",
+    "should_trigger": true
+  },
+  {
+    "query": "Spotify를 추가하려는데 design.md 자동 생성하는 워크플로우 있다고 했지? 그거로 해줘",
+    "should_trigger": true
+  },
+  {
+    "query": "services/_demo-courier.md의 typography 섹션 한 줄만 고쳐줘 — 'Pretendard'를 'Pretendard Variable'로",
+    "should_trigger": false
+  },
+  {
+    "query": "design.md 파일 형식이 뭔지 설명해줘. Google Stitch에서 만든 거 맞아?",
+    "should_trigger": false
+  },
+  {
+    "query": "services/_demo-pay.md의 last_updated를 오늘 날짜로 갱신만 해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "preview HTML의 dark mode에서 contrast가 부족해 보이는데 토큰 값 좀 봐줘 — public/preview/demo-courier/dark.html",
+    "should_trigger": false
+  },
+  {
+    "query": "src/routes/index.tsx에 카테고리 필터 사이드바 추가해줘. 기존 스타일 따라서",
+    "should_trigger": false
+  },
+  {
+    "query": "build:og 스크립트가 NaN 에러 내면서 실패해. 디버깅해줘. scripts/build-og.ts 봐주면 됨",
+    "should_trigger": false
+  },
+  {
+    "query": "내 다른 사이드프로젝트(설계 시스템 카탈로그 비슷한 거)에서도 design.md 같은 거 쓰고 싶은데 어떻게 시작해야 해?",
+    "should_trigger": false
+  },
+  {
+    "query": "design.md 잘 쓰는 법 가이드 같은 거 있어? 책이나 블로그 추천해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "Stripe design.md 파일을 다운로드해서 우리 프로젝트 docs/ 폴더에 참고 자료로 가져다 놔줘",
+    "should_trigger": false
+  },
+  {
+    "query": "services/_demo-pay.md를 services/toss.md로 이름 바꿔서 복제해줘. 내용은 그대로",
+    "should_trigger": false
+  },
+  {
+    "query": "ko-design-md 프로젝트 README에 카탈로그 항목 추가하는 방법 한 단락 적어줘",
+    "should_trigger": false
+  }
+]

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ __unconfig*
 todos.json
 .claude/design-previews/
 .claude/worktrees/
+.claude/cache/
 public/og/*.png
 .gstack/


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill `/design-md` that automates new brand onboarding into the ko-design-md catalog (research → design.md → preview HTML → OG image), gated by a single user approval at the design.md draft.
- 5 specialized subagents in `.claude/agents/` with constrained tool access; author and reviewer roles are split into separate definitions to avoid self-grading bias in score-based review loops (pass ≥ 8/10, max 3 iterations).
- Output follows Google Stitch v0.1 standard section headings (English) while keeping ko-design-md's catalog frontmatter (`name, slug, category, last_updated, sources, related_services, lang`). Existing `_demo-*.md` files keep their Korean editorial headings; migration is out of scope.

## Architecture

- **Pipeline**: `research-collector` → `design-md-author` ⇄ `design-md-reviewer` (loop, blocking) → user checkpoint → `preview-html-author` ⇄ `preview-html-reviewer` (loop, non-blocking) → file placement → `pnpm build:og` → preview MCP verification.
- **Staging**: `.claude/cache/design-md/{slug}/` (gitignored). Files only land in `services/` and `public/preview/` after the user approves the draft.
- **State**: file-presence based (no separate `state.json` for v1); resumable by inspecting the cache dir.
- **Path safety**: `${repo_root}` captured via `pwd` in Stage 1, used for every destructive `cp`/`mkdir` so cwd drift can't misroute files.

## Files

| Path | Role |
|---|---|
| `.claude/skills/design-md/SKILL.md` | Orchestration body (347 lines, 13 stages) |
| `.claude/skills/design-md/references/stitch-format.md` | Stitch v0.1 section reference |
| `.claude/skills/design-md/references/rubric-design.md` | design.md review rubric (10 pts, pass 8) |
| `.claude/skills/design-md/references/rubric-preview.md` | preview HTML review rubric |
| `.claude/agents/research-collector.md` | WebFetch / WebSearch / Read / Write |
| `.claude/agents/design-md-author.md` | Read / Write |
| `.claude/agents/design-md-reviewer.md` | Read / Write |
| `.claude/agents/preview-html-author.md` | Read / Write |
| `.claude/agents/preview-html-reviewer.md` | Read / Write |
| `.claude/skills/design-md/trigger-eval-queries.json` | 20 queries for future description optimization |
| `.gitignore` | exclude `.claude/cache/` |

## Verification

- **Code-review subagent (general-purpose)** audited all 9 files: Conditional Pass with 3 blocking + 6 warning issues; all addressed in the fix commit.
- **skill-creator self-audit**: structural conventions match (frontmatter, references organized, SKILL.md under 500 lines), description triggering acceptable.
- **Smoke-test**: `repo_root` pinned in 26 places; bilingual handling wired (Stage 6/6d/7/8); all preflights present (research.md H2 sanity, screenshot existence, port 3000 collision, OG PNG validation); research-collector trimmed to least privilege.

## Test plan

- [ ] Invoke `/design-md` against a real Korean SaaS (Toss / Karrot / Coupang) end-to-end.
- [ ] Confirm intake form collects brand name, ≥1 URL, category, lang, optional screenshots.
- [ ] Confirm slug derivation handles ASCII brand names; Korean-only fallback prompts for ASCII slug.
- [ ] Confirm research-collector cites every claim with `[src:N]` and writes all 9 H2 sections.
- [ ] Confirm design-md-reviewer reaches ≥ 8/10 within 3 iterations on a typical brand.
- [ ] Confirm user checkpoint surfaces draft + final review verdict (and en companion review when `lang: both`).
- [ ] Confirm preview HTML loads in `pnpm dev` and matches design.md tokens via `mcp__Claude_Preview__preview_*`.
- [ ] Confirm `pnpm build:og` produces a valid PNG; corrupt-PNG path caught by the `[ -s ]` + `file | grep PNG` checks.

## Notes for reviewer

- The skill verifies it's running in this repo via `package.json` `name === "start-app"` (intentional — the actual package name, not the project's display name `ko-design-md`).
- Pretendard Variable is loaded from jsDelivr at runtime; preview HTMLs assume online access for fonts. Documented as a known limitation.
- Deferred to v2: `--resume {slug}` CLI flag, logo asset workflow (`/public/logos/`), `related_services` auto-suggestion via embeddings, migrating `_demo-*.md` to Stitch sections, Pretendard offline caching.