### PR TITLE
fix(preview): align toss preview with mobile-first breakpoints

### DIFF
--- a/public/preview/toss/dark.html
+++ b/public/preview/toss/dark.html
@@ -579,6 +579,12 @@
     gap: 24px;
     justify-content: center;
     align-items: flex-start;
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .mock-frame > div {
+    width: 100%;
+    max-width: 360px;
   }
   .phone {
     width: 360px;

--- a/public/preview/toss/dark.html
+++ b/public/preview/toss/dark.html
@@ -773,16 +773,32 @@
   .elev-3 { box-shadow: var(--tds-shadow-3); }
   .elev-toast { box-shadow: var(--tds-shadow-toast); }
 
-  /* === Responsive === */
-  @media (max-width: 880px) {
-    .hero { padding: 56px 0 40px; }
-    .hero h1 { font-size: 40px; }
+  /* === Responsive === — services/toss.md:479-483 (Mobile ≤640, Tablet 641-1023, Desktop ≥1024) */
+  @media (max-width: 1023px) {
+    .hero { padding: 64px 0 40px; }
+    .hero h1 { font-size: clamp(32px, 5.6vw, 48px); }
     .hero .subtitle { font-size: 20px; }
     .section { padding: 56px 0; }
-    .swatches { grid-template-columns: repeat(2, 1fr); }
-    .alias-grid, .two-up, .elev-grid, .radius-ramp { grid-template-columns: 1fr 1fr; }
+    .swatches { grid-template-columns: repeat(3, 1fr); }
+    .alias-grid, .two-up { grid-template-columns: 1fr; }
+    .elev-grid, .radius-ramp { grid-template-columns: repeat(2, 1fr); }
     .type-row { grid-template-columns: 1fr; gap: 8px; }
     .phone, .tab-bar { width: 100%; max-width: 360px; }
+  }
+  @media (max-width: 640px) {
+    .container { padding: 0 16px; }
+    .strip .meta, .strip .right .text-meta-caps { display: none; }
+    .hero { padding: 48px 0 32px; }
+    .hero h1 { font-size: clamp(26px, 8vw, 36px); line-height: 1.25; }
+    .hero .subtitle { font-size: 17px; }
+    .hero .lede { font-size: 15px; margin: 20px 0 28px; }
+    .hero-meta { gap: 20px; margin-top: 36px; padding-top: 20px; }
+    .section { padding: 40px 0; }
+    .section-head { flex-wrap: wrap; gap: 8px; margin-bottom: 24px; }
+    .section-head h2 { font-size: 22px; }
+    .section-head .caption { display: none; }
+    .swatches { grid-template-columns: repeat(2, 1fr); gap: 8px; }
+    .elev-grid, .radius-ramp { grid-template-columns: 1fr; }
   }
 </style>
 </head>

--- a/public/preview/toss/dark.html
+++ b/public/preview/toss/dark.html
@@ -782,7 +782,7 @@
   /* === Responsive === — services/toss.md:479-483 (Mobile ≤640, Tablet 641-1023, Desktop ≥1024) */
   @media (max-width: 1023px) {
     .hero { padding: 64px 0 40px; }
-    .hero h1 { font-size: clamp(32px, 5.6vw, 48px); }
+    .hero h1 { font-size: clamp(32px, 5.6vw, 56px); }
     .hero .subtitle { font-size: 20px; }
     .section { padding: 56px 0; }
     .swatches { grid-template-columns: repeat(3, 1fr); }

--- a/public/preview/toss/light.html
+++ b/public/preview/toss/light.html
@@ -579,6 +579,12 @@
     gap: 24px;
     justify-content: center;
     align-items: flex-start;
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .mock-frame > div {
+    width: 100%;
+    max-width: 360px;
   }
   .phone {
     width: 360px;

--- a/public/preview/toss/light.html
+++ b/public/preview/toss/light.html
@@ -772,16 +772,32 @@
   .elev-3 { box-shadow: var(--tds-shadow-3); }
   .elev-toast { box-shadow: var(--tds-shadow-toast); }
 
-  /* === Responsive === */
-  @media (max-width: 880px) {
-    .hero { padding: 56px 0 40px; }
-    .hero h1 { font-size: 40px; }
+  /* === Responsive === — services/toss.md:479-483 (Mobile ≤640, Tablet 641-1023, Desktop ≥1024) */
+  @media (max-width: 1023px) {
+    .hero { padding: 64px 0 40px; }
+    .hero h1 { font-size: clamp(32px, 5.6vw, 48px); }
     .hero .subtitle { font-size: 20px; }
     .section { padding: 56px 0; }
-    .swatches { grid-template-columns: repeat(2, 1fr); }
-    .alias-grid, .two-up, .elev-grid, .radius-ramp { grid-template-columns: 1fr 1fr; }
+    .swatches { grid-template-columns: repeat(3, 1fr); }
+    .alias-grid, .two-up { grid-template-columns: 1fr; }
+    .elev-grid, .radius-ramp { grid-template-columns: repeat(2, 1fr); }
     .type-row { grid-template-columns: 1fr; gap: 8px; }
     .phone, .tab-bar { width: 100%; max-width: 360px; }
+  }
+  @media (max-width: 640px) {
+    .container { padding: 0 16px; }
+    .strip .meta, .strip .right .text-meta-caps { display: none; }
+    .hero { padding: 48px 0 32px; }
+    .hero h1 { font-size: clamp(26px, 8vw, 36px); line-height: 1.25; }
+    .hero .subtitle { font-size: 17px; }
+    .hero .lede { font-size: 15px; margin: 20px 0 28px; }
+    .hero-meta { gap: 20px; margin-top: 36px; padding-top: 20px; }
+    .section { padding: 40px 0; }
+    .section-head { flex-wrap: wrap; gap: 8px; margin-bottom: 24px; }
+    .section-head h2 { font-size: 22px; }
+    .section-head .caption { display: none; }
+    .swatches { grid-template-columns: repeat(2, 1fr); gap: 8px; }
+    .elev-grid, .radius-ramp { grid-template-columns: 1fr; }
   }
 </style>
 </head>

--- a/public/preview/toss/light.html
+++ b/public/preview/toss/light.html
@@ -781,7 +781,7 @@
   /* === Responsive === — services/toss.md:479-483 (Mobile ≤640, Tablet 641-1023, Desktop ≥1024) */
   @media (max-width: 1023px) {
     .hero { padding: 64px 0 40px; }
-    .hero h1 { font-size: clamp(32px, 5.6vw, 48px); }
+    .hero h1 { font-size: clamp(32px, 5.6vw, 56px); }
     .hero .subtitle { font-size: 20px; }
     .section { padding: 56px 0; }
     .swatches { grid-template-columns: repeat(3, 1fr); }


### PR DESCRIPTION
## 변경 요약

토스 프리뷰 데모 페이지(`public/preview/toss/{light,dark}.html`)가 모바일(360–414px)에서 가독성·레이아웃이 깨지던 문제를 수정. 단일 880px 브레이크포인트를 `services/toss.md:479-483`에 documented된 토스 공식 권장 분기점(Mobile ≤640 / Tablet 641-1023 / Desktop ≥1024)에 맞춰 2단으로 재구성하고, "모바일에서 다중 컬럼을 거의 사용하지 않는다"는 single-column 정책을 따르도록 그리드를 조정.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 상세 변경

| Viewport | Before (단일 880px) | After (1023 + 640px 2단) |
|---|---|---|
| Desktop ≥1024px | h1 56px · swatches 5 · elev 4 | 동일 (회귀 없음) |
| Tablet 641–1023px | (≤880px일 때만 축소) | h1 `clamp(32, 5.6vw, 48)` · swatches 3 · elev 2 · alias single-col |
| Mobile ≤640px | (≤880px 룰 그대로, 모바일 부적합) | h1 `clamp(26, 8vw, 36)` · container 16px · swatches 2 · elev 1 · strip meta·캡션 숨김 · hero-meta gap 40→20 |

- Hero h1 fluid typography는 Wanted 프리뷰(`wanted/light.html:489,507`)의 패턴 차용
- 헤더 strip의 `TDS Mobile · 2026 (Apps in Toss)` 메타와 `PREVIEW · LIGHT` 라벨은 ≤640px에서 숨겨, 토스 wordmark와 Token-driven 배지만 한 줄에 유지
- `services/toss.md`는 spec이 이미 옳았기에 손대지 않음 (preview ↔ spec 정합화 작업)

## 검증

- 1280px / 820px / 414px / 375px 모두 가로 스크롤 없음 (`scrollWidth === innerWidth`)
- 데스크톱(1024px+) 회귀 없음 — 미디어쿼리가 발동하지 않음
- light·dark 양쪽 모두 동일 거동
- 콘솔 에러 0건

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 항목 자체가 아닌 기존 토스 항목의 프리뷰 HTML 수정.

## 일반 체크

- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) 가이드라인 준수
- [ ] `pnpm typecheck && pnpm lint && pnpm build` — 정적 HTML만 수정, JS/TS 영향 없음

## 관련 이슈

없음