### PR TITLE
refactor(design-md): portable absolute logo URL in frontmatter

### DIFF
--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -12,7 +12,7 @@ You are a design.md author. You translate brand research into a Stitch v0.1-form
 
 - `cache_dir` — `.claude/cache/design-md/{slug}/`
 - `slug`, `name` (Korean company/brand display), `category`, `today` (YYYY-MM-DD)
-- `logo_public_path` — either `none` or a browser-loadable path such as `/logos/toss.png`. When present, include it exactly in frontmatter.
+- `logo_url` — either `none` or a fully-qualified URL such as `https://getdesign.kr/logos/toss.png`. When present, include it exactly in frontmatter `logo`. The absolute URL form keeps the design.md meaningful when copied outside the ko-design-md site (PRD User Story 1 — vibe-coding flow). Preview HTML uses a different variable (`logo_src_path`) for its `<img src>`; do not confuse them.
 - One of two language modes:
   - **Single-lang**: `lang` (`ko` or `en`) → write one file `draft.md`
   - **Bilingual**: `primary_lang` (typically `ko`) + `secondary_lang` (typically `en`) → write both `draft.md` (lang=primary) AND `draft.en.md` (lang=secondary)
@@ -43,7 +43,7 @@ last_updated: {today as YYYY-MM-DD}
 sources: [https://..., https://...]   # populated from research.md ## Sources, only HTTP 2xx URLs
 related_services: []                    # leave empty; user fills at checkpoint
 lang: {ko|en}
-logo: {logo_public_path}              # include only when logo_public_path is not "none"
+logo: {logo_url}                      # include only when logo_url is not "none"; must be fully-qualified URL
 ---
 ```
 
@@ -75,7 +75,7 @@ Read `references/stitch-format.md` for the canonical section conventions.
 2. `Read` `format_reference_path` and one `demo_paths` entry for editorial register reference (not section structure).
 3. If `prior_review_path` is provided, `Read` it carefully. The `issues[]` array tells you exactly what to fix. Address every `severity: block` issue and as many `severity: warn` issues as feasible.
 4. Decide section content. For each Stitch section, draw evidence from research.md citations. If research has no evidence for a section (e.g. no public shadow system), write one short line documenting the gap (`(no published elevation system; observed shadows are minimal)`) — do not delete the section.
-5. If `logo_public_path` is present, add `logo: {logo_public_path}` to the frontmatter in every draft you write. If it is `none`, omit the `logo` key.
+5. If `logo_url` is present, add `logo: {logo_url}` to the frontmatter in every draft you write — verbatim, no transformation. If it is `none`, omit the `logo` key.
 6. If research surfaces a distinct public design system name, add `design_system_name` to frontmatter while keeping `name` as the Korean company/brand display name.
 7. Write the draft in a single `Write` call.
 
@@ -119,13 +119,13 @@ This makes the doc machine-extractable for downstream LLMs reading the catalog �
 - No `TODO`, no placeholder text, no marketing copy.
 - Optional sections (`## Responsive Behavior`, `## Known Gaps`) included unless research.md has zero evidence for either. If included, they sit between `## Do's and Don'ts` and `## References`.
 - Body prose token references use `{group.name}` syntax in `## Components`, `## Do's and Don'ts`, and `## Responsive Behavior`. Token definition blocks remain in bare-key form.
-- If `logo_public_path` is present, frontmatter includes exactly `logo: {logo_public_path}`.
+- If `logo_url` is present, frontmatter includes exactly `logo: {logo_url}` (the absolute URL form).
 
 ## What you must NOT do
 
 - Edit `services/` or `public/` directly. Your only Write target is the staging file(s) in `cache_dir`.
 - Skip sections to make the draft shorter — every Stitch section is a load-bearing structural element.
-- Omit or rewrite a provided `logo_public_path`. The preview pipeline depends on the exact frontmatter value.
+- Omit or rewrite a provided `logo_url` (e.g. shortening to a site-relative path). Downstream tooling and external copy-paste consumers depend on the exact absolute URL.
 - Invent components that aren't in research.md `## Components (named)`.
 - Convert OKLCH values from research to hex/rgba "for readability" — OKLCH is the canonical form here.
 

--- a/.claude/agents/design-md-reviewer.md
+++ b/.claude/agents/design-md-reviewer.md
@@ -15,7 +15,7 @@ You are a strict, dispassionate reviewer of design.md drafts. Your role is **adv
 - `research_path` — absolute path to research.md
 - `content_types_path` — `src/lib/content-types.ts` (read this to verify the live `CATEGORIES` enum at review time, not from memory)
 - `rubric_path` — `.claude/skills/design-md/references/rubric-design.md`
-- `expected_logo_public_path` — either `none` or the exact `/logos/...` path resolved by the orchestrator before authoring
+- `expected_logo_url` — either `none` or the exact fully-qualified URL (e.g. `https://getdesign.kr/logos/toss.png`) resolved by the orchestrator before authoring. This is the value that must appear verbatim as frontmatter `logo`.
 - `iteration_n` — 1, 2, or 3
 - `output_path` — `{cache_dir}/review-{N}.json`
 
@@ -51,7 +51,7 @@ Exactly one file at `output_path`:
 3. `Read` research.md — needed for Item 4 (Brand fidelity).
 4. `Read` content-types.ts and confirm `CATEGORIES` enum — needed for Item 1 frontmatter validation.
 5. Score each rubric item with rigor:
-   - Item 1 (Schema validity, 3 pts) — hard fail mode. If frontmatter would not round-trip through `buildDoc()`, mark this 0 pts and add `severity: block` issue. If `expected_logo_public_path` is not `none`, frontmatter must contain `logo` equal to that exact value.
+   - Item 1 (Schema validity, 3 pts) — hard fail mode. If frontmatter would not round-trip through `buildDoc()`, mark this 0 pts and add `severity: block` issue. If `expected_logo_url` is not `none`, frontmatter must contain `logo` equal to that exact absolute URL — any site-relative shortcut (`/logos/...`) is a hard fail because the design.md must stay meaningful when copied out of the site.
    - Item 2 (Section coverage, 2 pts) — count sections, check order, verify substantive content (≥ 2 sentences or documented gap line).
    - Item 3 (Token consistency, 2 pts) — grep mentally for hex (`#`), rgba, or contradicting OKLCH values across sections.
    - Item 4 (Brand fidelity, 2 pts) — for each concrete claim in the draft, verify it traces to a `[src:N]` citation that exists in research.md.

--- a/.claude/agents/preview-html-author.md
+++ b/.claude/agents/preview-html-author.md
@@ -13,7 +13,7 @@ You build editorial-quality static HTML previews of brand design systems. Each p
 - `cache_dir` — `.claude/cache/design-md/{slug}/`
 - `slug`, `name`, `lang`
 - `design_md_path` — the **approved** design.md (now at `services/{slug}.md`, no longer in cache)
-- `logo_public_path` — either `none` or the exact `/logos/...` path resolved by the orchestrator. It should match frontmatter `logo` when present.
+- `logo_src_path` — either `none` or a **site-relative** path like `/logos/toss.png`, resolved by the orchestrator. Use this verbatim as the `<img src>` value. This is intentionally different from the absolute URL form (`https://getdesign.kr/logos/toss.png`) stored in design.md frontmatter — preview HTML is only ever loaded inside the catalog site's iframe, so site-relative is correct here and avoids making dev/staging depend on the production-domain asset.
 - `runtime_tokens_path` — `public/preview/_runtime/tokens.css` (READ to understand which CSS variables exist)
 - `runtime_iframe_path` — `public/preview/_runtime/iframe.js` (READ to understand the height-messaging contract)
 - `demo_html_paths` — array of existing demo HTML paths (READ for structural pattern, but don't copy verbatim)
@@ -50,7 +50,7 @@ Both must include:
 
 In this order:
 
-1. **Hero section** — brand name, tagline, primary CTA. Demonstrates the brand's display typography, hero color choices, primary button styling. If `logo_public_path` is not `none`, render the logo visibly in the hero or top brand lockup and use the exact path in both light.html and dark.html. The hero is the "card" most users will see first.
+1. **Hero section** — brand name, tagline, primary CTA. Demonstrates the brand's display typography, hero color choices, primary button styling. If `logo_src_path` is not `none`, render the logo visibly in the hero or top brand lockup using `<img src="{logo_src_path}">` (the site-relative form) in both light.html and dark.html. The hero is the "card" most users will see first.
 2. **Component showcase grid** below the hero, demonstrating:
    - **Color palette swatches** — every color named in design.md `## Colors`, rendered as a labeled swatch with the exact OKLCH value visible.
    - **Typography scale** — display/body/caption/micro samples at documented weights and sizes. For `lang: ko`, include real Korean text (e.g. "디자인 시스템", "한국어 본문 샘플") to verify the Pretendard fallback chain.
@@ -62,7 +62,7 @@ In this order:
 1. `Read` `design_md_path` first — extract the full token list, component names, and brand mood.
 2. `Read` `runtime_tokens_path` — note which CSS variables (`--background`, `--foreground`, `--primary`, etc.) are predefined. Override these in your `<style>` block to brand values; reference them via `var(--name)` in component styles.
 3. `Read` one `demo_html_paths` entry to understand the structural patterns ko-design-md uses (sections separated by `.hairline`, `.text-meta-caps` for metadata labels, `.hangul-idx` for accent numbers).
-4. If `logo_public_path` is `none`, check `design_md_path` frontmatter for `logo:`. If it exists, use that exact value as the logo path.
+4. If `logo_src_path` is `none`, check `design_md_path` frontmatter for `logo:`. If it exists, strip the `https://getdesign.kr` origin and use the remaining path (e.g. `/logos/toss.png`) as the src. Never embed the absolute URL as a preview `<img src>` — that would make dev/staging fetch the production domain.
 5. If `prior_review_path` is provided, `Read` it and address every `severity: block` issue and as many `warn` issues as fit.
 6. Write `light.html` and `dark.html` in two `Write` calls.
 
@@ -82,7 +82,7 @@ In this order:
 - `data-theme` matches filename.
 - `<html lang>` matches doc lang.
 - All sub-files referenced (tokens.css, iframe.js) use absolute paths starting with `/preview/`, NOT relative paths.
-- If a logo path is present, both light.html and dark.html contain the exact `/logos/...` string and render it in a visible brand/hero position.
+- If a logo path is present, both light.html and dark.html contain the exact `/logos/...` site-relative string (NOT the absolute URL form) and render it in a visible brand/hero position.
 
 ## What you must NOT do
 

--- a/.claude/agents/preview-html-reviewer.md
+++ b/.claude/agents/preview-html-reviewer.md
@@ -15,7 +15,7 @@ You score preview HTML files for visual fidelity to the source design.md. Advers
 - `dark_path` — `{cache_dir}/dark.html`
 - `design_md_path` — the approved design.md (now in `services/{slug}.md`)
 - `rubric_path` — `.claude/skills/design-md/references/rubric-preview.md`
-- `expected_logo_public_path` — either `none` or the exact `/logos/...` path resolved by the orchestrator
+- `expected_logo_src_path` — either `none` or the exact site-relative path (e.g. `/logos/toss.png`) that the preview `<img src>` must render. Distinct from the absolute URL form that lives in design.md frontmatter.
 - `iteration_n` — 1, 2, or 3
 - `output_path` — `{cache_dir}/preview-review-{N}.json`
 
@@ -50,7 +50,7 @@ Exactly one file at `output_path`:
 2. `Read` both HTML files.
 3. `Read` `design_md_path` — extract the canonical color list, typography scale, component names. These are the ground truth for fidelity checks.
 4. Score each item:
-   - **Item 1 (File structure)**: structural element checklist from rubric. Check `<html data-theme>` matches filename, tokens.css path is `/preview/_runtime/tokens.css` (absolute), iframe.js linked with `defer`, no external JS frameworks, file size estimate < 100KB. If `expected_logo_public_path` is not `none` or design.md frontmatter includes `logo`, both HTML files must contain the exact logo path.
+   - **Item 1 (File structure)**: structural element checklist from rubric. Check `<html data-theme>` matches filename, tokens.css path is `/preview/_runtime/tokens.css` (absolute), iframe.js linked with `defer`, no external JS frameworks, file size estimate < 100KB. If `expected_logo_src_path` is not `none`, both HTML files must contain that exact site-relative path inside an `<img src>` attribute. The absolute URL form from design.md frontmatter is NOT acceptable here — preview HTML deliberately keeps `<img src>` site-relative to avoid coupling dev/staging to the production domain.
    - **Item 2 (Color fidelity)**: for each color in `## Colors`, search the HTML for the OKLCH string. Exact character match — `oklch(0.7 0.18 50)` and `oklch(0.70 0.18 50)` are different.
    - **Item 3 (Typography hierarchy)**: identify display/body/caption/micro samples. For `lang: ko` design.md, verify Korean text is present in the typography section.
    - **Item 4 (Component coverage)**: list every component named in `## Components` of the design.md. For each, check the HTML renders it. Note states/variants present.

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -90,16 +90,23 @@ This directory holds all intermediate artifacts. It's gitignored (`.claude/cache
 
 ### Stage 4a — Logo asset resolution
 
-Resolve one `logo_public_path` value before dispatching author agents. It is either an empty string or a browser-loadable path under `/logos/`.
+Resolve **two** logo values before dispatching author agents — different downstream concerns need different forms:
+
+- **`logo_url`** — fully-qualified URL like `https://getdesign.kr/logos/toss.png`. Goes into design.md **frontmatter**, where it must stay meaningful when the file is copied outside the ko-design-md site (PRD User Story 1 — vibe-coding flow).
+- **`logo_src_path`** — site-relative path like `/logos/toss.png`. Goes into preview HTML `<img src>`, which is only ever loaded inside the catalog site's iframe. Keeping it relative avoids making dev/staging depend on the production-domain asset.
+
+Both either co-exist (logo found) or are simultaneously empty (no logo).
+
+The canonical site origin is **`https://getdesign.kr`**. Change this constant in one place only — this paragraph — if the origin ever moves.
 
 1. If `logo_asset_path` was provided:
    - Verify it exists and has a supported extension (`svg`, `png`, `webp`, `avif`).
-   - If it already lives under `${repo_root}/public/logos/`, set `logo_public_path` to `/logos/{basename}`.
-   - Otherwise copy it to `${repo_root}/public/logos/{slug}.{ext}` and set `logo_public_path` to `/logos/{slug}.{ext}`. This is allowed only for user-supplied local logo assets.
-2. If no logo path was provided, auto-detect the first existing file in `public/logos/{slug}.{svg,png,webp,avif}` (in that order) and set `logo_public_path` to the matching `/logos/{slug}.{ext}`.
-3. If nothing is found, set `logo_public_path` to an empty string and continue. The entry may ship without a logo, but Stage 13 must report the missing logo TODO.
+   - If it already lives under `${repo_root}/public/logos/`, set `logo_src_path = /logos/{basename}` and `logo_url = https://getdesign.kr/logos/{basename}`.
+   - Otherwise copy it to `${repo_root}/public/logos/{slug}.{ext}` and set `logo_src_path = /logos/{slug}.{ext}` and `logo_url = https://getdesign.kr/logos/{slug}.{ext}`. This is allowed only for user-supplied local logo assets.
+2. If no logo path was provided, auto-detect the first existing file in `public/logos/{slug}.{svg,png,webp,avif}` (in that order) and set `logo_src_path = /logos/{slug}.{ext}` and `logo_url = https://getdesign.kr/logos/{slug}.{ext}`.
+3. If nothing is found, set both to an empty string and continue. The entry may ship without a logo, but Stage 13 must report the missing logo TODO.
 
-The auto-detect pattern is exactly `public/logos/{slug}.{svg,png,webp,avif}`. When `logo_public_path` is non-empty, every later stage must preserve the exact same value.
+The auto-detect pattern is exactly `public/logos/{slug}.{svg,png,webp,avif}` (the asset itself stays self-hosted). When the two values are non-empty, every later stage must preserve them exactly — design-md-author writes `logo_url` verbatim into frontmatter, preview-html-author embeds `logo_src_path` as `<img src>`, and the Stage 10 grep checks match each file against the appropriate form.
 
 ## Stage 5 — Research (research-collector)
 
@@ -139,7 +146,7 @@ name: {brand_name}
 category: {category}
 lang: {lang}
 today: {today as YYYY-MM-DD}
-logo_public_path: {logo_public_path or "none"}
+logo_url: {logo_url or "none"}
 research_path: ${repo_root}/.claude/cache/design-md/{slug}/research.md
 prior_review_path: ${repo_root}/.claude/cache/design-md/{slug}/review-{N-1}.json or "none" on first pass
 format_reference_path: ${repo_root}/.claude/skills/design-md/references/stitch-format.md
@@ -169,7 +176,7 @@ draft_path: {cache_dir}/draft.md
 research_path: {cache_dir}/research.md
 content_types_path: {abs path}/src/lib/content-types.ts
 rubric_path: {abs path}/.claude/skills/design-md/references/rubric-design.md
-expected_logo_public_path: {logo_public_path or "none"}
+expected_logo_url: {logo_url or "none"}
 iteration_n: {N}
 output_path: {cache_dir}/review-{N}.json
 
@@ -196,7 +203,7 @@ draft_path: ${repo_root}/.claude/cache/design-md/{slug}/draft.en.md
 research_path: ${repo_root}/.claude/cache/design-md/{slug}/research.md
 content_types_path: ${repo_root}/src/lib/content-types.ts
 rubric_path: ${repo_root}/.claude/skills/design-md/references/rubric-design.md
-expected_logo_public_path: {logo_public_path or "none"}
+expected_logo_url: {logo_url or "none"}
 iteration_n: 1
 output_path: ${repo_root}/.claude/cache/design-md/{slug}/review-en.json
 
@@ -250,7 +257,7 @@ lang: {lang}
 design_md_path: {abs path}/services/{slug}.md
 runtime_tokens_path: {abs path}/public/preview/_runtime/tokens.css
 runtime_iframe_path: {abs path}/public/preview/_runtime/iframe.js
-logo_public_path: {logo_public_path or "none"}
+logo_src_path: {logo_src_path or "none"}
 demo_html_paths: (none — leave empty by default; pass an existing {abs path}/public/preview/*/light.html only if a visual peer genuinely fits. The early demo-courier/demo-pay previews have been removed.)
 prior_review_path: {cache_dir}/preview-review-{M-1}.json or "none"
 
@@ -267,7 +274,7 @@ light_path: {cache_dir}/light.html
 dark_path: {cache_dir}/dark.html
 design_md_path: {abs path}/services/{slug}.md
 rubric_path: {abs path}/.claude/skills/design-md/references/rubric-preview.md
-expected_logo_public_path: {logo_public_path or "none"}
+expected_logo_src_path: {logo_src_path or "none"}
 iteration_n: {M}
 output_path: {cache_dir}/preview-review-{M}.json
 
@@ -290,15 +297,15 @@ cp ${repo_root}/.claude/cache/design-md/{slug}/dark.html ${repo_root}/public/pre
 
 ### Logo deterministic check
 
-If `logo_public_path` is non-empty, verify the placed main markdown and both preview HTML files all contain the same logo path:
+If the resolved logo values are non-empty, verify the placed main markdown contains the absolute URL form and both preview HTML files contain the site-relative form:
 
 ```bash
-rg -q -F "logo: {logo_public_path}" "${repo_root}/services/{slug}.md" || echo "LOGO_MISSING_MD"
-rg -q -F "{logo_public_path}" "${repo_root}/public/preview/{slug}/light.html" || echo "LOGO_MISSING_LIGHT"
-rg -q -F "{logo_public_path}" "${repo_root}/public/preview/{slug}/dark.html" || echo "LOGO_MISSING_DARK"
+rg -q -F "logo: {logo_url}" "${repo_root}/services/{slug}.md" || echo "LOGO_MISSING_MD"
+rg -q -F "src=\"{logo_src_path}\"" "${repo_root}/public/preview/{slug}/light.html" || echo "LOGO_MISSING_LIGHT"
+rg -q -F "src=\"{logo_src_path}\"" "${repo_root}/public/preview/{slug}/dark.html" || echo "LOGO_MISSING_DARK"
 ```
 
-If any sentinel prints, do not proceed to Stage 11. If the markdown is missing the logo, re-run Stage 6a with a blocking prior-review issue that says `logo_public_path` must appear as frontmatter `logo`. If either preview is missing the logo, re-run Stage 9a with a blocking prior-preview issue that says the exact `logo_public_path` must render in both files.
+If any sentinel prints, do not proceed to Stage 11. If the markdown is missing the logo, re-run Stage 6a with a blocking prior-review issue that says `logo_url` must appear as frontmatter `logo` (the exact fully-qualified URL — not a site-relative shortcut). If either preview is missing the logo, re-run Stage 9a with a blocking prior-preview issue that says the exact `logo_src_path` (site-relative form) must render as an `<img src>` in both files.
 
 ## Stage 11 — Build OG image
 
@@ -348,7 +355,7 @@ Print a summary message containing:
 - Final review scores: design `{score}/10`, preview `{score}/10`.
 - Screenshots taken during verification (paths or inline).
 - Leftover TODOs:
-  - If `logo_public_path` is empty: "Logo asset: `public/logos/{slug}.svg|png|webp|avif` 가 아직 없습니다. 직접 추가한 뒤 frontmatter `logo: /logos/{slug}.{ext}` 를 채우고 preview HTML에도 같은 경로를 렌더링하세요."
+  - If the logo values are empty: "Logo asset: `public/logos/{slug}.svg|png|webp|avif` 가 아직 없습니다. 직접 추가한 뒤 frontmatter `logo: https://getdesign.kr/logos/{slug}.{ext}` (절대 URL, 외부 복사 대비) 를 채우고 preview HTML에는 `<img src=\"/logos/{slug}.{ext}\">` (site-relative, iframe 전용) 형식으로 렌더링하세요."
   - "related_services: 빈 배열입니다. 검토 후 frontmatter 를 갱신하세요."
   - Any preview review warnings if iteration 3 didn't reach 8.
 

--- a/.claude/skills/design-md/references/rubric-design.md
+++ b/.claude/skills/design-md/references/rubric-design.md
@@ -13,9 +13,9 @@ Frontmatter must round-trip through `buildDoc()` in `src/lib/content-parser.ts` 
 - `sources` is a non-empty array of `https?://` URLs.
 - `slug` matches `^[a-z0-9-]+$` and equals the staging filename stem (e.g. draft.md for slug X has frontmatter `slug: X`).
 - `lang` is exactly `ko` or `en`.
-- `logo` remains optional overall, but if the orchestrator passes an **Expected logo** (`expected_logo_public_path`) other than `none`, frontmatter must include `logo` and it must equal that exact `/logos/...` path. If `logo` is present without an Expected logo, it must still start with `/logos/` and end in `.svg`, `.png`, `.webp`, or `.avif`.
+- `logo` remains optional overall, but if the orchestrator passes an **Expected logo** (`expected_logo_url`) other than `none`, frontmatter must include `logo` and it must equal that exact URL string. If `logo` is present without an Expected logo, it must be a fully-qualified URL starting with `https://getdesign.kr/logos/` and ending in `.svg`, `.png`, `.webp`, or `.avif`. Bare `/logos/...` site-relative paths are rejected — frontmatter values must stay meaningful when the design.md is copied outside the ko-design-md site.
 
-**Failure modes**: typo'd key (`last-updated` instead of `last_updated`), Date object instead of string (gray-matter parses unquoted dates as Date), off-enum category (`fintech`, `media`), empty `sources: []`, slug with capitals or underscores, expected logo `/logos/toss.png` omitted from frontmatter or rewritten as a relative path.
+**Failure modes**: typo'd key (`last-updated` instead of `last_updated`), Date object instead of string (gray-matter parses unquoted dates as Date), off-enum category (`fintech`, `media`), empty `sources: []`, slug with capitals or underscores, expected logo `https://getdesign.kr/logos/toss.png` omitted from frontmatter or downgraded to a site-relative `/logos/toss.png`.
 
 This item is **hard-fail**: if any sub-check fails, deduct the full 3 pts and mark `severity: block` in the issue list. The skill body refuses to advance to the user checkpoint without a valid frontmatter.
 

--- a/.claude/skills/design-md/references/rubric-preview.md
+++ b/.claude/skills/design-md/references/rubric-preview.md
@@ -12,11 +12,11 @@ Both HTML files exist and conform:
 - All page CSS is in a single inline `<style>` block (no external stylesheets beyond tokens.css).
 - No external JS frameworks (no React, no jQuery — these are static HTML pages).
 - File size < 100KB each.
-- If design.md frontmatter includes `logo`, both HTML files contain that exact logo path and render it in a visible brand/hero position. If the orchestrator passes `expected_logo_public_path`, use that value as the required path.
+- If the orchestrator passes `expected_logo_src_path` (or design.md frontmatter includes `logo`), both HTML files must contain a `<img src="{expected_logo_src_path}">` rendered in a visible brand/hero position. The required form is **site-relative** (e.g. `/logos/toss.png`) — NOT the absolute URL (`https://getdesign.kr/logos/toss.png`) that design.md frontmatter stores. Preview HTML lives inside the catalog site's iframe, so site-relative is correct; the absolute URL exists only in frontmatter so that copied design.md files stay meaningful outside the site.
 
 **Pass**: 2 pts if all checks pass. 0 pts if any structural element missing or wrong path. No partial credit.
 
-**Failure modes**: writing `tokens.css` as a relative path; creating a per-slug `_runtime/` folder (the runtime is shared); adding `<script src="https://cdn.../react.js">`; frontmatter says `logo: /logos/toss.png` but light.html or dark.html omits `/logos/toss.png`.
+**Failure modes**: writing `tokens.css` as a relative path; creating a per-slug `_runtime/` folder (the runtime is shared); adding `<script src="https://cdn.../react.js">`; frontmatter says `logo: https://getdesign.kr/logos/toss.png` but light.html or dark.html omits the `<img src="/logos/toss.png">` site-relative form (or worse, embeds the absolute URL itself in `<img src>`).
 
 ## Item 2 — Color fidelity (2 pts)
 

--- a/services/krds.md
+++ b/services/krds.md
@@ -14,7 +14,7 @@ sources:
   - https://designcompass.org/en/2024/04/17/krds/
 related_services: []
 lang: ko
-logo: /logos/krds.svg
+logo: https://getdesign.kr/logos/krds.svg
 ---
 
 # KRDS — design.md

--- a/services/seed-design.md
+++ b/services/seed-design.md
@@ -20,7 +20,7 @@ sources:
   - https://www.daangn.com/kr/
 related_services: []
 lang: ko
-logo: /logos/seed-design-symbol.png
+logo: https://getdesign.kr/logos/seed-design-symbol.png
 ---
 
 # SEED Design — design.md

--- a/services/teamsparta.md
+++ b/services/teamsparta.md
@@ -2,7 +2,7 @@
 name: 팀스파르타
 slug: teamsparta
 category: etc
-logo: /logos/teamsparta-favicon.png
+logo: https://getdesign.kr/logos/teamsparta-favicon.png
 last_updated: "2026-05-13"
 sources:
   - https://api.anthropic.com/v1/design/h/wZ6KVUwvbzeAUM4Ji6lLjQ

--- a/services/toss.md
+++ b/services/toss.md
@@ -18,7 +18,7 @@ sources:
   - https://toss.im
 related_services: []
 lang: ko
-logo: /logos/toss.png
+logo: https://getdesign.kr/logos/toss.png
 ---
 
 # 토스 (Toss) — design.md

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -13,7 +13,7 @@ sources:
   - https://github.com/goorm-dev/vapor-ui
 related_services: []
 lang: ko
-logo: /logos/vapor-ui.png
+logo: https://getdesign.kr/logos/vapor-ui.png
 ---
 
 # Vapor UI — design.md

--- a/services/wanted.md
+++ b/services/wanted.md
@@ -12,7 +12,7 @@ sources:
   - https://github.com/orioncactus/pretendard
 related_services: []
 lang: ko
-logo: /logos/wanted.png
+logo: https://getdesign.kr/logos/wanted.png
 ---
 
 # 원티드 (Wanted) — design.md

--- a/src/lib/design-md-skill-logo-policy.test.ts
+++ b/src/lib/design-md-skill-logo-policy.test.ts
@@ -27,17 +27,19 @@ describe("/design-md logo policy", () => {
     )
 
     expect(skill).toContain("public/logos/{slug}.{svg,png,webp,avif}")
-    expect(skill).toContain("logo_public_path")
+    expect(skill).toContain("logo_url")
+    expect(skill).toContain("logo_src_path")
     expect(skill).toContain("Logo deterministic check")
     expect(skill).toContain('[ -f "$logo_asset_path" ]')
-    expect(skill).toContain('logo: {logo_public_path}')
-    expect(skill).not.toContain("${logo_public_path}")
-    expect(author).toContain("logo_public_path")
-    expect(author).toContain("logo: {logo_public_path}")
-    expect(previewAuthor).toContain("logo_public_path")
+    expect(skill).toContain("logo: {logo_url}")
+    expect(skill).not.toContain("${logo_url}")
+    expect(skill).not.toContain("${logo_src_path}")
+    expect(author).toContain("logo_url")
+    expect(author).toContain("logo: {logo_url}")
+    expect(previewAuthor).toContain("logo_src_path")
     expect(previewAuthor).toContain("both light.html and dark.html")
     expect(designRubric).toContain("Expected logo")
-    expect(previewRubric).toContain("logo path")
+    expect(previewRubric).toContain("site-relative")
   })
 
   it("keeps existing service logo assets present and visible in both previews", () => {
@@ -55,13 +57,21 @@ describe("/design-md logo policy", () => {
 
       expect(slug, `${servicePath} slug`).toBeTruthy()
       expect(logo, `${servicePath} logo frontmatter`).toBeTruthy()
-      expect(existsSync(join(ROOT, "public", logo!.replace(/^\//, "")))).toBe(
-        true,
+      expect(logo, `${servicePath} logo must be absolute URL`).toMatch(
+        /^https:\/\/getdesign\.kr\/logos\//,
       )
+      const logoSrcPath = logo!.replace(/^https:\/\/getdesign\.kr/, "")
+      expect(
+        existsSync(join(ROOT, "public", logoSrcPath.replace(/^\//, ""))),
+        `${servicePath} logo asset must exist at public${logoSrcPath}`,
+      ).toBe(true)
 
       for (const theme of ["light", "dark"]) {
         const previewPath = `public/preview/${slug}/${theme}.html`
-        expect(readRepoFile(previewPath), previewPath).toContain(logo)
+        expect(
+          readRepoFile(previewPath),
+          `${previewPath} must embed site-relative <img src> (not the absolute URL form)`,
+        ).toContain(`src="${logoSrcPath}"`)
       }
     }
   })

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { SITE_URL, absoluteUrl } from "./site-config"
+import { SITE_URL, absoluteUrl, siteRelativeIfSelf } from "./site-config"
 
 // In test mode (vitest sets NODE_ENV=test, import.meta.env.PROD = false),
 // VITE_SITE_URL is unset, so SITE_URL is the empty string and absoluteUrl
@@ -29,5 +29,29 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("absoluteUrl normalizes a path that lacks a leading slash", () => {
     expect(absoluteUrl("og/default.png")).toBe("/og/default.png")
+  })
+
+  // siteRelativeIfSelf in test env (SITE_URL empty) — the origin-match path
+  // can't be exercised here; covered by manual dev verification with
+  // VITE_SITE_URL set. These cases lock in the safe fallback behavior so
+  // unset-env environments never accidentally mangle a URL.
+  it("siteRelativeIfSelf returns undefined for undefined input", () => {
+    expect(siteRelativeIfSelf(undefined)).toBeUndefined()
+  })
+
+  it("siteRelativeIfSelf returns absolute URL unchanged when SITE_URL is empty", () => {
+    expect(siteRelativeIfSelf("https://getdesign.kr/logos/toss.png")).toBe(
+      "https://getdesign.kr/logos/toss.png",
+    )
+  })
+
+  it("siteRelativeIfSelf returns a site-relative path unchanged", () => {
+    expect(siteRelativeIfSelf("/logos/toss.png")).toBe("/logos/toss.png")
+  })
+
+  it("siteRelativeIfSelf returns a foreign-origin URL unchanged", () => {
+    expect(siteRelativeIfSelf("https://other-site.example/foo.png")).toBe(
+      "https://other-site.example/foo.png",
+    )
   })
 })

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -27,3 +27,25 @@ export function absoluteUrl(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`
   return `${SITE_URL}${normalized}`
 }
+
+// Reverse of absoluteUrl: when SITE_URL is configured and the input URL
+// shares that origin, return just the path portion. Otherwise return the
+// input unchanged.
+//
+// Use case: design.md frontmatter stores fully-qualified URLs so the file
+// stays meaningful when copied outside the site (PRD User Story 1 —
+// vibe-coding flow). But in-site rendering should fetch the same-origin
+// asset, not the production-domain URL — otherwise a localhost dev session
+// hits the production CDN for every card-grid logo, which breaks when
+// prod is down, the asset isn't deployed yet, or the user is offline.
+//
+// When VITE_SITE_URL is unset (test/SSR/dev-without-env), the input is
+// returned unchanged — the browser will resolve it as-is.
+export function siteRelativeIfSelf(
+  url: string | undefined,
+): string | undefined {
+  if (!url || !SITE_URL) return url
+  if (url === SITE_URL) return "/"
+  if (url.startsWith(`${SITE_URL}/`)) return url.slice(SITE_URL.length)
+  return url
+}

--- a/src/routes/-home/components/service-logo.tsx
+++ b/src/routes/-home/components/service-logo.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { siteRelativeIfSelf } from "@/lib/site-config"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -49,9 +50,10 @@ export function ServiceLogo({ name, logo, size = 24, className }: Props) {
   }, [logo])
 
   if (logo && !failed) {
+    const src = siteRelativeIfSelf(logo)
     return (
       <img
-        src={logo}
+        src={src}
         alt=""
         aria-hidden
         onError={() => {


### PR DESCRIPTION
## 변경 요약

design.md가 LLM 컨텍스트나 외부 .md로 복사될 때 frontmatter `logo`가 dead reference가 되던 문제를 해결한다. 의도에 따라 **frontmatter는 절대 URL**, **preview HTML / 카드 그리드는 site-relative path**로 분리한다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [x] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

> 카탈로그 콘텐츠 PR이 아니라 6개 기존 entry의 frontmatter 단일 필드(`logo`) 형식만 갱신.

- [ ] `/design-md` 스킬로 생성
- [ ] frontmatter 필수 필드 검증 완료
- [ ] `public/preview/{slug}/{light,dark}.html` 생성·확인
- [ ] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
- [ ] 브랜드 자산 라이선스/상표 우려 검토
- [ ] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) 가이드라인 준수

---

## 핵심 설계

| 영역 | 형식 | 이유 |
|---|---|---|
| **frontmatter `logo`** | 절대 URL `https://getdesign.kr/logos/...` | 외부 복사 시 의미 보존 (PRD User Story 1 — vibe-coding flow) |
| **preview HTML `<img src>`** | site-relative `/logos/...` | iframe 전용. dev/staging이 production CDN에 의존하지 않게 |
| **카드 그리드 `<img>`** | `siteRelativeIfSelf` 헬퍼 통과 | 같은 origin이면 path 추출, 다른 origin/unset이면 입력 그대로 |

### Skill pipeline 변수 분리

기존 단일 변수 `logo_public_path`는 두 가지 의도(절대 URL · site-relative)를 함께 떠맡고 있어 어느 한쪽 의도에 거짓말을 할 수밖에 없었다. 의도별로 분리:

- **`logo_url`** — design-md-author / -reviewer, frontmatter `logo`에 verbatim
- **`logo_src_path`** — preview-html-author / -reviewer, `<img src>`에 verbatim

## 변경 파일 (17개)

- **콘텐츠 6**: `services/{krds,seed-design,teamsparta,toss,vapor-ui,wanted}.md` — `logo` 절대 URL화
- **Skill**: `.claude/skills/design-md/SKILL.md` (Stage 4a/6a/6b/6d/9a/9b/10/13)
- **Agents 4**: design-md-author / design-md-reviewer / preview-html-author / preview-html-reviewer
- **Rubrics 2**: rubric-design (절대 URL 정책) · rubric-preview (site-relative 정책)
- **Site helper**: `src/lib/site-config.ts` — 새 `siteRelativeIfSelf(url)` (기존 `absoluteUrl(path)`의 짝)
- **UI**: `src/routes/-home/components/service-logo.tsx` — 헬퍼 통과
- **Tests 2**: `design-md-skill-logo-policy.test.ts` (split-format) + `site-config.test.ts` (4 신규 케이스)

## 검증

- ✅ `pnpm test --run` 72/72 (4 신규)
- ✅ `pnpm typecheck` clean
- ✅ `pnpm lint` clean
- ✅ `pnpm build` clean
- ✅ `pnpm build:og` 7 PNG 정상 생성
- ✅ Dev verification (env set + unset 양쪽): preview HTML 단독 / service detail iframe / 카드 그리드 모두 로고 정상 로드, frontmatter는 절대 URL, preview는 site-relative, 두 영역 혼재 0건

## 리뷰어가 알아두면 좋은 점

- **`public/preview/{slug}/*.html` 12 파일은 net-zero diff**. 작업 중 실험적으로 절대 URL로 한 번 바꿨다가 다시 site-relative로 되돌려서 git status에 안 잡힌다. 의도된 결과 — preview HTML은 이미 site-relative였고 그대로 유지되어야 옳다.
- **`siteRelativeIfSelf`는 SITE_URL이 empty일 때 입력 그대로 반환**(test/SSR-safe). dev에서 `VITE_SITE_URL`을 set해야 origin-match가 동작한다 (`.env.example` 참고). 미설정이어도 production 자산이 있는 한 외부 fetch로 화면은 보인다.

## 관련 이슈

— (별도 이슈 없이 사용자 피드백으로 진행)