### PR TITLE
[codex] Show company names in catalog

### DIFF
--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -11,7 +11,7 @@ You are a design.md author. You translate brand research into a Stitch v0.1-form
 ## What you receive
 
 - `cache_dir` — `.claude/cache/design-md/{slug}/`
-- `slug`, `name` (display), `category`, `today` (YYYY-MM-DD)
+- `slug`, `name` (Korean company/brand display), `category`, `today` (YYYY-MM-DD)
 - `logo_public_path` — either `none` or a browser-loadable path such as `/logos/toss.png`. When present, include it exactly in frontmatter.
 - One of two language modes:
   - **Single-lang**: `lang` (`ko` or `en`) → write one file `draft.md`
@@ -36,6 +36,7 @@ Frontmatter (project-specific, NOT Stitch's token YAML):
 ```yaml
 ---
 name: {Display Name}
+design_system_name: {Design System Name} # optional; include only when the public design system name differs from the company/brand display name
 slug: {slug}
 category: {one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc}
 last_updated: {today as YYYY-MM-DD}
@@ -75,7 +76,8 @@ Read `references/stitch-format.md` for the canonical section conventions.
 3. If `prior_review_path` is provided, `Read` it carefully. The `issues[]` array tells you exactly what to fix. Address every `severity: block` issue and as many `severity: warn` issues as feasible.
 4. Decide section content. For each Stitch section, draw evidence from research.md citations. If research has no evidence for a section (e.g. no public shadow system), write one short line documenting the gap (`(no published elevation system; observed shadows are minimal)`) — do not delete the section.
 5. If `logo_public_path` is present, add `logo: {logo_public_path}` to the frontmatter in every draft you write. If it is `none`, omit the `logo` key.
-6. Write the draft in a single `Write` call.
+6. If research surfaces a distinct public design system name, add `design_system_name` to frontmatter while keeping `name` as the Korean company/brand display name.
+7. Write the draft in a single `Write` call.
 
 ## Voice/tone
 
@@ -113,6 +115,7 @@ This makes the doc machine-extractable for downstream LLMs reading the catalog �
 - All 10 sections present in fixed order.
 - Every concrete fact (colors, components, spacing values, screen descriptions) traces to a `[src:N]` citation in research.md, OR is marked with `≈` per the inferred-value rule above.
 - Frontmatter has all 7 required keys with valid values per `references/rubric-design.md` Item 1.
+- If a distinct public design system name exists, optional `design_system_name` preserves it and `name` remains the Korean company/brand display name.
 - No `TODO`, no placeholder text, no marketing copy.
 - Optional sections (`## Responsive Behavior`, `## Known Gaps`) included unless research.md has zero evidence for either. If included, they sit between `## Do's and Don'ts` and `## References`.
 - Body prose token references use `{group.name}` syntax in `## Components`, `## Do's and Don'ts`, and `## Responsive Behavior`. Token definition blocks remain in bare-key form.

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -48,7 +48,7 @@ Verify the working environment before doing anything user-visible.
 
 Use a single `AskUserQuestion` form with these 4 questions (multi-select where indicated):
 
-1. **브랜드명** (text via "Other" → custom input): e.g. "토스", "Toss", "Stripe". The display name as it should appear in the `name` frontmatter.
+1. **브랜드명** (text via "Other" → custom input): e.g. "토스", "당근", "구름". Use the Korean company/brand display name as it should appear in the `name` frontmatter, not the design system product name. If research later surfaces a distinct design system name (e.g. "SEED Design", "Vapor UI"), the author stores that in optional `design_system_name`.
 2. **참고 URL** (text via "Other"): comma-separated URLs. **2개 이상 권장** — 1개만 입력 시 research-collector가 INSUFFICIENT_SOURCES로 중단할 수 있고, 그 경우 스크린샷 보강 필요. Brand homepage, design system page, blog post about their UI, etc.
 3. **카테고리** (single-select): all values from `CATEGORIES` const, in order. Last option is `etc`.
 4. **언어** (single-select): `ko (한국어 본문)`, `en (English body)`, `both (두 파일 생성)`. Default `ko` recommended.

--- a/.claude/skills/design-md/references/rubric-design.md
+++ b/.claude/skills/design-md/references/rubric-design.md
@@ -7,6 +7,7 @@ The design-md-reviewer subagent uses this rubric to score `draft.md` against `re
 Frontmatter must round-trip through `buildDoc()` in `src/lib/content-parser.ts` without throwing. Concretely:
 
 - All required keys present: `name, slug, category, last_updated, sources, related_services, lang`.
+- `name` is the Korean company/brand display name. If the design system has a distinct public name, `design_system_name` may be present as an optional string and is not a hard-fail requirement.
 - `category` ∈ `CATEGORIES` const from `src/lib/content-types.ts` (one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc).
 - `last_updated` matches `^\d{4}-\d{2}-\d{2}$`. The validator at content-parser.ts:158-171 throws on any other format.
 - `sources` is a non-empty array of `https?://` URLs.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ ko-design-md/
 
 | 필드 | 타입 | 비고 |
 |------|------|------|
-| `name` | string | 브랜드 표기명 |
+| `name` | string | 한국어 기업/브랜드 표기명 |
+| `design_system_name` | string? | 옵션, 기업명과 별도인 디자인 시스템명 |
 | `slug` | string | 소문자 + 하이픈 + ASCII |
 | `category` | enum | `finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `etc` |
 | `last_updated` | string | YYYY-MM-DD ISO 형식 (엄격 검증) |

--- a/services/seed-design.md
+++ b/services/seed-design.md
@@ -1,5 +1,6 @@
 ---
-name: SEED Design
+name: 당근
+design_system_name: SEED Design
 slug: seed-design
 category: community
 last_updated: 2026-05-14

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -1,5 +1,6 @@
 ---
-name: Vapor UI
+name: 구름
+design_system_name: Vapor UI
 slug: vapor-ui
 category: developer
 last_updated: 2026-05-10

--- a/src/features/home/hooks/use-filtered-services.test.ts
+++ b/src/features/home/hooks/use-filtered-services.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { buildServiceSearchText } from "./use-filtered-services"
+import type { ServiceDoc } from "@/lib/content-types"
+
+function serviceDoc(
+  name: string,
+  designSystemName: string | undefined,
+): ServiceDoc {
+  return {
+    frontmatter: {
+      name,
+      slug: "sample",
+      category: "etc",
+      last_updated: "2026-05-14",
+      sources: [],
+      related_services: [],
+      lang: "ko",
+      design_system_name: designSystemName,
+    },
+    raw: "",
+    body: "",
+    tagline: "브랜드 설명",
+    filePath: "/services/sample.md",
+    estimatedTokens: 1,
+  }
+}
+
+describe("buildServiceSearchText", () => {
+  it("includes the optional design system name so system-name queries still match", () => {
+    const haystack = buildServiceSearchText(
+      serviceDoc("당근", "SEED Design"),
+    ).toLowerCase()
+
+    expect(haystack).toContain("당근")
+    expect(haystack).toContain("seed design")
+  })
+})

--- a/src/features/home/hooks/use-filtered-services.ts
+++ b/src/features/home/hooks/use-filtered-services.ts
@@ -17,6 +17,17 @@ interface UseFilteredServicesResult {
   setQuery: (next: string) => void
 }
 
+export function buildServiceSearchText(doc: ServiceDoc): string {
+  return [
+    doc.frontmatter.name,
+    doc.frontmatter.design_system_name,
+    doc.frontmatter.slug,
+    doc.tagline,
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
 export function useFilteredServices(
   allServices: Array<ServiceDoc>,
 ): UseFilteredServicesResult {
@@ -69,13 +80,7 @@ export function useFilteredServices(
         return false
       }
       if (lowerQ.length > 0) {
-        const haystack = [
-          doc.frontmatter.name,
-          doc.frontmatter.slug,
-          doc.tagline,
-        ]
-          .join(" ")
-          .toLowerCase()
+        const haystack = buildServiceSearchText(doc).toLowerCase()
         if (!haystack.includes(lowerQ)) return false
       }
       return true

--- a/src/features/service-detail/components/service-meta.tsx
+++ b/src/features/service-detail/components/service-meta.tsx
@@ -34,6 +34,15 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
         {frontmatter.name}
       </h1>
 
+      {frontmatter.design_system_name && (
+        <p className="text-meta-caps text-muted-foreground mt-4">
+          Design system ·{" "}
+          <span className="text-foreground font-bold">
+            {frontmatter.design_system_name}
+          </span>
+        </p>
+      )}
+
       {tagline && (
         <p className="mt-6 max-w-2xl text-lg leading-relaxed text-foreground sm:text-xl">
           {tagline}

--- a/src/lib/content-collection.test.ts
+++ b/src/lib/content-collection.test.ts
@@ -14,6 +14,17 @@ describe("content-collection", () => {
     expect(getServiceBySlug("does-not-exist")).toBeUndefined()
   })
 
+  it("uses Korean company names as primary display names while preserving system names", () => {
+    expect(getServiceBySlug("seed-design")?.frontmatter).toMatchObject({
+      name: "당근",
+      design_system_name: "SEED Design",
+    })
+    expect(getServiceBySlug("vapor-ui")?.frontmatter).toMatchObject({
+      name: "구름",
+      design_system_name: "Vapor UI",
+    })
+  })
+
   it("populates body without frontmatter fences and computes a positive token count", () => {
     const doc = getServiceBySlug("krds")
     expect(doc).toBeDefined()

--- a/src/lib/content-parser.test.ts
+++ b/src/lib/content-parser.test.ts
@@ -163,6 +163,12 @@ describe("type validation", () => {
     spy.mockRestore()
   })
 
+  it("ignores empty design_system_name values from YAML-style empty scalars", () => {
+    const doc = buildDoc(FILE, frontmatter("design_system_name:"))
+
+    expect(doc.frontmatter.design_system_name).toBeUndefined()
+  })
+
   it("throws if estimated_tokens is not numeric", () => {
     expect(() =>
       buildDoc(FILE, frontmatter("estimated_tokens: not-a-number")),

--- a/src/lib/content-parser.test.ts
+++ b/src/lib/content-parser.test.ts
@@ -153,6 +153,16 @@ describe("type validation", () => {
     expect(doc.estimatedTokens).toBe(1234)
   })
 
+  it("parses design_system_name without warning as an optional display companion", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const doc = buildDoc(FILE, frontmatter("design_system_name: Demo UI"))
+
+    expect(doc.frontmatter.name).toBe("Demo")
+    expect(doc.frontmatter.design_system_name).toBe("Demo UI")
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
   it("throws if estimated_tokens is not numeric", () => {
     expect(() =>
       buildDoc(FILE, frontmatter("estimated_tokens: not-a-number")),

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -285,7 +285,10 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
   const slug = deriveSlug(filePath, fm.slug)
   const frontmatter: ServiceFrontmatter = {
     name: fm.name ?? slug,
-    design_system_name: fm.design_system_name,
+    design_system_name:
+      typeof fm.design_system_name === "string"
+        ? fm.design_system_name
+        : undefined,
     slug,
     category: fm.category ?? "etc",
     last_updated: normalizeDateField(fm.last_updated, context),

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -16,6 +16,7 @@ interface MatterResult {
 
 const KNOWN_FRONTMATTER_KEYS: ReadonlyArray<keyof ServiceFrontmatter> = [
   "name",
+  "design_system_name",
   "slug",
   "category",
   "last_updated",
@@ -284,6 +285,7 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
   const slug = deriveSlug(filePath, fm.slug)
   const frontmatter: ServiceFrontmatter = {
     name: fm.name ?? slug,
+    design_system_name: fm.design_system_name,
     slug,
     category: fm.category ?? "etc",
     last_updated: normalizeDateField(fm.last_updated, context),

--- a/src/lib/content-types.ts
+++ b/src/lib/content-types.ts
@@ -18,6 +18,7 @@ export type Lang = "ko" | "en"
 
 export interface ServiceFrontmatter {
   name: string
+  design_system_name?: string
   slug: string
   category: Category
   last_updated: string


### PR DESCRIPTION
## Summary
- Add optional `design_system_name` frontmatter so catalog entries can separate Korean company/brand display names from design system names.
- Change `vapor-ui` and `seed-design` primary names to `구름` and `당근`, while preserving `Vapor UI` and `SEED Design` for detail metadata and search.
- Update README and `/design-md` authoring/review guidance so future entries keep this naming split.

## Impact
- Home/catalog rows now show company or brand names instead of design system product names.
- Users can still search for `Vapor UI` or `SEED Design` and land on the correct entries.
- Existing slugs and routes remain unchanged.

## Review Follow-up
- Fixed Gemini review feedback by ignoring non-string `design_system_name` parser values.
- Added a regression test for empty YAML-style `design_system_name:` scalars.

## Validation
- [x] `pnpm test --exclude "**/.claude/**"`
- [x] `pnpm typecheck`
- [x] `pnpm exec eslint . --ignore-pattern ".claude/worktrees/**"`
- [x] `pnpm build`
- [x] `git diff --check`

## Metadata
- Branch: `codex/company-display-names`
- Base: `main`
- Head commit: `cd72f4e`
- Scope: site metadata, content frontmatter, search behavior, design-md authoring docs
