### PR TITLE
Fix toss preview mobile layout: grid overflow + tab-bar fade

### DIFF
--- a/public/preview/toss/dark.html
+++ b/public/preview/toss/dark.html
@@ -636,7 +636,7 @@
     background: var(--tds-grey-100);
     border: 1px solid var(--tds-grey-200);
     border-radius: 20px;
-    padding: 24px;
+    padding: clamp(16px, 5vw, 24px);
     min-width: 0;
   }
   .comp-card h4 {
@@ -752,7 +752,7 @@
   .pb-fill.brand-grad { background: linear-gradient(90deg, var(--tds-blue-500), var(--tds-blue-700)); }
 
   /* Rating */
-  .rating-row { display: flex; align-items: center; gap: 10px; }
+  .rating-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .rating-stars { display: flex; gap: 2px; }
   .rating-stars svg { width: 28px; height: 28px; }
   .rating-stars.lg svg { width: 44px; height: 44px; }

--- a/public/preview/toss/dark.html
+++ b/public/preview/toss/dark.html
@@ -637,6 +637,7 @@
     border: 1px solid var(--tds-grey-200);
     border-radius: 20px;
     padding: 24px;
+    min-width: 0;
   }
   .comp-card h4 {
     margin: 0 0 4px;
@@ -930,6 +931,7 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
   }
   .ftile .ftile-demo {
     min-height: 60px;
@@ -1337,6 +1339,7 @@
     display: flex;
     align-items: center;
     padding: 0 6px;
+    z-index: 2;
   }
   .phone .tab-bar .tab {
     flex: 1;

--- a/public/preview/toss/light.html
+++ b/public/preview/toss/light.html
@@ -629,7 +629,7 @@
     background: var(--tds-white);
     border: 1px solid var(--tds-grey-200);
     border-radius: 20px;
-    padding: 24px;
+    padding: clamp(16px, 5vw, 24px);
     min-width: 0;
   }
   .comp-card h4 {
@@ -745,7 +745,7 @@
   .pb-fill.brand-grad { background: linear-gradient(90deg, var(--tds-blue-500), var(--tds-blue-700)); }
 
   /* Rating */
-  .rating-row { display: flex; align-items: center; gap: 10px; }
+  .rating-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .rating-stars { display: flex; gap: 2px; }
   .rating-stars svg { width: 28px; height: 28px; }
   .rating-stars.lg svg { width: 44px; height: 44px; }

--- a/public/preview/toss/light.html
+++ b/public/preview/toss/light.html
@@ -630,6 +630,7 @@
     border: 1px solid var(--tds-grey-200);
     border-radius: 20px;
     padding: 24px;
+    min-width: 0;
   }
   .comp-card h4 {
     margin: 0 0 4px;
@@ -923,6 +924,7 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
   }
   .ftile .ftile-demo {
     min-height: 60px;
@@ -1330,6 +1332,7 @@
     display: flex;
     align-items: center;
     padding: 0 6px;
+    z-index: 2;
   }
   .phone .tab-bar .tab {
     flex: 1;


### PR DESCRIPTION
## 변경 요약

토스 프리뷰 데모의 **모바일 레이아웃 깨짐 2건**을 수정합니다. 둘 다 직전 PR(#73)에서 추가된 신규 섹션(NEW 컴포넌트 그리드 / Full component grid / 복원된 floating Tab-Bar)에서 발생했습니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정 (preview HTML)
- [ ] 사이트 코드/UI
- [ ] 문서
- [ ] `/design-md` 스킬

## 수정 내역

### 1. 좁은 뷰포트 가로 오버플로 (CSS Grid min-width 함정)
- **증상**: 360px 뷰포트에서 문서 전체가 ~520px로 늘어나 가로 스크롤 발생 (160px 오버플로).
- **근본 원인**: `06 NEW components`의 `.comp-card`와 `08 Full component grid`의 `.ftile`이 grid item인데 `min-width: 0`이 없었습니다. `1fr` 트랙 = `minmax(auto, 1fr)`이라 grid item의 **min-content**(내부 flex 행 — 예: segmented control)가 트랙을 뷰포트보다 넓게 밀어냈습니다.
- **수정**: `.comp-card`, `.ftile`에 `min-width: 0` 추가 → grid item이 트랙에 맞게 줄어듦.
- **검증** (Playwright, 실측): light·dark 모두 **360px에서 가로 오버플로 0**.

### 2. Floating Tab-Bar 하단이 투명도로 잘려 보임
- **증상**: Send-Money flow의 Home phone에서 floating 탭바 하단 ~28px가 흰색으로 페이드되어 잘린 것처럼 보임.
- **근본 원인**: bottom-CTA 보호 그라디언트(`.protection`, `white→transparent`)가 DOM상 탭바보다 뒤에 있고 z-index가 auto라, 탭바 하단 위에 페인트되어 페이드시켰습니다.
- **수정**: `.phone .tab-bar`에 `z-index: 2` 추가 → 탭바의 솔리드 배경이 그라디언트 위로 올라와 정상 렌더. 그라디언트는 탭바 옆/아래의 스크롤 콘텐츠는 그대로 페이드.
- **검증**: light·dark 스크린샷으로 탭바 솔리드 렌더 확인.

두 수정 모두 `light.html` / `dark.html` 대칭 적용 (각 +3줄).

## 카탈로그 PR 체크

- [x] `public/preview/toss/{light,dark}.html` 변경·확인 (Playwright 실측 + 스크린샷)
- [x] 토큰 영향 없음 (레이아웃 CSS만; OKLCH 토큰·컴포넌트 구조 변경 없음)
- [x] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)

## 알려진 follow-up (이 PR 범위 밖)

- **320px(iPhone SE)에서 NEW 섹션 ~11px 잔여 오버플로**: comp-card는 해결됐으나, 그 안의 줄바꿈 안 되는 leaf 요소가 320px 극협폭에서 남는 것으로 측정됨. 360px 이상(대부분 기기)은 완전 해결. 별도 추적.

## 관련

- #73 (토스 새 번들 업데이트) 의 모바일 회귀 수정