### PR TITLE
fix(docs-crawler): replace inline base64 images with a placeholder

### DIFF
--- a/.claude/skills/docs-crawler/SKILL.md
+++ b/.claude/skills/docs-crawler/SKILL.md
@@ -101,6 +101,9 @@ Nothing special is needed for that case — just run the crawl with the given
   re-fetches it through a headless browser. Chromium is installed automatically
   on first need (~150 MB, one-time). Static sites never launch a browser.
 - **Images** are kept as their original external URLs — never downloaded.
+  Inline `data:` URI images are the exception: the embedded base64 blob is
+  replaced with an `inline-image-omitted` placeholder (the alt text is kept),
+  because raw base64 is unreadable to an LLM and would bloat the corpus.
 - **Few or no images is normal, especially for design-system sites** — modern
   docs and design-system sites (Docusaurus and similar) render icons and
   component visuals as inline `<svg>`, CSS, or live DOM rather than `<img>`

--- a/.claude/skills/docs-crawler/SKILL.md
+++ b/.claude/skills/docs-crawler/SKILL.md
@@ -102,7 +102,7 @@ Nothing special is needed for that case — just run the crawl with the given
   on first need (~150 MB, one-time). Static sites never launch a browser.
 - **Images** are kept as their original external URLs — never downloaded.
   Inline `data:` URI images are the exception: the embedded base64 blob is
-  replaced with an `inline-image-omitted` placeholder (the alt text is kept),
+  replaced with an `inline-image-omitted` placeholder (alt and title text are kept),
   because raw base64 is unreadable to an LLM and would bloat the corpus.
 - **Few or no images is normal, especially for design-system sites** — modern
   docs and design-system sites (Docusaurus and similar) render icons and

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
@@ -23,6 +23,7 @@ const ARTICLE_PAGE = `<!doctype html>
       used by the button are documented on the foundations reference page and
       should never be overridden with inline styles.</p>
       <img src="/assets/button-example.png" alt="A row of primary buttons">
+      <img src="data:image/svg+xml;base64,PHN2Zy8+" alt="Inline status icon">
     </article>
     <footer>Copyright 2026 Example Incorporated. All rights reserved.</footer>
   </body>
@@ -70,6 +71,17 @@ describe("htmlToMarkdown", () => {
     const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
     expect(result.markdown).toContain(
       "https://ds.example.com/assets/button-example.png",
+    )
+  })
+
+  it("replaces inline data-URI images with a placeholder, keeping alt text", () => {
+    const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
+    // A data: URI is an embedded blob, not a link — its base64 payload must
+    // not leak into the corpus, where it is unreadable noise for an LLM.
+    expect(result.markdown).not.toContain("data:image")
+    // The alt text is the meaningful part and is preserved.
+    expect(result.markdown).toContain(
+      "![Inline status icon](inline-image-omitted)",
     )
   })
 

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
@@ -24,6 +24,7 @@ const ARTICLE_PAGE = `<!doctype html>
       should never be overridden with inline styles.</p>
       <img src="/assets/button-example.png" alt="A row of primary buttons">
       <img src="data:image/svg+xml;base64,PHN2Zy8+" alt="Inline status icon">
+      <img src="data:image/svg+xml;base64,PHN2Zy8+" alt="Chart" title="Quarterly chart">
     </article>
     <footer>Copyright 2026 Example Incorporated. All rights reserved.</footer>
   </body>
@@ -82,6 +83,15 @@ describe("htmlToMarkdown", () => {
     // The alt text is the meaningful part and is preserved.
     expect(result.markdown).toContain(
       "![Inline status icon](inline-image-omitted)",
+    )
+  })
+
+  it("preserves the title attribute on inline data-URI images", () => {
+    const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
+    // A data: URI image must render exactly like any other image apart from
+    // the src — including the optional title attribute.
+    expect(result.markdown).toContain(
+      '![Chart](inline-image-omitted "Quarterly chart")',
     )
   })
 

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.ts
@@ -56,14 +56,34 @@ function preprocessDom(doc: Document): void {
   }
 }
 
+// Inline `data:` URI images embed the whole image as a base64 blob. They are
+// replaced with this placeholder: the raw base64 is unreadable to an LLM and
+// can dominate a crawled corpus. The alt text is preserved separately.
+const DATA_URI_PLACEHOLDER = "inline-image-omitted"
+
 function createTurndown(): TurndownService {
-  return new TurndownService({
+  const turndown = new TurndownService({
     headingStyle: "atx",
     codeBlockStyle: "fenced",
     bulletListMarker: "-",
     hr: "---",
     emDelimiter: "_",
   })
+  // Swap inline data: URI image sources for the placeholder, keeping alt text.
+  // Done here rather than in preprocessDom because Readability runs in between
+  // and resolves relative `src` values against the page URL — it would rewrite
+  // a bare placeholder set earlier into a bogus absolute link.
+  turndown.addRule("inlineDataUriImage", {
+    filter: (node) =>
+      node.nodeName === "IMG" &&
+      (node.getAttribute("src") ?? "")
+        .trimStart()
+        .toLowerCase()
+        .startsWith("data:"),
+    replacement: (_content, node) =>
+      `![${node.getAttribute("alt") ?? ""}](${DATA_URI_PLACEHOLDER})`,
+  })
+  return turndown
 }
 
 /**

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.ts
@@ -56,34 +56,18 @@ function preprocessDom(doc: Document): void {
   }
 }
 
-// Inline `data:` URI images embed the whole image as a base64 blob. They are
-// replaced with this placeholder: the raw base64 is unreadable to an LLM and
-// can dominate a crawled corpus. The alt text is preserved separately.
+// Placeholder substituted for inline `data:` URI image sources — see
+// htmlToMarkdown for the rewrite and its rationale.
 const DATA_URI_PLACEHOLDER = "inline-image-omitted"
 
 function createTurndown(): TurndownService {
-  const turndown = new TurndownService({
+  return new TurndownService({
     headingStyle: "atx",
     codeBlockStyle: "fenced",
     bulletListMarker: "-",
     hr: "---",
     emDelimiter: "_",
   })
-  // Swap inline data: URI image sources for the placeholder, keeping alt text.
-  // Done here rather than in preprocessDom because Readability runs in between
-  // and resolves relative `src` values against the page URL — it would rewrite
-  // a bare placeholder set earlier into a bogus absolute link.
-  turndown.addRule("inlineDataUriImage", {
-    filter: (node) =>
-      node.nodeName === "IMG" &&
-      (node.getAttribute("src") ?? "")
-        .trimStart()
-        .toLowerCase()
-        .startsWith("data:"),
-    replacement: (_content, node) =>
-      `![${node.getAttribute("alt") ?? ""}](${DATA_URI_PLACEHOLDER})`,
-  })
-  return turndown
 }
 
 /**
@@ -103,7 +87,15 @@ export function htmlToMarkdown(html: string, pageUrl: string): ExtractResult {
     const fallbackTitle = doc.title.trim() || pageUrl
 
     const article = new Readability(doc).parse()
-    const contentHtml = article?.content ?? ""
+    // Replace inline `data:` URI image sources with a placeholder. A data: URI
+    // embeds the image as a base64 blob that would flood the corpus with bytes
+    // an LLM cannot read. Rewriting Readability's output (not the input DOM)
+    // avoids the placeholder being resolved into a bogus absolute URL, and
+    // keeps it ahead of Turndown so the built-in image rule renders alt/title.
+    const contentHtml = (article?.content ?? "").replace(
+      /src="data:[^"]*"/gi,
+      `src="${DATA_URI_PLACEHOLDER}"`,
+    )
     const markdown = contentHtml
       ? createTurndown().turndown(contentHtml).trim()
       : ""


### PR DESCRIPTION
## 변경 요약

docs-crawler가 인라인 `data:` URI(base64) 이미지를 corpus에 그대로 통과시키던 버그 수정. 이미지가 많은 디자인 시스템 사이트에서 corpus 대부분이 LLM이 못 읽는 base64로 채워졌습니다 — Gmarket GDS 크롤이 1.41 MB, 약 85%가 base64. Turndown 룰로 `data:` URI 이미지를 `inline-image-omitted` 플레이스홀더로 치환(alt 보존, 외부 URL은 그대로). 같은 크롤이 이제 210 KB, base64 0건.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [ ] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

→ **docs-crawler 스킬 버그 수정**: `extract.ts`(코드) + `extract.test.ts`(회귀 테스트) + `docs-crawler/SKILL.md`(문서). 위 5개 분류에 도구/스킬 항목이 없어 미체크.

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 항목 변경이 아닙니다.

## 일반 체크

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test` 통과 — 328/328 (`extract.test.ts`에 회귀 테스트 추가)
- [ ] `pnpm build` — 미실행. 변경이 `.claude/skills/docs-crawler/`(tsx 스크립트)로 vite 앱 빌드 그래프 밖 → 영향 없음, CI build에서 검증
- [x] DCO 서명 (`git commit -s`)

## 관련 이슈

없음. CONTRIBUTING §6은 `design-md` 스킬 변경에 이슈 선행을 요구하나, 본 PR은 `docs-crawler` 스킬의 contained 버그 수정입니다.

## 변경 상세

- **`extract.ts`** — `createTurndown()`에 `inlineDataUriImage` Turndown 룰 추가. `<img>` src가 `data:` URI면 `![alt](inline-image-omitted)`로 출력. `preprocessDom`이 아닌 Turndown 단계에서 처리하는 이유: 그 사이 Readability가 상대 src를 절대 URL로 재작성하므로, 이른 단계의 플레이스홀더는 가짜 절대 URL이 됨.
- **`extract.test.ts`** — `data:` URI → 플레이스홀더 치환 + alt 보존 검증 (RED→GREEN).
- **`SKILL.md`** — Images 항목에 `data:` URI 처리 동작 명시.

검증: Gmarket GDS 재크롤 — corpus 1.41 MB→210 KB, base64 0건, 외부 이미지 URL 419개 전부 HTTP 200 유지.