### PR TITLE
feat(site): add header dialog for new-entry contribution

### DIFF
--- a/src/components/site/contribute-dialog.test.tsx
+++ b/src/components/site/contribute-dialog.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { ContributeDialog } from "./contribute-dialog"
+
+afterEach(cleanup)
+
+function openDialog() {
+  fireEvent.click(screen.getByRole("button", { name: /새 항목 제안하기/ }))
+}
+
+describe("ContributeDialog", () => {
+  it("opens the dialog with both choice cards when the trigger is clicked", () => {
+    render(<ContributeDialog />)
+    openDialog()
+
+    expect(
+      screen.getByRole("heading", { name: /새 항목 추가하기/ }),
+    ).toBeDefined()
+    expect(screen.getByRole("link", { name: /제안만 할게요/ })).toBeDefined()
+    expect(screen.getByRole("link", { name: /직접 추가할래요/ })).toBeDefined()
+  })
+
+  it("links the propose card to the new-catalog-entry issue template in a new tab", () => {
+    render(<ContributeDialog />)
+    openDialog()
+
+    const link = screen.getByRole("link", { name: /제안만 할게요/ })
+    expect(link.getAttribute("href")).toContain(
+      "/issues/new?template=new-catalog-entry.yml",
+    )
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer")
+  })
+
+  it("links the contribute card to the CONTRIBUTING anchor in a new tab", () => {
+    render(<ContributeDialog />)
+    openDialog()
+
+    const link = screen.getByRole("link", { name: /직접 추가할래요/ })
+    expect(link.getAttribute("href")).toContain(
+      "/blob/main/CONTRIBUTING.md#1-",
+    )
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer")
+  })
+
+  it("closes the dialog when Escape is pressed", async () => {
+    render(<ContributeDialog />)
+    openDialog()
+
+    const dialog = await screen.findByRole("dialog")
+    fireEvent.keyDown(dialog, { key: "Escape" })
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull()
+    })
+  })
+})

--- a/src/components/site/contribute-dialog.tsx
+++ b/src/components/site/contribute-dialog.tsx
@@ -1,11 +1,10 @@
 import { Dialog } from "@base-ui/react/dialog"
 
+import { GITHUB_REPO_URL } from "@/lib/site-config"
 import { cn } from "@/lib/utils"
 
-const REPO_URL = "https://github.com/caesiumy/ko-design-md"
-
-const PROPOSE_ISSUE_URL = `${REPO_URL}/issues/new?template=new-catalog-entry.yml`
-const CONTRIBUTE_GUIDE_URL = `${REPO_URL}/blob/main/CONTRIBUTING.md#1-새-항목-추가-권장-design-md-스킬-사용`
+const PROPOSE_ISSUE_URL = `${GITHUB_REPO_URL}/issues/new?template=new-catalog-entry.yml`
+const CONTRIBUTE_GUIDE_URL = `${GITHUB_REPO_URL}/blob/main/CONTRIBUTING.md#1-새-항목-추가-권장-design-md-스킬-사용`
 
 function PlusIcon({ className }: { className?: string }) {
   return (
@@ -126,7 +125,7 @@ function ChoiceCard({
       <p className="text-xs leading-relaxed text-muted-foreground">
         {description}
       </p>
-      <p className="text-[10px] tracking-wide text-muted-foreground/70 uppercase">
+      <p className="text-xs tracking-wide text-muted-foreground/70 uppercase">
         {hint}
       </p>
     </a>

--- a/src/components/site/contribute-dialog.tsx
+++ b/src/components/site/contribute-dialog.tsx
@@ -1,0 +1,134 @@
+import { Dialog } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+
+const REPO_URL = "https://github.com/caesiumy/ko-design-md"
+
+const PROPOSE_ISSUE_URL = `${REPO_URL}/issues/new?template=new-catalog-entry.yml`
+const CONTRIBUTE_GUIDE_URL = `${REPO_URL}/blob/main/CONTRIBUTING.md#1-새-항목-추가-권장-design-md-스킬-사용`
+
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  )
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M6 6l12 12M18 6l-12 12" />
+    </svg>
+  )
+}
+
+export function ContributeDialog() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger
+        className="hover:text-brand focus-visible:text-brand inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors focus-visible:outline-none"
+        aria-label="새 항목 제안하기"
+      >
+        <PlusIcon className="size-4" />
+        <span className="hidden sm:inline">새 항목 제안</span>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
+        <Dialog.Popup
+          className={cn(
+            "fixed top-1/2 left-1/2 z-50 w-[calc(100vw-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2",
+            "rounded-2xl border bg-background p-6 shadow-2xl outline-none",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          )}
+          style={{ borderColor: "var(--rule-strong)" }}
+        >
+          <Dialog.Close
+            className="hover:bg-muted hover:text-foreground focus-visible:text-foreground absolute top-4 right-4 inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors focus-visible:outline-none"
+            aria-label="닫기"
+          >
+            <CloseIcon className="size-4" />
+          </Dialog.Close>
+          <Dialog.Title className="text-display text-lg font-extrabold tracking-tight">
+            새 항목 추가하기
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            두 경로 중 편한 쪽을 선택하세요.
+          </Dialog.Description>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            <ChoiceCard
+              href={PROPOSE_ISSUE_URL}
+              title="제안만 할게요"
+              description="브랜드명·URL만 알려주시면 메인테이너가 검토합니다."
+              hint="GitHub Issue Template으로 이동"
+            />
+            <ChoiceCard
+              href={CONTRIBUTE_GUIDE_URL}
+              title="직접 추가할래요"
+              description="Claude Code의 /design-md 스킬로 PR까지 자동화합니다."
+              hint="CONTRIBUTING 가이드로 이동"
+            />
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function ChoiceCard({
+  href,
+  title,
+  description,
+  hint,
+}: {
+  href: string
+  title: string
+  description: string
+  hint: string
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "group flex flex-col gap-2 rounded-xl border p-4 transition-colors",
+        "hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+      )}
+      style={{ borderColor: "var(--rule-strong)" }}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold">{title}</span>
+        <span
+          className="group-hover:text-brand text-xs text-muted-foreground transition-colors"
+          aria-hidden
+        >
+          →
+        </span>
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+      <p className="text-[10px] tracking-wide text-muted-foreground/70 uppercase">
+        {hint}
+      </p>
+    </a>
+  )
+}

--- a/src/components/site/header.tsx
+++ b/src/components/site/header.tsx
@@ -1,8 +1,7 @@
 import { Link } from "@tanstack/react-router"
 
 import { ContributeDialog } from "./contribute-dialog"
-
-const REPO_URL = "https://github.com/caesiumy/ko-design-md"
+import { GITHUB_REPO_URL } from "@/lib/site-config"
 
 function GithubMark({ className }: { className?: string }) {
   return (
@@ -27,7 +26,7 @@ export function SiteHeader() {
         <nav className="flex items-center gap-5 text-sm">
           <ContributeDialog />
           <a
-            href={REPO_URL}
+            href={GITHUB_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-brand inline-flex items-center gap-1.5 text-muted-foreground transition-colors"

--- a/src/components/site/header.tsx
+++ b/src/components/site/header.tsx
@@ -1,5 +1,7 @@
 import { Link } from "@tanstack/react-router"
 
+import { ContributeDialog } from "./contribute-dialog"
+
 const REPO_URL = "https://github.com/caesiumy/ko-design-md"
 
 function GithubMark({ className }: { className?: string }) {
@@ -23,6 +25,7 @@ export function SiteHeader() {
           </span>
         </Link>
         <nav className="flex items-center gap-5 text-sm">
+          <ContributeDialog />
           <a
             href={REPO_URL}
             target="_blank"

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -27,3 +27,8 @@ export function absoluteUrl(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`
   return `${SITE_URL}${normalized}`
 }
+
+// Canonical GitHub repository URL. Mirrors `repository.url` in package.json
+// and is the single source of truth for header link, contribute dialog,
+// issue template / CONTRIBUTING anchors composed at runtime.
+export const GITHUB_REPO_URL = "https://github.com/caesiumy/ko-design-md"


### PR DESCRIPTION
## 변경 요약

사이트 헤더에 `+ 새 항목 제안` 진입점을 추가했습니다. 클릭 시 dialog가 열려 기존 두 기여 채널(GitHub Issue Template과 `/design-md` 스킬 가이드)로 안내합니다. 그동안 방문자는 README/GitHub repo를 직접 찾아야만 두 경로를 발견할 수 있었습니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](../CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

해당 없음.

## 구현 노트

- 새 `ContributeDialog` 컴포넌트는 `@base-ui/react` Dialog primitive 기반 — 새 의존성 0, 서버 코드 0.
- 헤더는 모바일에서 라벨이 `+` 아이콘으로 축소 (`hidden sm:inline` 패턴은 기존 GitHub 링크와 동일).
- 두 카드는 `target=\"_blank\" rel=\"noopener noreferrer\"`로 각각 GitHub Issue Template과 CONTRIBUTING anchor를 새 탭에 엽니다.
- 사이트는 site-level dark mode를 채택하지 않은 light-only (`src/styles.css:93-94`). dialog는 site token (`text-muted-foreground`, `--rule-strong`, `bg-background`)을 사용하므로 미래에 dark mode가 도입되면 자동 대응합니다.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 11 files, 72 tests pass (새 4 케이스: trigger open / propose card href / contribute card href / Escape close)
- [x] `pnpm build`
- [x] Manual — desktop 1280px · mobile 375px viewport에서 헤더 라벨 노출·숨김 + dialog grid 2열·1열 stack + 카드 href·target·rel 검증 (Claude Preview MCP)