### PR TITLE
fix(home): render service logos from local path regardless of VITE_SITE_URL

### DIFF
--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { SITE_URL, absoluteUrl, siteRelativeIfSelf } from "./site-config"
+import {
+  SITE_URL,
+  absoluteUrl,
+  localLogoPath,
+  siteRelativeIfSelf,
+} from "./site-config"
 
 // In test mode (vitest sets NODE_ENV=test, import.meta.env.PROD = false),
 // VITE_SITE_URL is unset, so SITE_URL is the empty string and absoluteUrl
@@ -53,5 +58,32 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
     expect(siteRelativeIfSelf("https://other-site.example/foo.png")).toBe(
       "https://other-site.example/foo.png",
     )
+  })
+
+  // localLogoPath strips the origin off any absolute URL so the in-site
+  // <img> always points to the local `public/logos/...` asset, regardless
+  // of whether VITE_SITE_URL is set. Frontmatter keeps its absolute form.
+  it("localLogoPath returns undefined for undefined input", () => {
+    expect(localLogoPath(undefined)).toBeUndefined()
+  })
+
+  it("localLogoPath strips the origin from a frontmatter absolute URL", () => {
+    expect(localLogoPath("https://getdesign.kr/logos/toss.png")).toBe(
+      "/logos/toss.png",
+    )
+  })
+
+  it("localLogoPath is origin-agnostic", () => {
+    expect(localLogoPath("https://other-origin.example/logos/x.png")).toBe(
+      "/logos/x.png",
+    )
+  })
+
+  it("localLogoPath returns an already-relative path unchanged", () => {
+    expect(localLogoPath("/logos/toss.png")).toBe("/logos/toss.png")
+  })
+
+  it("localLogoPath returns an unparseable input unchanged", () => {
+    expect(localLogoPath("not a url")).toBe("not a url")
   })
 })

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -86,4 +86,16 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
   it("localLogoPath returns an unparseable input unchanged", () => {
     expect(localLogoPath("not a url")).toBe("not a url")
   })
+
+  it("localLogoPath preserves query strings and hashes", () => {
+    expect(localLogoPath("https://getdesign.kr/logos/toss.png?v=1#top")).toBe(
+      "/logos/toss.png?v=1#top",
+    )
+  })
+
+  it("localLogoPath preserves data URIs", () => {
+    const dataUri =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+    expect(localLogoPath(dataUri)).toBe(dataUri)
+  })
 })

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -50,6 +50,29 @@ export function siteRelativeIfSelf(
   return url
 }
 
+// Extracts the path portion of a logo URL for in-site rendering.
+//
+// design.md frontmatter stores logos as fully-qualified URLs so the file
+// stays meaningful when copied outside the site (PRD User Story 1 —
+// vibe-coding flow). But in-site rendering should always hit the local
+// `public/logos/{slug}.{ext}` asset — design-md skill policy guarantees
+// that file exists, so the URL's path component is always a safe target.
+//
+// Unlike `siteRelativeIfSelf`, this is origin-agnostic and has no
+// VITE_SITE_URL dependency, so dev sessions work without any env setup.
+// Already-relative inputs and unparseable strings are returned unchanged
+// so misconfigured frontmatter still surfaces in the onError fallback
+// rather than being silently mangled.
+export function localLogoPath(url: string | undefined): string | undefined {
+  if (!url) return url
+  if (url.startsWith("/")) return url
+  try {
+    return new URL(url).pathname
+  } catch {
+    return url
+  }
+}
+
 // Canonical GitHub repository URL. Mirrors `repository.url` in package.json
 // and is the single source of truth for header link, contribute dialog,
 // issue template / CONTRIBUTING anchors composed at runtime.

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -60,14 +60,19 @@ export function siteRelativeIfSelf(
 //
 // Unlike `siteRelativeIfSelf`, this is origin-agnostic and has no
 // VITE_SITE_URL dependency, so dev sessions work without any env setup.
-// Already-relative inputs and unparseable strings are returned unchanged
-// so misconfigured frontmatter still surfaces in the onError fallback
-// rather than being silently mangled.
+// Already-relative inputs, unparseable strings, and non-http(s) URLs
+// (data:, blob:, etc.) are returned unchanged — misconfigured frontmatter
+// still surfaces in the onError fallback rather than being silently
+// mangled, and data URIs stay intact rather than being collapsed to a
+// broken relative path. Query strings and fragments survive in case
+// frontmatter ever uses cache-busting params.
 export function localLogoPath(url: string | undefined): string | undefined {
   if (!url) return url
   if (url.startsWith("/")) return url
   try {
-    return new URL(url).pathname
+    const parsed = new URL(url)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return url
+    return parsed.pathname + parsed.search + parsed.hash
   } catch {
     return url
   }

--- a/src/routes/-home/components/service-logo.tsx
+++ b/src/routes/-home/components/service-logo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { siteRelativeIfSelf } from "@/lib/site-config"
+import { localLogoPath } from "@/lib/site-config"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -50,7 +50,7 @@ export function ServiceLogo({ name, logo, size = 24, className }: Props) {
   }, [logo])
 
   if (logo && !failed) {
-    const src = siteRelativeIfSelf(logo)
+    const src = localLogoPath(logo)
     return (
       <img
         src={src}


### PR DESCRIPTION
## 변경 요약

메인 홈 페이지의 브랜드 로고가 dev(`pnpm dev`) 환경에서 표시되지 않던 문제 수정. frontmatter 절대 URL 정책은 그대로 유지하고, 사이트 내 렌더링 경로만 환경변수와 무관하게 로컬 자산을 가리키도록 분리.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 배경

`services/*.md`의 `logo` 필드는 정책상 `https://getdesign.kr/logos/{slug}.{ext}` 형식의 절대 URL이고, design-md skill의 logo-policy 테스트가 이를 강제한다 — design.md 파일을 외부 환경에 복사해도 자체적으로 의미를 가져야 하기 때문(PRD User Story 1, vibe-coding flow).

기존 렌더링은 `siteRelativeIfSelf()`를 통해 "같은 origin이면 root-relative로 변환"하는 방식이었는데, `VITE_SITE_URL`이 frontmatter URL의 origin과 일치할 때만 변환된다. dev 환경에 `.env.local`이 없으면 변환이 일어나지 않아 브라우저가 외부 `getdesign.kr`로 직접 요청 → 실패 → fallback 배지로 떨어졌다.

## 해결 방식

`src/lib/site-config.ts`에 origin-agnostic helper 도입:

```ts
export function localLogoPath(url: string | undefined): string | undefined {
  if (!url) return url
  if (url.startsWith("/")) return url
  try {
    return new URL(url).pathname
  } catch {
    return url
  }
}
```

design-md skill 정책상 logo asset은 항상 `public/logos/{slug}.{ext}`에 존재하므로 origin을 잘라내고 path만 써도 안전하다. `ServiceLogo`가 `siteRelativeIfSelf` 대신 이 helper를 사용하도록 1줄 교체.

`siteRelativeIfSelf()`는 그대로 유지 — 다른 in-site URL 흐름(OG 메타 등)에서 의미가 다를 수 있어 보존.

## 변경 파일

- `src/lib/site-config.ts` — `localLogoPath()` 추가
- `src/routes/-home/components/service-logo.tsx` — helper 교체 (2 lines)
- `src/lib/site-config.test.ts` — `localLogoPath` 테스트 5개 추가

`services/*.md` 6개 파일과 logo-policy 테스트는 **변경 없음**.

## 검증

- `pnpm test src/lib/site-config.test.ts` — 14개 테스트 통과 (기존 9 + 신규 5)
- `pnpm typecheck` 통과
- 수정 파일 ESLint 통과
- Dev 환경 (`.env.local` 없이) end-to-end 확인:
  - 6개 로고 모두 `http://localhost:3100/logos/...`로 로드, `naturalWidth > 0`
  - 외부 `getdesign.kr` 요청 0건
  - Console에 `[ServiceLogo] failed to load` 경고 0건

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (lint는 수정 파일 기준)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수