### PR TITLE
[codex] Fix home catalog list markers

### DIFF
--- a/src/routes/-home/components/service-list-row.test.ts
+++ b/src/routes/-home/components/service-list-row.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import {
+  formatServiceListNumber,
+  isRecentServiceUpdate,
+} from "./service-list-row"
+
+describe("formatServiceListNumber", () => {
+  it("counts backward from the current list length", () => {
+    expect(formatServiceListNumber(1, 6)).toBe("06")
+    expect(formatServiceListNumber(6, 6)).toBe("01")
+  })
+
+  it("keeps two-digit padding for single-digit list lengths", () => {
+    expect(formatServiceListNumber(1, 3)).toBe("03")
+  })
+
+  it("pads to the total count digit length for larger lists", () => {
+    expect(formatServiceListNumber(100, 100)).toBe("001")
+  })
+})
+
+describe("isRecentServiceUpdate", () => {
+  const nowMs = Date.UTC(2026, 4, 15)
+
+  it("treats updates from the past week as NEW", () => {
+    expect(isRecentServiceUpdate("2026-05-08", nowMs)).toBe(true)
+  })
+
+  it("does not treat updates older than one week as NEW", () => {
+    expect(isRecentServiceUpdate("2026-05-07", nowMs)).toBe(false)
+  })
+})

--- a/src/routes/-home/components/service-list-row.tsx
+++ b/src/routes/-home/components/service-list-row.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 interface Props {
   doc: ServiceDoc
   index: number
+  totalCount: number
   /**
    * Wall-clock millis used for the NEW-badge cutoff. Pass `null` (or omit)
    * during SSR / first hydration render so the badge stays off — the parent
@@ -14,7 +15,7 @@ interface Props {
   nowMs: number | null
 }
 
-const NEW_WINDOW_DAYS = 30
+const NEW_WINDOW_DAYS = 7
 
 function formatTokensCompact(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
@@ -28,7 +29,7 @@ function formatShortDate(iso: string): string {
   return `${parts[1]}/${parts[2]}`
 }
 
-function isRecent(
+export function isRecentServiceUpdate(
   iso: string,
   nowMs: number | null,
   windowDays = NEW_WINDOW_DAYS,
@@ -38,6 +39,14 @@ function isRecent(
   if (Number.isNaN(updated.getTime())) return false
   const ageMs = nowMs - updated.getTime()
   return ageMs >= 0 && ageMs <= windowDays * 24 * 60 * 60 * 1000
+}
+
+export function formatServiceListNumber(
+  index: number,
+  totalCount: number,
+): string {
+  const targetLength = Math.max(2, String(totalCount).length)
+  return String(totalCount - index + 1).padStart(targetLength, "0")
 }
 
 function NewBadge({ className }: { className?: string }) {
@@ -53,12 +62,12 @@ function NewBadge({ className }: { className?: string }) {
   )
 }
 
-export function ServiceListRow({ doc, index, nowMs }: Props) {
+export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
   const { name, slug, logo, last_updated } = doc.frontmatter
   const tokens = formatTokensCompact(doc.estimatedTokens)
   const date = formatShortDate(last_updated)
-  const isNew = isRecent(last_updated, nowMs)
-  const pageNo = String(index).padStart(2, "0")
+  const isNew = isRecentServiceUpdate(last_updated, nowMs)
+  const pageNo = formatServiceListNumber(index, totalCount)
 
   return (
     <Link

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -83,6 +83,7 @@ function HomePage() {
                       key={doc.frontmatter.slug}
                       doc={doc}
                       index={i + 1}
+                      totalCount={filter.filtered.length}
                       nowMs={nowMs}
                     />
                   ))


### PR DESCRIPTION
## 요약
- 메인 홈 카탈로그 목록 번호를 현재 필터링된 목록 길이 기준 역순으로 표시합니다.
- `NEW` 배지 기준을 30일에서 7일로 줄입니다.
- 번호 포맷과 최신 배지 cutoff를 단위 테스트로 고정합니다.
- 총 항목 수가 3자리 이상일 때도 번호 자릿수가 맞도록 동적 padding을 적용합니다.

## 영향
- 최신순으로 노출되는 디자인 리스트에서 새 항목이 더 큰 번호를 유지합니다.
- 오래된 업데이트가 과도하게 `NEW`로 표시되지 않습니다.
- 카탈로그 항목이 100개 이상으로 늘어나도 번호 열의 시각적 정렬이 유지됩니다.

## 검증
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (67 tests)
- `TMPDIR=/tmp pnpm build`