### PR TITLE
fix(og): path traversal 가드 + 로고 정책 OG 컨텍스트 보강

### DIFF
--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -57,7 +57,7 @@ Then ask three follow-up text inputs:
 - **스크린샷 경로** (optional) — comma-separated absolute paths to screenshot files. The user can type "없음" to skip.
 - **로고 자산 경로** (optional) — an existing local file path for a brand logo. Accept only `.svg`, `.png`, `.webp`, or `.avif`. The user can type "없음" to skip.
 
-  **CRITICAL — pick a small square symbol mark, NOT a wordmark.** The catalog grid card renders a small square logo slot (favicon/app-icon shape, ~48–96 px on screen). Choose accordingly:
+  **CRITICAL — pick a small square symbol mark, NOT a wordmark.** Two square slots in the site consume this asset: the catalog grid card (~48–96 px on screen) AND the OG image's top-left brand mark (32×32 px in the 1200×630 social card, see `src/og/template.tsx`). The OG renderer (Satori) has limited `object-fit` support, so a non-square asset is stretched into the 32×32 box rather than letterboxed — the catalog card has the same constraint at its own scale. Choose accordingly:
   - ✅ Pick the brand's standalone **symbol / mark / favicon shape** with a transparent background — e.g. SOCAR's angular blue mark, Toss's curved oval lens, Gmarket's circular G, Baemin's symbol. Match the style of existing `public/logos/{toss,socar,baemin,…}.png` (square, no text, no baked-in frame).
   - ❌ Avoid the **horizontal wordmark / lockup** (the brand name written out, e.g. "Gmarket", "toss", "쏘카") — wordmarks render too small in the grid card or break its aspect.
   - ❌ Avoid **iOS-squircle / framed app icons** with a rounded gradient background baked in — that frame conflicts with the catalog card's own background. Prefer the unframed symbol form.

--- a/src/og/load-logo.test.ts
+++ b/src/og/load-logo.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { loadOgLogo } from "./load-logo"
+
+describe("loadOgLogo", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it("returns a data URI for an existing in-catalog logo", () => {
+    // krds.svg is guaranteed to exist by the design-md logo policy test.
+    const dataUri = loadOgLogo("https://getdesign.kr/logos/krds.svg")
+    expect(dataUri).toMatch(/^data:image\/svg\+xml;base64,/)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns undefined for empty / missing logo URL", () => {
+    expect(loadOgLogo(undefined)).toBeUndefined()
+    expect(loadOgLogo("")).toBeUndefined()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("rejects site-relative path traversal that escapes public/", () => {
+    // Absolute URLs like "https://x/logos/../../etc/passwd" are normalized
+    // away by the WHATWG URL parser (`new URL()` flattens `..`), so they
+    // can't escape on their own. The real risk is a site-relative input
+    // like "/../etc/passwd" — `frontmatterLogoToPath` short-circuits on
+    // `startsWith("/")` and returns the string verbatim, bypassing URL
+    // normalization. Without this guard, `path.join(PUBLIC_DIR, ...)`
+    // would resolve outside `public/` and read repo secrets in CI.
+    const result = loadOgLogo("/../etc/passwd")
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("escapes public/"),
+    )
+  })
+
+  it("normalizes absolute URL traversal harmlessly via URL parser", () => {
+    // Documents the URL-parser behaviour the guard above relies on: even
+    // a hostile-looking absolute URL is collapsed to a safe pathname
+    // before the guard runs. Result is undefined because the normalized
+    // path ("/etc/passwd") doesn't exist under `public/`, not because
+    // the traversal guard fired.
+    const result = loadOgLogo(
+      "https://getdesign.kr/logos/../../etc/passwd",
+    )
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("logo missing"),
+    )
+  })
+
+  it("returns undefined for a logo file that does not exist", () => {
+    const result = loadOgLogo(
+      "https://getdesign.kr/logos/__no_such_logo__.png",
+    )
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("logo missing"),
+    )
+  })
+
+  it("returns undefined for an unsupported extension", () => {
+    const result = loadOgLogo("https://getdesign.kr/logos/krds.gif")
+    expect(result).toBeUndefined()
+    // Extension check runs after existence check, so the warning here is
+    // about the missing file (gif doesn't exist in the catalog).
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it("ignores non-http(s) URLs", () => {
+    expect(loadOgLogo("data:image/png;base64,abc")).toBeUndefined()
+    expect(loadOgLogo("ftp://example.com/logo.png")).toBeUndefined()
+  })
+})

--- a/src/og/load-logo.test.ts
+++ b/src/og/load-logo.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { loadOgLogo } from "./load-logo"
 
@@ -66,15 +67,37 @@ describe("loadOgLogo", () => {
   })
 
   it("returns undefined for an unsupported extension", () => {
-    const result = loadOgLogo("https://getdesign.kr/logos/krds.gif")
-    expect(result).toBeUndefined()
-    // Extension check runs after existence check, so the warning here is
-    // about the missing file (gif doesn't exist in the catalog).
-    expect(warnSpy).toHaveBeenCalled()
+    // Mock the file as present so we actually reach the extension check
+    // instead of short-circuiting at the existence guard — otherwise the
+    // test would silently pass for the wrong reason (a false sense of
+    // security where the MIME_BY_EXT branch is never exercised).
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true)
+    try {
+      const result = loadOgLogo("https://getdesign.kr/logos/krds.gif")
+      expect(result).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("logo unsupported extension"),
+      )
+    } finally {
+      existsSpy.mockRestore()
+    }
   })
 
   it("ignores non-http(s) URLs", () => {
     expect(loadOgLogo("data:image/png;base64,abc")).toBeUndefined()
     expect(loadOgLogo("ftp://example.com/logo.png")).toBeUndefined()
+  })
+
+  it("rejects relative paths without a leading slash immediately", () => {
+    // Negative invariant: inputs like `../etc/passwd` or
+    // `logos/../../etc/passwd` are NOT absolute URLs (no `://`) and don't
+    // start with `/`, so `frontmatterLogoToPath` returns them verbatim
+    // and `loadOgLogo` rejects them at the `!relPath.startsWith("/")`
+    // gate BEFORE any path.join happens — no warning, no fs touch.
+    // Codifying this protects the traversal guard's "first line of
+    // defense" from a refactor that drops the leading-slash check.
+    expect(loadOgLogo("../etc/passwd")).toBeUndefined()
+    expect(loadOgLogo("logos/../../etc/passwd")).toBeUndefined()
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/og/load-logo.ts
+++ b/src/og/load-logo.ts
@@ -39,6 +39,25 @@ export function loadOgLogo(logoUrl: string | undefined): string | undefined {
   if (!relPath || !relPath.startsWith("/")) return undefined
 
   const absPath = path.join(PUBLIC_DIR, relPath.replace(/^\//, ""))
+
+  // Path traversal guard. Absolute URLs are safe because the WHATWG URL
+  // parser inside `frontmatterLogoToPath` flattens `..` segments before we
+  // see them — `https://x/logos/../../etc/passwd` becomes `/etc/passwd`,
+  // which fails the existence check harmlessly. The real risk is the
+  // site-relative branch: when `logo:` starts with `/`, that helper short-
+  // circuits and returns the string verbatim, so `/../etc/passwd` reaches
+  // `path.join(PUBLIC_DIR, ...)` and resolves OUTSIDE `public/`. The build
+  // runs in CI with read access to `.env` and deploy keys, so an arbitrary
+  // file read here is a real supply-chain surface even though only base64
+  // ends up in the PNG. Reject anything that doesn't land inside PUBLIC_DIR.
+  if (
+    !absPath.startsWith(PUBLIC_DIR + path.sep) &&
+    absPath !== PUBLIC_DIR
+  ) {
+    console.warn(`[og] logo path escapes public/: ${relPath}`)
+    return undefined
+  }
+
   if (!fs.existsSync(absPath)) {
     console.warn(`[og] logo missing: ${path.relative(process.cwd(), absPath)}`)
     return undefined


### PR DESCRIPTION
## 변경 요약

#71 머지 후 [`gemini-code-assist` 봇 리뷰](https://github.com/CaesiumY/ko-design-md/pull/71#pullrequestreview-4377291292)의 두 지적을 follow-up으로 처리합니다.

1. **[HIGH] Path traversal 취약점** — `src/og/load-logo.ts`의 frontmatter 처리에 가드 추가
2. **[MEDIUM] Satori `object-fit` 제한 + 정사각 권장 가이드 누락** — 기존 design-md 스킬은 catalog grid card 슬롯 정사각 권장만 명시. OG 32×32 슬롯 컨텍스트 + Satori 제한 한 문장 보강

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [x] `/design-md` 스킬

## 무엇이 바뀌나

### 1. Path traversal 가드 (`src/og/load-logo.ts`)

```ts
if (
  !absPath.startsWith(PUBLIC_DIR + path.sep) &&
  absPath !== PUBLIC_DIR
) {
  console.warn(`[og] logo path escapes public/: ${relPath}`)
  return undefined
}
```

리뷰 도중 발견한 미묘함: **절대 URL은 `new URL()` 파서가 `..` 세그먼트를 자동 정규화하므로 traversal이 자체적으로 불가능**합니다 (`https://x/logos/../../etc/passwd` → `/etc/passwd`로 평탄화). 진짜 위험은 **site-relative 입력** — `frontmatterLogoToPath`가 `if (url.startsWith(\"/\")) return url`로 short-circuit해서 URL 파서의 정규화 보호를 우회합니다. `/../etc/passwd` 같은 입력에서 `path.join(PUBLIC_DIR, ...)`이 `public/` 밖으로 빠져나가 CI의 `.env` / 배포키를 base64로 읽을 수 있는 supply-chain 표면이 됩니다.

가드는 양쪽 시나리오를 모두 막고, 주석에 두 경로의 차이를 명시했습니다.

### 2. 단위 테스트 (`src/og/load-logo.test.ts`, 신규)

회귀 방지 + traversal 가드 동작의 객관적 증거:

| 케이스 | 기대 동작 |
|--------|----------|
| 정상 in-catalog 로고 (`krds.svg`) | data URI 반환, 경고 없음 |
| `undefined` / 빈 문자열 | undefined, 경고 없음 |
| **site-relative traversal** (`/../etc/passwd`) | **undefined + "escapes public/" 경고** |
| 절대 URL traversal (URL 파서 정규화 시나리오 문서화) | undefined + "logo missing" 경고 |
| 존재하지 않는 파일 | undefined + "logo missing" 경고 |
| `data:` / `ftp:` 같은 비-http URL | undefined |

vitest 9/9 통과 (load-logo 6 + 기존 정책 테스트 2 + 1).

### 3. design-md 스킬 가이드 보강 (`.claude/skills/design-md/SKILL.md`)

Stage 2 "CRITICAL — pick a small square symbol mark" 단락에 한 문장 추가:

> Two square slots in the site consume this asset: the catalog grid card (~48–96 px on screen) AND the OG image's top-left brand mark (32×32 px in the 1200×630 social card, see `src/og/template.tsx`). The OG renderer (Satori) has limited `object-fit` support, so a non-square asset is stretched into the 32×32 box rather than letterboxed — the catalog card has the same constraint at its own scale.

기존 "정사각 강제" 정책은 그대로 유지하면서 OG 컨텍스트와 Satori의 기술적 제약을 contributor에게 가시화합니다. 정책 테스트(`design-md-skill-logo-policy.test.ts`)의 anchor 문자열은 모두 유지.

## 검증 결과

| 항목 | 결과 |
|------|------|
| `pnpm vitest run src/og/load-logo.test.ts src/lib/design-md-skill-logo-policy.test.ts` | ✅ 9/9 |
| `pnpm typecheck` | ✅ 0 errors |
| `pnpm lint` | ✅ 통과 |
| `pnpm build` | ✅ ✓ built in 708ms |
| `pnpm build:og` (12장 회귀) | ✅ 정상 (이전 시각 결과 변경 없음) |

> 메모: vitest 실행 시 끝에 `ReferenceError: module is not defined` + `close timed out`은 vitest 4.1.6 + vite 8.0.13 cleanup 단계 알려진 이슈로 PASS 후 발생. 실제 결과(9 passed)와 무관.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 PR

- #71 (gemini 리뷰의 출처 — 머지 직후 follow-up)