### PR TITLE
feat(og): 카탈로그 브랜드 로고를 OG 이미지 좌상단에 추가

### DIFF
--- a/scripts/build-og.ts
+++ b/scripts/build-og.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { getCategoryStyle } from "../src/lib/category-style"
 import { buildDoc, sortDocs } from "../src/lib/content-parser"
 import { ogLede } from "../src/lib/og-lede"
+import { loadOgLogo } from "../src/og/load-logo"
 import { renderOgPng } from "../src/og/render"
 import type { ServiceDoc } from "../src/lib/content-types"
 import type {
@@ -23,6 +24,7 @@ interface OgJob {
   colophon?: string
   titleSegments: Array<TitleSegment>
   lede: string
+  logoDataUri?: string
 }
 
 function buildDefaultJob(): OgJob {
@@ -59,6 +61,7 @@ function buildServiceJob(doc: ServiceDoc): OgJob {
       : undefined,
     titleSegments: [{ text: doc.frontmatter.name }],
     lede: ogLede(doc.tagline),
+    logoDataUri: loadOgLogo(doc.frontmatter.logo),
   }
 }
 
@@ -97,6 +100,7 @@ async function main() {
       colophon: job.colophon,
       titleSegments: job.titleSegments,
       lede: job.lede,
+      logoDataUri: job.logoDataUri,
     })
     fs.writeFileSync(path.join(OUTPUT_DIR, job.outputName), png)
     const ms = Date.now() - start

--- a/src/og/load-logo.ts
+++ b/src/og/load-logo.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const PUBLIC_DIR = path.resolve(process.cwd(), "public")
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+}
+
+// Mirrors `localLogoPath()` in src/lib/site-config.ts. Duplicated here because
+// site-config.ts touches `import.meta.env` at top level, which crashes when
+// the build script is run directly under tsx/Node (no Vite env injection).
+// Keeping the logic identical so frontmatter URL handling stays consistent
+// across web rendering and OG generation.
+function frontmatterLogoToPath(url: string | undefined): string | undefined {
+  if (!url) return url
+  if (url.startsWith("/")) return url
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return url
+    return parsed.pathname + parsed.search + parsed.hash
+  } catch {
+    return url
+  }
+}
+
+// Convert a frontmatter `logo:` URL into a base64 data URI ready to drop into
+// a Satori `<img src>`. Returns undefined when the asset is missing or the
+// extension is unsupported — callers render the OG without a logo in that
+// case (text-only fallback). All errors are swallowed so one bad asset never
+// kills the whole `build:og` run.
+export function loadOgLogo(logoUrl: string | undefined): string | undefined {
+  if (!logoUrl) return undefined
+
+  const relPath = frontmatterLogoToPath(logoUrl)
+  if (!relPath || !relPath.startsWith("/")) return undefined
+
+  const absPath = path.join(PUBLIC_DIR, relPath.replace(/^\//, ""))
+  if (!fs.existsSync(absPath)) {
+    console.warn(`[og] logo missing: ${path.relative(process.cwd(), absPath)}`)
+    return undefined
+  }
+
+  const ext = path.extname(absPath).toLowerCase()
+  const mime = MIME_BY_EXT[ext]
+  if (!mime) {
+    console.warn(`[og] logo unsupported extension: ${ext} (${absPath})`)
+    return undefined
+  }
+
+  try {
+    const buffer = fs.readFileSync(absPath)
+    return `data:${mime};base64,${buffer.toString("base64")}`
+  } catch (err) {
+    console.warn(`[og] logo read failed: ${absPath}`, err)
+    return undefined
+  }
+}

--- a/src/og/template.tsx
+++ b/src/og/template.tsx
@@ -28,13 +28,18 @@ export interface OgTemplateProps {
   titleSegments: Array<TitleSegment>
   /** Subtitle / lede paragraph below the title. */
   lede: string
+  /** Base64 data URI for the brand logo. Rendered top-left when present. */
+  logoDataUri?: string
 }
+
+const LOGO_SIZE = 32
 
 export function OgTemplate({
   breadcrumb,
   colophon,
   titleSegments,
   lede,
+  logoDataUri,
 }: OgTemplateProps) {
   const renderedTitle = titleSegments.map((s) => s.text).join("")
   const titleStyle = pickTitleStyle(renderedTitle)
@@ -63,10 +68,23 @@ export function OgTemplate({
           style={{
             display: "flex",
             flexDirection: "row",
-            alignItems: "baseline",
+            alignItems: "center",
             paddingBottom: 16,
           }}
         >
+          {logoDataUri && (
+            <img
+              src={logoDataUri}
+              width={LOGO_SIZE}
+              height={LOGO_SIZE}
+              style={{
+                width: LOGO_SIZE,
+                height: LOGO_SIZE,
+                objectFit: "contain",
+                marginRight: 20,
+              }}
+            />
+          )}
           {breadcrumb.map((seg, i) => (
             <span
               key={i}


### PR DESCRIPTION
## 변경 요약

서비스 OG 이미지가 텍스트만 그려서 SNS 공유 시 카탈로그 항목 간 시각적 변별력이 낮은 문제를 해결합니다. 모든 카탈로그 항목이 이미 `public/logos/{slug}.{png,svg,…}` 자산을 보유하고 있고 [design-md 스킬 정책 테스트](https://github.com/CaesiumY/ko-design-md/blob/main/src/lib/design-md-skill-logo-policy.test.ts)가 이를 강제 중이라, OG 빌더가 안전하게 자산을 참조해 좌상단에 32×32 마크를 합성하도록 했습니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 무엇이 바뀌나

| 파일 | 변경 |
|------|------|
| `src/og/load-logo.ts` *(신규)* | frontmatter `logo:` URL → base64 data URI 로더 (PNG/SVG/WebP/AVIF). 자산 누락·확장자 미지원·읽기 실패는 모두 콘솔 경고 후 `undefined` 반환 → 텍스트-only 폴백 |
| `src/og/template.tsx` | `logoDataUri` prop 추가, breadcrumb 행에 32×32 `<img>` 좌측 배치 (`object-fit: contain`, `marginRight: 20`). 값 없으면 기존 레이아웃 그대로 |
| `scripts/build-og.ts` | 빌드 타임에 `loadOgLogo()` 호출해 OgJob에 주입. `default.png`(메인 OG)는 변경 없음 — 브랜드 자체가 텍스트 로고타이프 |

### 디자인 결정

- **배치**: 좌상단 작은 마크 (32px) — breadcrumb 위계를 깨지 않으면서 브랜드 인식 추가
- **자산 로딩**: 빌드 타임 `fs.readFileSync` + base64 임베딩. 외부 fetch 없음 → CI/오프라인 안전
- **폴백**: 로고 누락 시 빌드는 계속, 경고 1줄 출력 + 텍스트-only로 렌더 (`default.png`가 이 경로의 산 증거)
- **SVG 처리**: utf8 인라인 대신 base64 (escape 이슈 회피)

### 계획에서 빗나간 한 가지

원래 [`src/lib/site-config.ts`의 `localLogoPath()`](https://github.com/CaesiumY/ko-design-md/blob/main/src/lib/site-config.ts#L69)를 재사용하려 했지만, `site-config.ts`가 top-level에서 `import.meta.env.VITE_SITE_URL`을 접근해 **tsx Node 환경(`build:og`)에서 모듈 로드 자체가 실패**합니다. 사이드이펙트를 피하려고 동일 11줄 로직을 `load-logo.ts`에 인라인하고 출처를 주석으로 명시했습니다. `site-config.ts`는 손대지 않았습니다.

## 검증 결과

| 항목 | 결과 |
|------|------|
| `pnpm build:og` (12장) | ✅ 모두 성공, 경고 0건 (default.png + 11개 서비스) |
| PNG 로고 시각 확인 (11st, 배민, 소카, …) | ✅ 좌상단 정사각 마크 깔끔 |
| SVG 로고 시각 확인 (krds, baemin 심볼) | ✅ 컬러·비율 유지 |
| `default.png` 변경 없음 | ✅ 텍스트만 (의도대로) |
| `pnpm typecheck` | ✅ 0 errors |
| `pnpm lint` | ✅ 통과 |
| `pnpm build` | ✅ 787ms |
| `pnpm vitest run design-md-skill-logo-policy` | ✅ 2/2 통과 |

> 메모: vitest 실행 시 끝에 `ReferenceError: module is not defined` + `close timed out`이 뜨지만 PASS 후 cleanup 단계의 vitest 4.1.6 + vite 8.0.13 알려진 이슈입니다. 실제 테스트 결과(2 passed)와 무관합니다.

`public/og/*.png`는 `.gitignore`되어 있어 PR diff에 포함되지 않습니다. 머지 후 빌드 파이프라인이 새 PNG를 생성합니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- N/A -->