### PR TITLE
feat(services): serve raw design.md at /services/{slug}/llms.txt per detail page

### DIFF
--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -384,7 +384,8 @@ Start the dev server and confirm the new entry renders correctly. This is the st
 7. `preview_screenshot` once on the default tab.
 8. `preview_eval`: navigate to `?tab=md` and confirm DESIGN.md tab renders the syntax-highlighted markdown.
 9. `preview_screenshot` once on the `?tab=md` view.
-10. **Stop the dev server**: `Bash`: `kill $(lsof -t -i:3000) 2>/dev/null || true`. Killing by port is portable across macOS/Linux and avoids accidentally killing other `pnpm` processes the user might be running. The `|| true` keeps the skill from aborting if the process already exited.
+10. **Agent endpoint check**: `Bash`: `curl -sf -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:3000/services/{slug}/llms.txt` — expect `200 text/plain; charset=utf-8`. This raw-markdown sibling route reads from `services/{slug}.md` directly, so a failure here means either the file wasn't placed correctly or the project's `/services/$slug/llms.txt` route regressed. Surface non-200 output to the user before stopping the server.
+11. **Stop the dev server**: `Bash`: `kill $(lsof -t -i:3000) 2>/dev/null || true`. Killing by port is portable across macOS/Linux and avoids accidentally killing other `pnpm` processes the user might be running. The `|| true` keeps the skill from aborting if the process already exited.
 
 If preview MCP tools are unavailable, fall back to `Bash`: `curl -sf http://localhost:3000/services/{slug} | grep -q '<iframe'` — non-zero exit means the page failed to render.
 
@@ -397,6 +398,9 @@ Print a summary message containing:
   - `public/preview/{slug}/light.html`
   - `public/preview/{slug}/dark.html`
   - `public/og/{slug}.png` (from `pnpm build:og`)
+- Surfaced URLs (paths only — host depends on env):
+  - `/services/{slug}` — HTML detail page (Live Preview + DESIGN.md tabs).
+  - `/services/{slug}/llms.txt` — raw `text/plain` design.md (frontmatter + body) for LLMs / agents to fetch directly. Discoverable via `<link rel="alternate" type="text/plain">` on the HTML page.
 - Final review scores: design `{score}/10`, preview `{score}/10`.
 - Screenshots taken during verification (paths or inline).
 - Leftover TODOs:

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ServicesSlugRouteImport } from './routes/services/$slug'
+import { Route as ServicesSlugLlmsDottxtRouteImport } from './routes/services/$slug/llms[.]txt'
 
 const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
   id: '/sitemap.xml',
@@ -40,20 +41,27 @@ const ServicesSlugRoute = ServicesSlugRouteImport.update({
   path: '/services/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ServicesSlugLlmsDottxtRoute = ServicesSlugLlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
+  getParentRoute: () => ServicesSlugRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/services/$slug': typeof ServicesSlugRoute
+  '/services/$slug': typeof ServicesSlugRouteWithChildren
+  '/services/$slug/llms.txt': typeof ServicesSlugLlmsDottxtRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/services/$slug': typeof ServicesSlugRoute
+  '/services/$slug': typeof ServicesSlugRouteWithChildren
+  '/services/$slug/llms.txt': typeof ServicesSlugLlmsDottxtRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -61,7 +69,8 @@ export interface FileRoutesById {
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/services/$slug': typeof ServicesSlugRoute
+  '/services/$slug': typeof ServicesSlugRouteWithChildren
+  '/services/$slug/llms.txt': typeof ServicesSlugLlmsDottxtRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -71,8 +80,15 @@ export interface FileRouteTypes {
     | '/rss.xml'
     | '/sitemap.xml'
     | '/services/$slug'
+    | '/services/$slug/llms.txt'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/robots.txt' | '/rss.xml' | '/sitemap.xml' | '/services/$slug'
+  to:
+    | '/'
+    | '/robots.txt'
+    | '/rss.xml'
+    | '/sitemap.xml'
+    | '/services/$slug'
+    | '/services/$slug/llms.txt'
   id:
     | '__root__'
     | '/'
@@ -80,6 +96,7 @@ export interface FileRouteTypes {
     | '/rss.xml'
     | '/sitemap.xml'
     | '/services/$slug'
+    | '/services/$slug/llms.txt'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -87,7 +104,7 @@ export interface RootRouteChildren {
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   RssDotxmlRoute: typeof RssDotxmlRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
-  ServicesSlugRoute: typeof ServicesSlugRoute
+  ServicesSlugRoute: typeof ServicesSlugRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
@@ -127,15 +144,34 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ServicesSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/services/$slug/llms.txt': {
+      id: '/services/$slug/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/services/$slug/llms.txt'
+      preLoaderRoute: typeof ServicesSlugLlmsDottxtRouteImport
+      parentRoute: typeof ServicesSlugRoute
+    }
   }
 }
+
+interface ServicesSlugRouteChildren {
+  ServicesSlugLlmsDottxtRoute: typeof ServicesSlugLlmsDottxtRoute
+}
+
+const ServicesSlugRouteChildren: ServicesSlugRouteChildren = {
+  ServicesSlugLlmsDottxtRoute: ServicesSlugLlmsDottxtRoute,
+}
+
+const ServicesSlugRouteWithChildren = ServicesSlugRoute._addFileChildren(
+  ServicesSlugRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
   RssDotxmlRoute: RssDotxmlRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
-  ServicesSlugRoute: ServicesSlugRoute,
+  ServicesSlugRoute: ServicesSlugRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -71,6 +71,14 @@ export const Route = createFileRoute("/services/$slug")({
         { name: "twitter:description", content: description },
         { name: "twitter:image", content: ogImage },
       ],
+      links: [
+        {
+          rel: "alternate",
+          type: "text/plain",
+          title: `${doc.frontmatter.name} design.md (raw)`,
+          href: absoluteUrl(`/services/${doc.frontmatter.slug}/llms.txt`),
+        },
+      ],
     }
   },
   component: ServiceDetailPage,

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -9,6 +9,7 @@ import {
   DetailTabsTab,
 } from "./-components/detail-tabs"
 import { InlineCopyButton } from "./-components/inline-copy-button"
+import { OpenRawButton } from "./-components/open-raw-button"
 import {
   PreviewFrame,
   PreviewUnavailable,
@@ -171,6 +172,7 @@ export function ServiceDetailLayout({
           {primaryAction.suffix}
         </p>
         <CopyButton raw={doc.raw} />
+        <OpenRawButton slug={doc.frontmatter.slug} />
         <div
           className="mt-6 border-t pt-5"
           style={{ borderColor: "var(--rule-strong)" }}

--- a/src/routes/services/$slug/llms[.]txt.ts
+++ b/src/routes/services/$slug/llms[.]txt.ts
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { getServiceBySlug } from "@/lib/content-collection"
+
+const TEXT_HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "public, max-age=0, s-maxage=3600",
+}
+
+// `throw notFound()` is for React-rendered routes — it bubbles to the
+// router's notFoundComponent. For a raw text endpoint that agents fetch
+// directly, return a real HTTP 404 with a plain-text body instead.
+export const Route = createFileRoute("/services/$slug/llms.txt")({
+  server: {
+    handlers: {
+      GET: ({ params }) => {
+        const doc = getServiceBySlug(params.slug)
+        if (!doc) {
+          return new Response(`Not found: ${params.slug}\n`, {
+            status: 404,
+            headers: TEXT_HEADERS,
+          })
+        }
+        return new Response(doc.raw, { headers: TEXT_HEADERS })
+      },
+    },
+  },
+})

--- a/src/routes/services/$slug/llms[.]txt.ts
+++ b/src/routes/services/$slug/llms[.]txt.ts
@@ -4,6 +4,10 @@ import { getServiceBySlug } from "@/lib/content-collection"
 const TEXT_HEADERS = {
   "content-type": "text/plain; charset=utf-8",
   "cache-control": "public, max-age=0, s-maxage=3600",
+  // Public catalog content already accessible as HTML. Open CORS so
+  // client-side agents (browser extensions, custom GPTs, web-based IDEs)
+  // can fetch this URL without proxying.
+  "access-control-allow-origin": "*",
 }
 
 // `throw notFound()` is for React-rendered routes — it bubbles to the

--- a/src/routes/services/-components/open-raw-button.tsx
+++ b/src/routes/services/-components/open-raw-button.tsx
@@ -1,0 +1,45 @@
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface Props {
+  slug: string
+}
+
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </svg>
+  )
+}
+
+export function OpenRawButton({ slug }: Props) {
+  return (
+    <a
+      href={`/services/${slug}/llms.txt`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        buttonVariants({ variant: "outline", size: "lg" }),
+        "mt-3 w-full justify-between tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]",
+      )}
+    >
+      <span className="inline-flex items-center gap-2.5">
+        <ExternalLinkIcon className="size-4" />
+        <span>llms.txt 열기</span>
+      </span>
+      <span aria-hidden className="text-base">↗</span>
+    </a>
+  )
+}


### PR DESCRIPTION
Each catalog entry now has a sibling agent-friendly text endpoint that
returns the raw design.md (frontmatter + body) with text/plain so LLMs
and crawlers can fetch the source directly instead of scraping the HTML.
Inspired by the agent-friendly content negotiation pattern.

The HTML detail page exposes the variant via <link rel="alternate"
type="text/plain"> so tools discover it without out-of-band knowledge.
Unknown slugs return a real HTTP 404 (not the router's notFound JSON),
since this endpoint is consumed by agents, not rendered as a React page.