### PR TITLE
fix(docs-crawler): warn on ignored CLI args, document image-light corpora

### DIFF
--- a/.claude/skills/docs-crawler/SKILL.md
+++ b/.claude/skills/docs-crawler/SKILL.md
@@ -101,6 +101,13 @@ Nothing special is needed for that case — just run the crawl with the given
   re-fetches it through a headless browser. Chromium is installed automatically
   on first need (~150 MB, one-time). Static sites never launch a browser.
 - **Images** are kept as their original external URLs — never downloaded.
+- **Few or no images is normal, especially for design-system sites** — modern
+  docs and design-system sites (Docusaurus and similar) render icons and
+  component visuals as inline `<svg>`, CSS, or live DOM rather than `<img>`
+  files; any real `<img>` (e.g. a navbar logo) is usually site chrome the
+  content extractor correctly drops. An image-light or image-free corpus is
+  expected in that case — it is not a crawl failure. Capture visuals separately
+  (screenshots) if the research needs them.
 - **robots.txt** is respected; disallowed paths are skipped.
 - **Page cap** — at most 200 pages per crawl.
 - **Zero pages crawled** — the engine exits non-zero and prints the reason

--- a/.claude/skills/docs-crawler/scripts/crawl.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl.ts
@@ -43,18 +43,32 @@ function parseArgs(argv: Array<string>): CliArgs {
   const args = argv.slice(2)
   let url = ""
   let outDir = ""
+  const extraPositionals: Array<string> = []
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
     if (arg === "--out") {
       outDir = args[i + 1] ?? ""
       i++
-    } else if (!url && !arg.startsWith("--")) {
+    } else if (arg.startsWith("--")) {
+      // Unknown flag — ignored.
+    } else if (!url) {
       url = arg
+    } else {
+      // A second positional argument. The crawler takes exactly one URL; the
+      // sitemap is discovered automatically, so a sitemap URL passed here is a
+      // no-op. Collect it to warn rather than dropping it silently.
+      extraPositionals.push(arg)
     }
   }
   if (!url) {
     console.error("Usage: tsx crawl.ts <docs-site-url> [--out <dir>]")
     process.exit(1)
+  }
+  if (extraPositionals.length > 0) {
+    console.warn(
+      `[crawl] Ignoring extra argument(s): ${extraPositionals.join(", ")} — ` +
+        `the crawler uses only the first URL; the sitemap is found automatically.`,
+    )
   }
   let host = ""
   try {


### PR DESCRIPTION
## 변경 요약

`docs-crawler` 스킬 개선 2건. 이번 세션에서 디자인 시스템 docs 사이트를 크롤하다 발견한 작은 DX 문제 수정 — `SKILL.md` 엣지케이스 노트 + `crawl.ts` CLI 인자 경고.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [ ] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

_위 5개 분류에 정확히 해당하는 항목 없음 — `docs-crawler` 스킬 인프라 수정(SKILL.md 문서 + crawl.ts 스크립트)._

### 상세

**`scripts/crawl.ts`** — `parseArgs`가 두 번째 이후 위치 인자를 조용히 버렸습니다. 크롤러는 URL을 하나만 받고 사이트맵은 자동 발견하므로, 사이트맵 URL을 추가로 넘기면 silent no-op이었습니다. 이제 여분 인자가 있으면 경고합니다:

\`\`\`
[crawl] Ignoring extra argument(s): … — the crawler uses only the first URL; the sitemap is found automatically.
\`\`\`

**`SKILL.md`** — "Notes and edge cases"에 추가: 모던 디자인 시스템·docs 사이트(Docusaurus 등)는 아이콘·컴포넌트 시각 요소를 인라인 SVG·CSS·라이브 DOM으로 렌더하므로, 코퍼스에 이미지가 거의/전혀 없는 게 정상이며 크롤 실패가 아님.

## 카탈로그 PR 체크 (해당 시)

해당 없음 (카탈로그 항목 PR 아님).

## 일반 체크

- [x] \`pnpm typecheck\` · \`pnpm lint\` 통과 — \`pnpm build\`는 변경이 \`.claude/skills/\` 내부라 사이트 빌드와 무관해 미실행
- [ ] **DCO 서명 미완** (\`git commit -s\`) — 머지 전 \`git commit --amend -s\` + force-push로 보완 필요
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수 (DCO 항목 제외)

검증: \`pnpm crawl:docs <invalid-url> <extra-arg>\` → 새 경고 출력 후 invalid-URL로 정상 종료(exit 1) 확인.

## 관련 이슈

없음.