### PR TITLE
fix(home): 태블릿 폭에서 페이지 가로 스크롤 제거

### DIFF
--- a/src/routes/-home/components/category-sidebar.tsx
+++ b/src/routes/-home/components/category-sidebar.tsx
@@ -115,7 +115,7 @@ export function CategorySidebar({
       {/* Mobile: horizontal scrollable chip row */}
       <nav
         aria-label="Categories"
-        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden"
+        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 sm:-mx-8 sm:px-8 lg:hidden"
       >
         <CategoryChip
           label="All"

--- a/src/routes/-home/components/category-sidebar.tsx
+++ b/src/routes/-home/components/category-sidebar.tsx
@@ -87,7 +87,7 @@ export function CategorySidebar({
       {/* Desktop: vertical sidebar */}
       <nav
         aria-label="Categories"
-        className="hidden md:block"
+        className="hidden lg:block"
       >
         <h2 className="text-meta-caps mb-3 px-3">Find Designs</h2>
         <ul>
@@ -115,7 +115,7 @@ export function CategorySidebar({
       {/* Mobile: horizontal scrollable chip row */}
       <nav
         aria-label="Categories"
-        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 md:hidden"
+        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden"
       >
         <CategoryChip
           label="All"

--- a/src/routes/-home/components/service-list-row.tsx
+++ b/src/routes/-home/components/service-list-row.tsx
@@ -86,8 +86,8 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
       {/* Desktop: single-row 6-col grid */}
       <div
         className={cn(
-          "hidden items-center gap-4 px-6 py-3 md:grid",
-          "md:grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px]",
+          "hidden items-center gap-4 px-6 py-3 lg:grid",
+          "lg:grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px]",
         )}
       >
         <span className="text-muted-foreground text-xs tabular-nums">
@@ -99,7 +99,7 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
             {name}
           </span>
         </span>
-        <span className="text-muted-foreground truncate text-sm">
+        <span className="text-muted-foreground min-w-0 truncate text-sm">
           {doc.tagline}
         </span>
         <span className="flex items-center">{isUpdated && <UpdatedBadge />}</span>
@@ -110,7 +110,7 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
       </div>
 
       {/* Mobile: 2-line stacked layout */}
-      <div className="px-4 py-3 md:hidden">
+      <div className="px-4 py-3 lg:hidden">
         <div className="flex items-center gap-2.5">
           <ServiceLogo name={name} logo={logo} size={24} />
           <span className="truncate text-sm font-semibold tracking-tight">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -53,8 +53,8 @@ function HomePage() {
             에 .md 파일을 추가해 보세요.
           </p>
         ) : (
-          <div className="md:grid md:grid-cols-[220px_1fr] md:gap-10">
-            <aside className="mb-4 md:mb-0 md:pt-8">
+          <div className="lg:grid lg:grid-cols-[220px_1fr] lg:gap-10">
+            <aside className="mb-4 lg:mb-0 lg:pt-8">
               <CategorySidebar
                 totalCount={filter.totalCount}
                 counts={filter.counts}
@@ -63,7 +63,7 @@ function HomePage() {
               />
             </aside>
 
-            <div className="md:pt-8">
+            <div className="lg:pt-8">
               <DesignSearch
                 value={filter.query}
                 onChange={filter.setQuery}
@@ -100,7 +100,7 @@ function HomePage() {
 function ColumnHeader() {
   return (
     <div
-      className="text-meta-caps hidden grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px] items-center gap-4 border-b px-6 py-2 md:grid"
+      className="text-meta-caps hidden grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px] items-center gap-4 border-b px-6 py-2 lg:grid"
       style={{ borderColor: "var(--rule-strong)" }}
     >
       <span>#</span>


### PR DESCRIPTION
## 변경 요약

태블릿 폭(768~1023px)에서 **홈 페이지 전체에 발생하던 가로 스크롤을 제거**합니다. 데스크톱 6컬럼 테이블+사이드바 레이아웃이 `md`(768px)부터 켜지지만, 이 레이아웃의 최소 폭(콘텐츠 약 548px)이 태블릿 가용 폭(768px에서 444px)을 초과한 것이 원인입니다. 모바일↔데스크톱 분기점을 `md` → `lg`(1024px)로 올려, 태블릿에서는 이미 검증된 **모바일 카드 레이아웃**(칩 필터 + 2줄 카드)을 사용하도록 했습니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

---

### 원인

- 768px 기준 콘텐츠 가용 폭: `768 − 64(sm:px-8) − 220(사이드바) − 40(gap-10)` = **444px**
- 6컬럼 행 최소 폭: `40 + 180 + (설명) + 56 + 72 + 72` + gap-4×5(80) + px-6(48) ≈ **548px+**
- 548 > 444 → 약 100px+ 초과. `body`에 `overflow-x` 방어막도 없어 페이지 전체 가로 스크롤로 노출.

### 변경

- 홈 목록의 모바일↔데스크톱 분기 `md:` → `lg:` 일괄 전환 (9곳)
  - `src/routes/index.tsx` — 메인 그리드 / aside / 콘텐츠 / ColumnHeader
  - `src/routes/-home/components/category-sidebar.tsx` — 세로 사이드바 / 칩 행
  - `src/routes/-home/components/service-list-row.tsx` — 데스크톱 행 / 모바일 카드
- 설명 셀에 `min-w-0` 추가 → grid 트랙 안에서 `truncate`가 실제로 적용되도록 하여 `lg`(1024px) 경계 여유 폭 확보

### 검증 (preview 실측: `scrollWidth` vs `clientWidth`)

| 폭(px) | 가로 스크롤 | 초과량 | 레이아웃 |
|---|:---:|:---:|---|
| 375 | 없음 | 0px | 카드형 |
| 768 | 없음 | 0px | 카드형 |
| 1023 | 없음 | 0px | 카드형 |
| 1024 | 없음 | 0px | 데스크톱 테이블 복귀 |
| 1280 | 없음 | 0px | 데스크톱 테이블 |

- 레이아웃 전환 정확: ≤1023px 칩+카드, ≥1024px 6컬럼 테이블 + 세로 사이드바
- 콘솔 에러 없음, `typecheck`/`lint`/`build` 통과
- 데스크톱(≥1024px) 동작에는 변화 없음 (회귀 없음)

> 참고: 서비스 상세 페이지는 `md:grid-cols-[minmax(0,1fr)_280px]` 구조로 좌측이 0까지 줄어 태블릿에서도 넘치지 않아 이번 범위에서 제외했습니다.
