### PR TITLE
feat(catalog): etc 묶음을 education·career 카테고리로 승격

### DIFF
--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -38,7 +38,7 @@ Frontmatter (project-specific, NOT Stitch's token YAML):
 name: {Display Name}
 design_system_name: {Design System Name} # optional; include only when the public design system name differs from the company/brand display name
 slug: {slug}
-category: {one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc}
+category: {one of: finance, messenger, commerce, delivery, mobility, content, community, travel, gov, developer, education, career, etc}
 last_updated: {today as YYYY-MM-DD}
 sources: [https://..., https://...]   # populated from research.md ## Sources, only HTTP 2xx URLs
 related_services: []                    # leave empty; user fills at checkpoint

--- a/.claude/agents/research-collector.md
+++ b/.claude/agents/research-collector.md
@@ -15,7 +15,7 @@ You are a brand research analyst gathering verifiable facts about a brand's UI/U
 - `source_urls` — array of URLs to investigate (≥ 1)
 - `screenshot_paths` — array of local image paths to read (0 or more)
 - `crawl_corpus_path` — absolute path to a pre-crawled Markdown corpus of the brand's official design-system docs, or `"none"`. When present, this is usually your richest source.
-- `category` — one of finance, messenger, commerce, delivery, mobility, content, community, travel, etc
+- `category` — one of finance, messenger, commerce, delivery, mobility, content, community, travel, gov, developer, education, career, etc
 - `lang` — `ko` or `en` (affects which `## Korean market context` you emphasize)
 - `cache_dir` — absolute path where you write your output (e.g. `/path/to/repo/.claude/cache/design-md/toss/`)
 

--- a/.claude/skills/design-md/references/rubric-design.md
+++ b/.claude/skills/design-md/references/rubric-design.md
@@ -8,7 +8,7 @@ Frontmatter must round-trip through `buildDoc()` in `src/lib/content-parser.ts` 
 
 - All required keys present: `name, slug, category, last_updated, sources, related_services, lang`.
 - `name` is the Korean company/brand display name. If the design system has a distinct public name, `design_system_name` may be present as an optional string and is not a hard-fail requirement.
-- `category` ∈ `CATEGORIES` const from `src/lib/content-types.ts` (one of: finance, messenger, commerce, delivery, mobility, content, community, travel, etc).
+- `category` ∈ `CATEGORIES` const from `src/lib/content-types.ts` (one of: finance, messenger, commerce, delivery, mobility, content, community, travel, gov, developer, education, career, etc).
 - `last_updated` matches `^\d{4}-\d{2}-\d{2}$`. The validator at content-parser.ts:158-171 throws on any other format.
 - `sources` is a non-empty array of `https?://` URLs.
 - `slug` matches `^[a-z0-9-]+$` and equals the staging filename stem (e.g. draft.md for slug X has frontmatter `slug: X`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@
 | 필드 | 규칙 |
 |------|------|
 | `slug` | 소문자 + 하이픈 + ASCII. 한글/공백 불가. 브랜드 영문 표기 우선 (`toss`, `kakao-bank`, `daangn`) |
-| `category` | [content-types.ts](./src/lib/content-types.ts)의 `CATEGORIES` enum (`finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `etc`). 모르겠다면 `etc`로 두고 PR에서 토의 |
+| `category` | [content-types.ts](./src/lib/content-types.ts)의 `CATEGORIES` enum (`finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `gov`, `developer`, `education`, `career`, `etc`). 모르겠다면 `etc`로 두고 PR에서 토의 |
 | `lang` | 자료가 한국어 위주면 `ko`, 영어 위주면 `en` |
 | `last_updated` | YYYY-MM-DD ISO 형식 (`2026-05-10`) |
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ko-design-md/
 | `name` | string | 한국어 기업/브랜드 표기명 |
 | `design_system_name` | string? | 옵션, 기업명과 별도인 디자인 시스템명 |
 | `slug` | string | 소문자 + 하이픈 + ASCII |
-| `category` | enum | `finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `etc` |
+| `category` | enum | `finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `gov`, `developer`, `education`, `career`, `etc` |
 | `last_updated` | string | YYYY-MM-DD ISO 형식 (엄격 검증) |
 | `sources` | string[] | 인용 출처 URL 배열 (본문 `[src:N]`이 인덱스 참조) |
 | `related_services` | string[] | 관련 슬러그 배열 (없으면 `[]`) |

--- a/services/teamsparta.md
+++ b/services/teamsparta.md
@@ -1,7 +1,7 @@
 ---
 name: 팀스파르타
 slug: teamsparta
-category: etc
+category: education
 logo: https://getdesign.kr/logos/teamsparta-favicon.png
 last_updated: "2026-05-13"
 created_at: "2026-05-13"

--- a/services/wanted.md
+++ b/services/wanted.md
@@ -1,7 +1,7 @@
 ---
 name: 원티드
 slug: wanted
-category: etc
+category: career
 last_updated: "2026-05-12"
 created_at: "2026-05-12"
 sources:

--- a/src/lib/category-style.test.ts
+++ b/src/lib/category-style.test.ts
@@ -28,6 +28,8 @@ describe("getCategoryStyle", () => {
       "travel",
       "gov",
       "developer",
+      "education",
+      "career",
       "etc",
     ]
     const indices = cats.map((c) => getCategoryStyle(c).koIndex)

--- a/src/lib/category-style.ts
+++ b/src/lib/category-style.ts
@@ -20,6 +20,8 @@ const STYLES: Record<Category, CategoryStyle> = {
   travel: { label: "Travel", koLabel: "여행", koIndex: "ㅇ" },
   gov: { label: "Government", koLabel: "공공", koIndex: "ㅊ" },
   developer: { label: "Developer", koLabel: "개발자도구", koIndex: "ㅋ" },
+  education: { label: "Edu", koLabel: "교육", koIndex: "ㅌ" },
+  career: { label: "Career", koLabel: "커리어", koIndex: "ㅍ" },
   etc: { label: "Etc", koLabel: "기타", koIndex: "ㅈ" },
 }
 

--- a/src/lib/category-style.ts
+++ b/src/lib/category-style.ts
@@ -20,7 +20,7 @@ const STYLES: Record<Category, CategoryStyle> = {
   travel: { label: "Travel", koLabel: "여행", koIndex: "ㅇ" },
   gov: { label: "Government", koLabel: "공공", koIndex: "ㅊ" },
   developer: { label: "Developer", koLabel: "개발자도구", koIndex: "ㅋ" },
-  education: { label: "Edu", koLabel: "교육", koIndex: "ㅌ" },
+  education: { label: "Education", koLabel: "교육", koIndex: "ㅌ" },
   career: { label: "Career", koLabel: "커리어", koIndex: "ㅍ" },
   etc: { label: "Etc", koLabel: "기타", koIndex: "ㅈ" },
 }

--- a/src/lib/content-types.ts
+++ b/src/lib/content-types.ts
@@ -9,6 +9,8 @@ export const CATEGORIES = [
   "travel",
   "gov",
   "developer",
+  "education",
+  "career",
   "etc",
 ] as const
 


### PR DESCRIPTION
## 변경 요약

`etc`(기타)에 묶여 있던 유일한 두 항목 **팀스파르타·원티드**를 각자의 명확한 도메인 카테고리로 승격했습니다 — 팀스파르타 → **education**(라벨 `Education`), 원티드 → **career**(라벨 `Career`). `etc`는 frontmatter 누락·unknown 폴백으로 남고, 항목이 0개가 되어 동적 필터에서 자동으로 빠집니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정
- [x] 사이트 코드/UI
- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [x] `/design-md` 스킬 (rubric·intake 카테고리 목록 동기화)

## 카탈로그 PR 체크 (해당 시)

> 기존 2개 항목의 `category` 필드 **재태깅**이며 신규 카탈로그 항목 PR이 아닙니다. preview/OG/인용은 카테고리와 무관하게 그대로입니다.

- [ ] `/design-md` 스킬로 생성 — N/A(기존 항목)
- [x] frontmatter 필수 필드 검증 완료 (`pnpm typecheck` + `pnpm build` round-trip 통과)
- [ ] `public/preview/{slug}/{light,dark}.html` 생성·확인 — N/A(변경 없음)
- [ ] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치 — N/A(변경 없음)
- [ ] 브랜드 자산 라이선스/상표 우려 검토 — N/A(자산 변경 없음)
- [x] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- 없음 -->

---

### 세부 변경

**카테고리 시스템 (SSOT → 파생)**
- `src/lib/content-types.ts` — `CATEGORIES`에 `education`·`career` 추가
- `src/lib/category-style.ts` — `Education`(교육/ㅌ)·`Career`(커리어/ㅍ) 라벨·색인 추가
- `src/lib/category-style.test.ts` — distinct-koIndex 검증 배열 13개로 확장

**데이터 재태깅**
- `services/teamsparta.md` · `services/wanted.md` — `category: etc` → `education`·`career`

**문서·스킬 카테고리 목록 동기화** (코드 SSOT와 일치 — 드리프트로 누락돼 있던 `gov`·`developer`도 함께 보강)
- `CONTRIBUTING.md`, `README.md`, `.claude/agents/research-collector.md`, `.claude/agents/design-md-author.md`, `.claude/skills/design-md/references/rubric-design.md`

### 검증
- **사이드바**: `Education (1)`·`Career (1)` 등장, `Etc` 제거 — 동적 필터라 UI 코드 변경 없음
- **상세 브레드크럼 / OG 이미지**: `ㅌ. EDUCATION` · `ㅍ. CAREER`
- `Tests 151 passed (151)`, typecheck/lint/build 모두 통과