### PR TITLE
chore(copy): drop GPT/Claude/Cursor mentions for tool-neutral wording

### DIFF
--- a/src/features/home/components/hero.tsx
+++ b/src/features/home/components/hero.tsx
@@ -33,7 +33,7 @@ export function HomeHero() {
         <strong className="text-brand font-bold">
           한 번의 클릭으로 design.md 전체를 복사
         </strong>
-        해 Claude · Cursor · v0 같은 도구에 그대로 붙여넣으세요.
+        해 그대로 붙여넣으세요.
       </p>
 
       {/* spacer */}

--- a/src/features/service-detail/components/token-badge.tsx
+++ b/src/features/service-detail/components/token-badge.tsx
@@ -17,7 +17,7 @@ export function TokenBadge({ tokens }: Props) {
         {formatTokens(tokens)}
       </span>
       <span className="text-meta-caps mt-1 inline-block">
-        TOKENS · GPT-4 / CLAUDE
+        TOKENS
       </span>
     </div>
   )

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -17,7 +17,7 @@ export const Route = createRootRoute({
       {
         name: "description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. Claude · Cursor · v0에 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
       },
       { name: "theme-color", content: "#141414" },
       { property: "og:type", content: "website" },
@@ -31,7 +31,7 @@ export const Route = createRootRoute({
       {
         property: "og:description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. Claude · Cursor · v0에 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
       },
       { property: "og:image", content: absoluteUrl("/og/default.png") },
       { property: "og:image:width", content: "1200" },
@@ -48,7 +48,7 @@ export const Route = createRootRoute({
       {
         name: "twitter:description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. Claude · Cursor · v0에 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
       },
       { name: "twitter:image", content: absoluteUrl("/og/default.png") },
     ],

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -17,7 +17,7 @@ export const Route = createRootRoute({
       {
         name: "description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
       },
       { name: "theme-color", content: "#141414" },
       { property: "og:type", content: "website" },
@@ -31,7 +31,7 @@ export const Route = createRootRoute({
       {
         property: "og:description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
       },
       { property: "og:image", content: absoluteUrl("/og/default.png") },
       { property: "og:image:width", content: "1200" },
@@ -48,7 +48,7 @@ export const Route = createRootRoute({
       {
         name: "twitter:description",
         content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 그대로 붙여넣으세요.",
+          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
       },
       { name: "twitter:image", content: absoluteUrl("/og/default.png") },
     ],


### PR DESCRIPTION
## 요약

ko/design.md 카탈로그가 **특정 LLM/AI 빌더 도구에 종속되지 않은 중립적인 카탈로그**로 보이도록, 사용자 노출 영역(UI + SEO/OG 메타)에서 `GPT-4`, `Claude`, `Cursor`, `v0` 같은 모델·도구 이름 하드코딩을 모두 제거했습니다.

## 변경 사항

### UI

- **`src/features/service-detail/components/token-badge.tsx`**
  - `TOKENS · GPT-4 / CLAUDE` → `TOKENS`
  - 상세페이지 우측 sticky 영역에 모든 서비스마다 동일하게 박혀 있던 모델 라벨 제거

- **`src/features/home/components/hero.tsx`**
  - 홈 lede의 \`해 Claude · Cursor · v0 같은 도구에 그대로 붙여넣으세요.\` → \`해 그대로 붙여넣으세요.\`
  - 도구 나열을 통째로 삭제하고 한국어 호응을 자연스럽게 유지

### SEO / OG 메타

- **`src/routes/__root.tsx`** — `meta[name=\"description\"]`, `og:description`, `twitter:description` 3곳 동일 갱신
  - \`...design.md 한 장으로. Claude · Cursor · v0에 그대로 붙여넣으세요.\` → \`...design.md 한 장으로. 그대로 붙여넣으세요.\`

## 의도적으로 손대지 않은 영역

- \`docs/PRD.md\` — 내부 기획 문서 (역사적 맥락 보존)
- \`docs/superpowers/specs/*\`, \`docs/superpowers/plans/*\` — 작업 시점 기록물
- \`.claude/skills/design-md/SKILL.md\`의 \`mcp__Claude_Preview__*\` — MCP 도구 함수명(코드 식별자)
- \`services/_demo-*.md\` — 데모 콘텐츠는 카탈로그 데이터이지 UI 하드코딩이 아님

## Test plan

- [x] dev server 기동 확인 (port 3000)
- [x] \`grep\`으로 \`src/\` 하위 \`GPT|Claude|Cursor|v0\` 잔여 0건 확인
- [x] 홈 \`/\` snapshot에서 lede 문구가 \"…복사해 그대로 붙여넣으세요.\"로 자연스럽게 끝남 확인
- [x] 상세페이지 \`/services/demo-courier\` snapshot에서 TokenBadge 라벨이 \`TOKENS\`만 남음 확인
- [x] \`document.querySelector\`로 meta/og/twitter description 3곳 모두 도구 나열 사라짐 확인
- [x] 콘솔 에러 없음 확인