### PR TITLE
fix(line-design-system): repair mobile layout for buttons and popup

### DIFF
--- a/public/preview/line-design-system/dark.html
+++ b/public/preview/line-design-system/dark.html
@@ -1003,6 +1003,37 @@
     }
 
     .korean { font-feature-settings: "ss01", "kern"; }
+
+    /* ---------- Mobile (≤560px) component overrides ---------- */
+    @media (max-width: 560px) {
+      /* Action Button rows — label on its own line, buttons fill the card.
+         Scoped with :not([style*="column"]) so the Full-Bleed row, which uses
+         inline flex-direction: column, keeps its own layout. */
+      .btn-rows { gap: 12px; }
+      .btn-row:not([style*="column"]) { gap: 10px; }
+      .btn-row:not([style*="column"]) > .btn-rowlabel { flex: 1 0 100%; width: auto; }
+      .btn-row:not([style*="column"]) > .btn {
+        box-sizing: border-box;
+        min-width: 0;
+        flex: 1 1 100%;
+        padding: 0 16px;
+      }
+      .btn-row:not([style*="column"]) > .btn.s { min-width: 0; flex: 1 1 100%; }
+
+      /* Popup modal — fluid width up to the 288px spec */
+      .popup-stage { padding: 20px 10px; min-height: 0; }
+      .popup { width: 100%; max-width: 288px; padding: 20px 16px 16px; }
+
+      /* Hero — tame padding/typography so CTAs + badge fit */
+      .hero { padding: 26px 22px 30px; }
+      .hero-name { font-size: 30px; }
+      .hero-family-badge { margin-left: 0; margin-top: 8px; }
+      .hero-cta { height: 44px; padding: 0 18px; font-size: 14px; }
+
+      /* Section header — let the subtitle drop below the title */
+      .section-head { flex-wrap: wrap; gap: 6px 14px; margin: 40px 0 16px; }
+      .section-sub { margin-left: 0; flex-basis: 100%; }
+    }
   </style>
 </head>
 <body>

--- a/public/preview/line-design-system/light.html
+++ b/public/preview/line-design-system/light.html
@@ -971,6 +971,37 @@
     }
 
     .korean { font-feature-settings: "ss01", "kern"; }
+
+    /* ---------- Mobile (≤560px) component overrides ---------- */
+    @media (max-width: 560px) {
+      /* Action Button rows — label on its own line, buttons fill the card.
+         Scoped with :not([style*="column"]) so the Full-Bleed row, which uses
+         inline flex-direction: column, keeps its own layout. */
+      .btn-rows { gap: 12px; }
+      .btn-row:not([style*="column"]) { gap: 10px; }
+      .btn-row:not([style*="column"]) > .btn-rowlabel { flex: 1 0 100%; width: auto; }
+      .btn-row:not([style*="column"]) > .btn {
+        box-sizing: border-box;
+        min-width: 0;
+        flex: 1 1 100%;
+        padding: 0 16px;
+      }
+      .btn-row:not([style*="column"]) > .btn.s { min-width: 0; flex: 1 1 100%; }
+
+      /* Popup modal — fluid width up to the 288px spec */
+      .popup-stage { padding: 20px 10px; min-height: 0; }
+      .popup { width: 100%; max-width: 288px; padding: 20px 16px 16px; }
+
+      /* Hero — tame padding/typography so CTAs + badge fit */
+      .hero { padding: 26px 22px 30px; }
+      .hero-name { font-size: 30px; }
+      .hero-family-badge { margin-left: 0; margin-top: 8px; }
+      .hero-cta { height: 44px; padding: 0 18px; font-size: 14px; }
+
+      /* Section header — let the subtitle drop below the title */
+      .section-head { flex-wrap: wrap; gap: 6px 14px; margin: 40px 0 16px; }
+      .section-sub { margin-left: 0; flex-basis: 100%; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Action Button rows overflowed on narrow viewports because the 90px row
label plus 120px-min buttons could not fit inside the single-column card.
The popup modal also overflowed its dark stage because of a fixed 288px
width. Add a ≤560px media-query block (placed after the original rules
so it actually wins the cascade) that stacks the row label above the
buttons, lets each button fill the card width with border-box sizing,
and switches the popup to width:100% max-width:288px. Also nudges hero
padding/typography and lets the section subtitle drop below its title.

The Full-Bleed row is excluded via :not([style*="column"]) so its
column-direction layout is preserved.