### PR TITLE
fix(baemin): prevent mobile category grid overflow

### DIFF
--- a/public/preview/baemin/dark.html
+++ b/public/preview/baemin/dark.html
@@ -482,8 +482,9 @@
     gap: 8px;
   }
   .cat-circle {
-    width: 64px;
-    height: 64px;
+    width: 100%;
+    max-width: 64px;
+    aspect-ratio: 1;
     border-radius: 50%;
     background: var(--bm-bg-subtle);
     border: 1px solid var(--bm-border-1);
@@ -1036,7 +1037,7 @@
     .hero-illust { display: none; }
     .section { padding: 56px 0; }
     .section-title { font-size: 30px; }
-    .cat-grid { grid-template-columns: repeat(4, 1fr); }
+    .cat-grid { grid-template-columns: repeat(4, 1fr); gap: 14px 8px; }
     .type-row { grid-template-columns: 1fr; gap: 10px; }
     .type-sample-display1 { font-size: 44px; line-height: 1.05; }
     .type-sample-display3,

--- a/public/preview/baemin/light.html
+++ b/public/preview/baemin/light.html
@@ -471,8 +471,9 @@
     gap: 8px;
   }
   .cat-circle {
-    width: 64px;
-    height: 64px;
+    width: 100%;
+    max-width: 64px;
+    aspect-ratio: 1;
     border-radius: 50%;
     background: var(--bm-bg-subtle);
     border: 1px solid var(--bm-border-1);
@@ -1000,7 +1001,7 @@
     .hero-illust { display: none; }
     .section { padding: 56px 0; }
     .section-title { font-size: 30px; }
-    .cat-grid { grid-template-columns: repeat(4, 1fr); }
+    .cat-grid { grid-template-columns: repeat(4, 1fr); gap: 14px 8px; }
     .type-row { grid-template-columns: 1fr; gap: 10px; }
     .type-sample-display1 { font-size: 44px; line-height: 1.05; }
     .type-sample-display3,


### PR DESCRIPTION
The fixed 64px .cat-circle overflowed its grid track on viewports
below ~388px, causing category tiles to overlap. Make the circle
fluid (width 100% capped at 64px via max-width + aspect-ratio) so it
shrinks to fit narrow tracks while keeping the desktop sizing intact.

https://claude.ai/code/session_01T2Mg3hXjWJtdz9VKZV8HdW