### PR TITLE
feat(og): 로고를 좌상단 마크에서 H1 옆 큰 로고로 이동 — 상세 페이지와 일관

### DIFF
--- a/src/og/template.tsx
+++ b/src/og/template.tsx
@@ -32,7 +32,13 @@ export interface OgTemplateProps {
   logoDataUri?: string
 }
 
-const LOGO_SIZE = 32
+// Logo sits next to the title (paired-with, not competing-with). 0.85×
+// the title font keeps the mark slightly shorter than the cap height so
+// it reads as a brand stamp rather than a glyph of equal weight. This
+// scales automatically with `pickTitleStyle` — long Korean names that
+// step the title down to 108px also shrink the logo to ~92px, preserving
+// the same visual relationship across all catalog cards.
+const LOGO_TO_TITLE_RATIO = 0.85
 
 export function OgTemplate({
   breadcrumb,
@@ -43,6 +49,7 @@ export function OgTemplate({
 }: OgTemplateProps) {
   const renderedTitle = titleSegments.map((s) => s.text).join("")
   const titleStyle = pickTitleStyle(renderedTitle)
+  const logoSize = Math.round(titleStyle.fontSize * LOGO_TO_TITLE_RATIO)
 
   return (
     <div
@@ -72,19 +79,6 @@ export function OgTemplate({
             paddingBottom: 16,
           }}
         >
-          {logoDataUri && (
-            <img
-              src={logoDataUri}
-              width={LOGO_SIZE}
-              height={LOGO_SIZE}
-              style={{
-                width: LOGO_SIZE,
-                height: LOGO_SIZE,
-                objectFit: "contain",
-                marginRight: 20,
-              }}
-            />
-          )}
           {breadcrumb.map((seg, i) => (
             <span
               key={i}
@@ -129,25 +123,52 @@ export function OgTemplate({
           paddingBottom: PADDING_BOTTOM,
         }}
       >
+        {/* Logo + title — outer row keeps logo and title-box vertically
+            centered, while the inner title-box preserves alignItems:
+            "baseline" so mixed Hangul/Latin segments stay aligned on the
+            glyph baseline. The logo is intentionally ~0.85× the title
+            font (see LOGO_TO_TITLE_RATIO) so the brand mark pairs with
+            the title instead of competing with it. */}
         <div
           style={{
             display: "flex",
             flexDirection: "row",
-            alignItems: "baseline",
-            ...titleStyle,
+            alignItems: "center",
           }}
         >
-          {titleSegments.map((seg, i) => (
-            <span
-              key={i}
+          {logoDataUri && (
+            <img
+              src={logoDataUri}
+              width={logoSize}
+              height={logoSize}
               style={{
-                color: seg.brand ? COLORS.brand : titleStyle.color,
-                wordBreak: "keep-all",
+                width: logoSize,
+                height: logoSize,
+                objectFit: "contain",
+                marginRight: 40,
               }}
-            >
-              {seg.text}
-            </span>
-          ))}
+            />
+          )}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "baseline",
+              ...titleStyle,
+            }}
+          >
+            {titleSegments.map((seg, i) => (
+              <span
+                key={i}
+                style={{
+                  color: seg.brand ? COLORS.brand : titleStyle.color,
+                  wordBreak: "keep-all",
+                }}
+              >
+                {seg.text}
+              </span>
+            ))}
+          </div>
         </div>
 
         <span

--- a/src/og/template.tsx
+++ b/src/og/template.tsx
@@ -48,7 +48,11 @@ export function OgTemplate({
   logoDataUri,
 }: OgTemplateProps) {
   const renderedTitle = titleSegments.map((s) => s.text).join("")
-  const titleStyle = pickTitleStyle(renderedTitle)
+  // pickTitleStyle needs to know the logo is present so it can shrink the
+  // title's usable-width budget — the logo eats ~159px (119px mark + 40px
+  // gap), so a title that JUST fit at 140px without a logo could overflow
+  // here. Passing hasLogo steps such cases down to the 108px compact style.
+  const titleStyle = pickTitleStyle(renderedTitle, !!logoDataUri)
   const logoSize = Math.round(titleStyle.fontSize * LOGO_TO_TITLE_RATIO)
 
   return (
@@ -146,6 +150,11 @@ export function OgTemplate({
                 height: logoSize,
                 objectFit: "contain",
                 marginRight: 40,
+                // Satori uses Yoga, where flexShrink defaults to 0 — but
+                // pinning it explicitly documents the intent and survives
+                // any future Satori/Yoga default change. Without this, a
+                // very long title could in theory squeeze the mark.
+                flexShrink: 0,
               }}
             />
           )}

--- a/src/og/tokens.ts
+++ b/src/og/tokens.ts
@@ -56,6 +56,14 @@ export const TYPE = {
 // larger 140px size while stepping down before titles like
 // "야놀자모텔체크인" (8 glyphs ≈ 13 Latin-equiv) overflow.
 const TITLE_WIDTH_BUDGET = 14
+// When a brand logo sits next to the title (see template.tsx), the title's
+// usable width shrinks by ~159px (logo ~119px + 40px gap) out of the 1040px
+// content column — about 15%. Drop the budget by the same proportion
+// (14 × 0.85 ≈ 12) so titles that JUST fit without a logo get stepped
+// down to the 108px compact style when a logo is present, preventing
+// silent overflow / wrap. The 108px case shrinks logo to ~92px so the
+// math works out to roughly the same ratio there too.
+const TITLE_WIDTH_BUDGET_WITH_LOGO = 12
 const CJK_WIDTH_FACTOR = 1.6
 
 function titleWidthScore(rendered: string): number {
@@ -67,9 +75,14 @@ function titleWidthScore(rendered: string): number {
 }
 
 // Pick a title size based on weighted character width so long Korean service
-// names don't overflow the 1040px content width at 140px.
-export function pickTitleStyle(rendered: string) {
-  return titleWidthScore(rendered) > TITLE_WIDTH_BUDGET
+// names don't overflow the 1040px content width at 140px. Pass
+// `hasLogo: true` when the brand mark is rendered on the same row as the
+// title so the budget accounts for the reduced usable width.
+export function pickTitleStyle(rendered: string, hasLogo = false) {
+  const budget = hasLogo
+    ? TITLE_WIDTH_BUDGET_WITH_LOGO
+    : TITLE_WIDTH_BUDGET
+  return titleWidthScore(rendered) > budget
     ? TYPE.titleCompact
     : TYPE.title
 }


### PR DESCRIPTION
## Summary

직전 PR #74에서 서비스 상세 페이지 헤더의 로고를 **H1 왼쪽 옆 80px**로 배치하면서 OG 이미지의 **좌상단 32px 마크**와 시각 문법이 어긋나는 상태가 됐음. 사용자가 카드 → 페이지로 진입했을 때 보던 "H1 옆 브랜드 로고" 패턴이 SNS 공유 OG에선 다시 좌상단 작은 마크로 바뀌는 셈이라, **인지 단서가 끊김**. OG도 같은 패턴으로 통일.

### 변경

- **좌상단 행**: `<img>` 분기 제거 — breadcrumb + colophon만 남아 헤더가 가벼워지고 시선이 자연스럽게 H1으로 떨어짐.
- **타이틀 행**: 외부 wrapper(`alignItems: center`) + 내부 title 박스(`alignItems: baseline` 유지)로 분리. 이렇게 하면 **한글/영문 mixed 타이틀의 baseline 정렬을 깨지 않으면서** 로고는 수직 중앙으로 맞춰짐.
- **로고 크기**: `LOGO_TO_TITLE_RATIO = 0.85` 비례 계산
  - `title` (140px) → 로고 **119px**
  - `titleCompact` (108px, 긴 한국어 이름 자동 강등) → 로고 **92px**
  - 약간 짧은 비례라 "타이틀과 paired-with, 경쟁 아님" 느낌이 잡힘
- `default.png`는 `logoDataUri` 미전달이라 분기 안 타고 **시각 변화 없음**.

### 시각 검증 (로컬 build:og 결과)

12개 카탈로그 PNG 재생성 완료, 대표 케이스 직접 확인:
- ✅ `krds.png` — H1 옆 KRDS 태극 로고, 비례 균형 좋음
- ✅ `gmarket.png` — 가로형 logotype이 정사각형 슬롯에 `object-contain`으로 깔끔히 들어감
- ✅ `default.png` — 텍스트 로고타이프 그대로, 변경 없음

## Test plan

- [ ] Vercel preview deploy의 OG URL 시각 확인 (`/og/{slug}.png` 직접 접근):
  - `/og/krds.png`, `/og/baemin.png`, `/og/socar.png`, `/og/11st.png`
  - `/og/gmarket.png` (가로형 logotype 처리 확인)
  - `/og/default.png` (변경 없어야 함)
- [ ] 긴 한국어 이름 케이스(titleCompact 108px 강등)에서 로고가 ~92px로 같이 작아져 비례 유지하는지
- [ ] SNS 공유 시뮬레이션 (https://www.opengraph.xyz/ 같은 디버거에 preview URL 입력) — 선택
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm build:og` — 12장 모두 성공
- [x] DCO signoff 포함 커밋

## Notes

- `public/og/*.png`은 의도적으로 gitignored (빌드 artifact). Vercel 빌드 단계의 `npm run build:og`가 새 layout으로 PNG 생성.
- 변경 파일: `src/og/template.tsx` 1개, +46/-25.
- 이전 PR과 함께 보면: 카드 그리드(#기존) → 상세 페이지(#74) → OG(이 PR) 모든 슬롯에서 "H1 옆 브랜드 로고" 패턴 완성.