### PR TITLE
chore(deps): replace vite-tsconfig-paths with vite 8 native + alias fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.2.1",
-    "tw-animate-css": "^1.4.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1))
     devDependencies:
       '@tanstack/devtools-vite':
         specifier: ^0.7.0
@@ -4273,16 +4270,6 @@ packages:
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -4487,14 +4474,6 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -8716,10 +8695,6 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -8897,17 +8872,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-    optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@7.3.3(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.1):
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { existsSync, readdirSync } from "node:fs"
-import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
 import { defineConfig } from "vite"
 import { devtools } from "@tanstack/devtools-vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import viteReact from "@vitejs/plugin-react"
-import viteTsConfigPaths from "vite-tsconfig-paths"
 import tailwindcss from "@tailwindcss/vite"
 import { nitro } from "nitro/vite"
 import type { Plugin, UserConfig } from "vite"
@@ -120,7 +120,21 @@ function previewSlugsPlugin(): Plugin {
   }
 }
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
 const config = defineConfig({
+  resolve: {
+    // Native tsconfig path alias resolution (vite >= 8). Replaces the
+    // previous `vite-tsconfig-paths` plugin — vite auto-discovers the root
+    // `tsconfig.json` and honors the `paths` field (`@/* → ./src/*`).
+    tsconfigPaths: true,
+    // Explicit alias fallback for environments where the native resolver
+    // does not apply (notably vitest's SSR worker). Keeps `@/...` imports
+    // working uniformly across dev / build / test.
+    alias: {
+      "@": join(__dirname, "src"),
+    },
+  },
   build: {
     rollupOptions: appRollupOptions,
   },
@@ -128,10 +142,6 @@ const config = defineConfig({
     previewSlugsPlugin(),
     devtools(),
     nitro({ rollupConfig: nitroRollupOptions }),
-    // this is the plugin that enables path aliases
-    viteTsConfigPaths({
-      projects: ["./tsconfig.json"],
-    }),
     tailwindcss(),
     tanstackStart(),
     viteReact(),


### PR DESCRIPTION
## 변경 요약

vite 8.0.13 부터 `resolve.tsconfigPaths` 옵션으로 tsconfig path alias 해석이 native 지원됩니다. `vite-tsconfig-paths` 플러그인을 제거하고 native 설정으로 전환합니다.

- `vite.config.ts`: `viteTsConfigPaths({ projects: ["./tsconfig.json"] })` 제거 → `resolve.tsconfigPaths: true`
- `vite.config.ts`: vitest 환경에서 native option 이 동작하지 않는 케이스 (test 환경의 SSR worker resolver 경로) 를 보강하기 위해 `resolve.alias: { "@": <root>/src }` 명시 fallback 추가
- `package.json` / `pnpm-lock.yaml`: `vite-tsconfig-paths` devDependency 제거

PR #41 (`vite-tsconfig-paths` 5.1.4 → 6.1.1 major bump) 을 **대체**합니다. 머지 후 #41 close 예정.

## 배경

vite 8 머지 (#42) 이후 dev server 가 다음 가이드를 출력 — vite 가 직접 지원하므로 플러그인을 유지할 필요가 없다는 안내:

> The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the `resolve.tsconfigPaths` option.

dev dep -1, 코드 1 줄 추가 + 플러그인 호출 4 줄 제거로 정리됩니다.

## 변경 종류

- [x] 사이트 코드/UI 인프라 (`vite.config.ts`)
- [x] 의존성 변경 (`vite-tsconfig-paths` 제거)
- [ ] `/design-md` 스킬
- [ ] 새 카탈로그 항목

## 일반 체크

- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과 (1.13s, nitro adapter OK)
- [x] `pnpm test`: 33 files / 242 tests 모두 통과
  - alias fallback **없이는** 9 files fail — vitest 의 SSR worker 가 vite 8 native option 을 따라가지 않아서 `Failed to resolve import "@/lib/site-config"` 등. fallback 한 줄로 회복.
- [x] `pnpm lint`: preexisting `.claude/worktrees/...` parsing error 외 새 lint 에러 없음
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 수동 검증

**Dev server (vite 8.0.13 ready in 1544ms)** — `@/` import 가 native 로 해석되는지 확인:

| Path | HTTP | size | alias error |
|---|---|---|---|
| `/` | 200 | 419 KB | none |
| `/services/toss` | 200 | 309 KB | none |
| `/services/wanted` | 200 | 389 KB | none |
| `/rss.xml` | 200 | 5.3 KB | none |
| `/sitemap.xml` | 200 | 830 B | none |

**Production SSR (Nitro `node .output/server/index.mjs`)**:

| Path | HTTP | content-type |
|---|---|---|
| `/` | 200 | text/html |
| `/services/toss` | 200 | text/html (`<title>토스 design.md`) |
| `/services/teamsparta` | 200 | text/html |
| `/services/seed-design` | 200 | text/html (`<title>당근 design.md`) |
| `/services/wanted` | 200 | text/html (`<title>원티드 design.md`) |
| `/sitemap.xml` | 200 | application/xml |
| `/rss.xml` | 200 | application/rss+xml |
| `/nonexistent-page` | 404 | text/html (custom 404) |

에러 시그니처 (`Failed to resolve | Cannot find package | Incompatible React | TypeError`) 0 건.

## Follow-up 가능 (선택)

vitest 가 향후 vite 8 의 `resolve.tsconfigPaths` 를 직접 지원하게 되면, `resolve.alias` fallback 줄을 제거할 수 있습니다 (지금은 안전 보강용).