### PR TITLE
fix(seo): RSS description을 tagline 기반으로 교체해 네이버 검증 통과

### DIFF
--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -199,8 +199,7 @@ describe("buildRssXml with real /services/*.md content", () => {
     // siblings (e.g. <image><description>...</description></image>).
     const doc = new DOMParser().parseFromString(xml, "application/xml")
     return Array.from(doc.getElementsByTagName("item")).map(
-      (item) =>
-        item.getElementsByTagName("description")[0]?.textContent ?? "",
+      (item) => item.getElementsByTagName("description")[0].textContent,
     )
   }
 

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -194,11 +194,14 @@ describe("buildRssXml with real /services/*.md content", () => {
   const xml = buildRssXml({ siteUrl: SITE_URL, services: getAllServices() })
 
   function itemDescriptions(): Array<string> {
-    const matches = Array.from(
-      xml.matchAll(/<description>([\s\S]*?)<\/description>/g),
+    // Use DOM navigation rather than regex so we target <description> children of
+    // <item> specifically — robust against future channel-level <description>
+    // siblings (e.g. <image><description>...</description></image>).
+    const doc = new DOMParser().parseFromString(xml, "application/xml")
+    return Array.from(doc.getElementsByTagName("item")).map(
+      (item) =>
+        item.getElementsByTagName("description")[0]?.textContent ?? "",
     )
-    // first <description> is channel-level (SITE_DESCRIPTION); rest are items.
-    return matches.slice(1).map((m) => m[1])
   }
 
   it("produces well-formed XML (no parsererror node)", () => {
@@ -227,8 +230,9 @@ describe("buildRssXml with real /services/*.md content", () => {
 
   it("caps every <description> at 500 chars + ellipsis (regression guard against full-body descriptions)", () => {
     for (const desc of itemDescriptions()) {
-      // 500 cap + "…" + worst-case escape overhead (e.g. " → &quot;) ≈ 600.
-      expect(desc.length).toBeLessThanOrEqual(600)
+      // textContent decodes entities, so the bound matches truncateForMeta
+      // exactly: max=500 + "…" = 501.
+      expect(desc.length).toBeLessThanOrEqual(501)
     }
   })
 })

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -1,9 +1,12 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it } from "vitest"
 import {
   buildRobotsTxt,
   buildRssXml,
   buildSitemapXml,
 } from "./seo-feed"
+import { getAllServices } from "./content-collection"
 import type { ServiceDoc } from "./content-types"
 
 const SITE_URL = "https://ko-design.example/"
@@ -114,13 +117,119 @@ describe("buildRssXml", () => {
     ).toThrow(/Invalid date format/)
   })
 
-  it("escapes XML-sensitive text and exposes the full document body", () => {
+  it("uses tagline (not full body) for item description and escapes XML-sensitive text", () => {
     const xml = buildRssXml({ siteUrl: SITE_URL, services: docs })
 
     expect(xml).toContain("<title>A&amp;B &lt;Design&gt;</title>")
     expect(xml).toContain(
-      "<description>본문에 &lt;tag&gt; &amp; 특수문자가 들어갑니다.</description>",
+      "<description>요약에도 &amp; 문자가 들어갑니다.</description>",
     )
+    // Raw markdown body must NOT leak into <description>
+    expect(xml).not.toContain("본문에 &lt;tag&gt; &amp; 특수문자가 들어갑니다.")
+  })
+
+  it("truncates long taglines with an ellipsis under 500 characters", () => {
+    const longTagline = "가".repeat(600)
+    const xml = buildRssXml({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Long",
+          slug: "long",
+          lastUpdated: "2026-05-10",
+          body: "body",
+          tagline: longTagline,
+        }),
+      ],
+    })
+
+    const match = xml.match(/<description>([\s\S]*?)<\/description>/g)
+    // first <description> is channel-level, second is the item
+    expect(match).not.toBeNull()
+    const itemDescription = match![1]
+    const inner = itemDescription
+      .replace(/^<description>/, "")
+      .replace(/<\/description>$/, "")
+    expect(inner.endsWith("…")).toBe(true)
+    // truncateForMeta cuts to max=500 and appends an ellipsis → up to 501 chars
+    expect(inner.length).toBeLessThanOrEqual(501)
+  })
+
+  it("falls back to frontmatter name when tagline is empty", () => {
+    const xml = buildRssXml({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Heading Only",
+          slug: "heading-only",
+          lastUpdated: "2026-05-10",
+          body: "# 헤딩만 있음\n\n> 인용만 있음",
+          tagline: "",
+        }),
+      ],
+    })
+
+    expect(xml).toContain("<description>Heading Only</description>")
+  })
+
+  it("never emits an empty <description> tag", () => {
+    const xml = buildRssXml({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Empty Body",
+          slug: "empty-body",
+          lastUpdated: "2026-05-10",
+          body: "",
+          tagline: "",
+        }),
+      ],
+    })
+
+    expect(xml).not.toMatch(/<description>\s*<\/description>/)
+  })
+})
+
+describe("buildRssXml with real /services/*.md content", () => {
+  const xml = buildRssXml({ siteUrl: SITE_URL, services: getAllServices() })
+
+  function itemDescriptions(): Array<string> {
+    const matches = Array.from(
+      xml.matchAll(/<description>([\s\S]*?)<\/description>/g),
+    )
+    // first <description> is channel-level (SITE_DESCRIPTION); rest are items.
+    return matches.slice(1).map((m) => m[1])
+  }
+
+  it("produces well-formed XML (no parsererror node)", () => {
+    const doc = new DOMParser().parseFromString(xml, "application/xml")
+    const errors = doc.getElementsByTagName("parsererror")
+    expect(errors.length).toBe(0)
+    expect(doc.documentElement.nodeName).toBe("rss")
+  })
+
+  it("does not leak raw markdown markup into any <description>", () => {
+    const descriptions = itemDescriptions()
+    expect(descriptions.length).toBeGreaterThan(0)
+    for (const desc of descriptions) {
+      expect(desc).not.toMatch(/(^|\n)#+\s/) // ATX headings
+      expect(desc).not.toContain("```") // code fences
+      expect(desc).not.toContain("[src:") // Stitch citation refs
+      expect(desc).not.toContain("**") // bold markers
+    }
+  })
+
+  it("emits a non-empty <description> for every item", () => {
+    for (const desc of itemDescriptions()) {
+      expect(desc.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it("caps every <description> at 500 chars + ellipsis (regression guard against full-body descriptions)", () => {
+    for (const desc of itemDescriptions()) {
+      // 500 cap + "…" + worst-case escape overhead (e.g. " → &quot;) ≈ 600.
+      expect(desc.length).toBeLessThanOrEqual(600)
+    }
   })
 })
 

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -1,3 +1,4 @@
+import { truncateForMeta } from "./content-parser"
 import type { ServiceDoc } from "./content-types"
 
 const SITE_TITLE = "ko/design.md"
@@ -90,7 +91,10 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
   const items = services.map((doc) => {
     const itemUrl = canonicalUrl(origin, `/services/${doc.frontmatter.slug}`)
     const updated = doc.frontmatter.last_updated
-    const body = doc.body || doc.tagline
+    const description = truncateForMeta(
+      doc.tagline || doc.frontmatter.name,
+      500,
+    )
 
     return [
       "    <item>",
@@ -98,7 +102,7 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
       `      <link>${escapeXml(itemUrl)}</link>`,
       `      <guid isPermaLink="true">${escapeXml(itemUrl)}</guid>`,
       updated ? `      <pubDate>${toRssDate(updated)}</pubDate>` : "",
-      `      <description>${escapeXml(body)}</description>`,
+      `      <description>${escapeXml(description)}</description>`,
       "    </item>",
     ]
       .filter(Boolean)


### PR DESCRIPTION
## 변경 요약

`https://getdesign.kr/rss.xml` 이 네이버 서치 어드바이저에서 **"형식/구조가 RSS 아님"** 으로 거부되던 이슈를 해결한다. 각 item `<description>` 에 마크다운 본문 전체가 들어가 응답이 200KB+ 가 되고 `# 헤딩` · ` ``` ` 코드펜스 · `[src:N]` citation 이 escape된 채 살아남던 것을 `tagline` + 500자 cap 으로 교체했다. 응답 크기 ~5KB 로 축소, 마크다운 마크업 leak 0건.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 변경 상세

### `src/lib/seo-feed.ts`

- `import { truncateForMeta } from "./content-parser"` 추가
- `const body = doc.body || doc.tagline` → `const description = truncateForMeta(doc.tagline || doc.frontmatter.name, 500)`
- `<description>` 출력 변수 교체

`doc.body` 는 `gray-matter` 가 잘라낸 마크다운 RAW 본문 전체(toss 38KB · krds 26KB · teamsparta 16KB 등 6개 합 80KB+) 라 escape만 거쳐도 RSS 페이로드가 비대해지고 description 안에 마크다운 syntax 가 그대로 남는다. `tagline` 은 `deriveTagline()` 이 이미 첫 비-헤딩/비-인용 문단에서 `**` 와 `[src:N]` 을 제거한 평문이므로 RSS 2.0 의 "item synopsis" 의미에 부합한다. `truncateForMeta` 는 기존에 OG 메타용으로 이미 export 되어 있어 새 의존성 없이 재사용.

### `src/lib/seo-feed.test.ts`

- 기존 `"exposes the full document body"` 어서션을 tagline 기반으로 뒤집음
- 단위 케이스 3개 추가: 긴 tagline cap + ellipsis, tagline 비면 `frontmatter.name` fallback, 빈 `<description>` 부재
- **실제 `services/*.md` 6개로 빌드한 RSS 통합 describe 추가** (jsdom DOMParser):
  - well-formedness (`<parsererror>` 부재 + root === `rss`)
  - 마크다운 마크업 leak 부재 (`# 헤딩` / ` ``` ` / `[src:` / `**`)
  - 모든 item `<description>` non-empty
  - 모든 item `<description>` ≤ 600자 (cap 500 + ellipsis + escape overhead) — 본문 통째 노출 회귀 가드

## 검증

| 항목 | 결과 |
|---|---|
| `pnpm test` | 83/83 그린 (seo-feed.test.ts 단독 14 tests) |
| `pnpm typecheck` | 통과 |
| `pnpm lint` | 통과 |
| `pnpm build` | 통과 |
| 로컬 `/rss.xml` 크기 | 200KB+ → **5,367 bytes** |
| PowerShell `[xml]` 캐스팅 (well-formed) | throw 없음 |
| 마크다운 잔재 (`# ` · ` ``` ` · `[src:` · `**`) | 0건 |
| 빈 `<description></description>` | 0건 |

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 머지 후 후속 작업

1. CDN 캐시 무효화 (`/rss.xml`, `s-maxage=3600`)
2. [W3C Feed Validator](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fgetdesign.kr%2Frss.xml) 로 통과 1차 확인
3. 네이버 서치 어드바이저 → RSS 기존 등록 삭제 후 재제출

별도 PR 로 분리해둔 후속 개선안 (회귀 위험 격리 목적):
- `escapeXml` 의 `&apos;` → `&#39;` 및 XML 1.0 illegal control char strip
- `<content:encoded>` 모듈 추가로 풀텍스트 노출 (마크다운→HTML 변환기 도입)