### PR TITLE
feat(detail): 서비스 상세 페이지 타이틀에 브랜드 로고 추가

### DIFF
--- a/src/routes/services/-components/service-meta.tsx
+++ b/src/routes/services/-components/service-meta.tsx
@@ -1,5 +1,6 @@
 import type { ServiceFrontmatter } from "@/lib/content-types"
 import { getCategoryStyle } from "@/lib/category-style"
+import { ServiceLogo } from "@/routes/-home/components/service-logo"
 
 interface Props {
   frontmatter: ServiceFrontmatter
@@ -26,13 +27,24 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
         )}
       </div>
 
-      {/* Massive title */}
-      <h1
-        className="text-display mt-6 text-5xl font-black leading-[1.0] tracking-tighter sm:text-6xl lg:text-7xl"
-        style={{ letterSpacing: "-0.06em" }}
-      >
-        {frontmatter.name}
-      </h1>
+      {/* Logo + massive title — flex-wrap keeps a narrow viewport safe by
+          letting the H1 drop to its own line under the 80px mark instead of
+          overflowing. The mark uses the shared ServiceLogo, which already
+          handles onError → initial badge fallback (HMR-safe via the
+          useEffect-reset failed state). */}
+      <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-4">
+        <ServiceLogo
+          name={frontmatter.name}
+          logo={frontmatter.logo}
+          size={80}
+        />
+        <h1
+          className="text-display text-5xl font-black leading-[1.0] tracking-tighter sm:text-6xl lg:text-7xl"
+          style={{ letterSpacing: "-0.06em" }}
+        >
+          {frontmatter.name}
+        </h1>
+      </div>
 
       {frontmatter.design_system_name && (
         <p className="text-meta-caps text-muted-foreground mt-4">

--- a/src/routes/services/-components/service-meta.tsx
+++ b/src/routes/services/-components/service-meta.tsx
@@ -37,6 +37,13 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
           name={frontmatter.name}
           logo={frontmatter.logo}
           size={80}
+          // ServiceLogo의 FallbackBadge가 text-[11px]을 baseline으로
+          // 가지는데, 80px 박스에선 너무 작아 폴백 발생 시 이니셜이
+          // 박스 안에서 떠 보인다. cn() (tailwind-merge)이 충돌하는
+          // font-size를 자동 머지해주므로 text-3xl(30px ≈ 박스의 37%)
+          // 로 끌어올려 카드 그리드의 비율감(11px/24 ≈ 45%)에 근접시킨다.
+          // img 분기에는 의미 없지만 부작용도 없다.
+          className="text-3xl"
         />
         <h1
           className="text-display text-5xl font-black leading-[1.0] tracking-tighter sm:text-6xl lg:text-7xl"


### PR DESCRIPTION
## Summary

- 카탈로그 그리드 카드와 OG 이미지(이전 PR #71/#72)엔 이미 브랜드 로고가 들어가지만, 정작 사용자가 카드를 클릭해 들어오는 서비스 상세 페이지(`/services/{slug}`) 헤더엔 마크가 비어 있어 **그리드 → 페이지 진입 시 브랜드 단서가 끊기는 시각 일관성 공백**이 있었음. H1 왼쪽에 80px `ServiceLogo`를 두어 같은 마크가 이어지도록 함.
- **새 컴포넌트 없음** — `src/routes/-home/components/service-logo.tsx`의 `ServiceLogo`를 그대로 재사용. `onError` → 이니셜 배지 폴백과 `useEffect` 기반 HMR-safe failed state 리셋이 이미 내장돼 있음.
- **모바일 안전판** — 부모 div를 `flex flex-wrap items-center`로 두어, 좁은 viewport에서 80px 마크 아래로 H1이 자연스럽게 줄바꿈되어 overflow 없음. 기존 H1 타이포그래피(`text-7xl font-black -0.06em letter-spacing`)는 변동 없음.

변경 파일: `src/routes/services/-components/service-meta.tsx` 단 1개, +19/-7.

## Test plan

- [ ] Vercel preview deploy에서 다음 URL 시각 확인:
  - `/services/krds` — SVG 로고
  - `/services/baemin` — PNG 로고  
  - `/services/gmarket` — 가로형 logotype (object-contain으로 80×80 박스에 비율 유지되는지)
- [ ] 모바일 viewport(360px)에서 H1이 80px 로고 아래로 wrap, overflow 없음
- [ ] 다크 모드에서도 로고 시인성 유지
- [ ] 로고 누락 시뮬레이션 — `frontmatter.logo` 임시 변경 후 이니셜 배지 폴백 확인 (수동, 선택)
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm test` — 17 파일 / 148 테스트 PASS (vitest 4.1.6 + vite 8 cleanup hang은 알려진 이슈)
- [x] DCO signoff 포함 커밋