### PR TITLE
docs(issue-template): 이슈 폼 드롭다운 한글 통일 + 카테고리 13종 동기화

### DIFF
--- a/.github/ISSUE_TEMPLATE/entry-correction.yml
+++ b/.github/ISSUE_TEMPLATE/entry-correction.yml
@@ -21,16 +21,16 @@ body:
     attributes:
       label: 어떤 섹션 / 필드인가요?
       options:
-        - frontmatter (name, slug, category 등)
-        - last_updated
-        - sources (출처 추가/수정)
-        - Brand & Style
-        - Colors
-        - Typography
-        - Spacing / Rounded / Elevation
-        - Components
-        - Do's and Don'ts
-        - References
+        - 프론트매터 (name, slug, category 등)
+        - 최종 수정일 (last_updated)
+        - 출처 (sources)
+        - 브랜드 & 스타일
+        - 색상
+        - 타이포그래피
+        - 여백 / 라운드 / 엘리베이션
+        - 컴포넌트
+        - 권장 & 지양
+        - 참고 문헌
         - 본문 오타·문장 다듬기
         - 기타
     validations:

--- a/.github/ISSUE_TEMPLATE/new-catalog-entry.yml
+++ b/.github/ISSUE_TEMPLATE/new-catalog-entry.yml
@@ -27,7 +27,7 @@ body:
     id: category
     attributes:
       label: 카테고리 후보
-      description: 정확하지 않다면 기타로 두고 토의해도 됩니다
+      description: 정확하지 않다면 '기타'로 두고 토의해도 됩니다
       options:
         - 결제
         - 메신저

--- a/.github/ISSUE_TEMPLATE/new-catalog-entry.yml
+++ b/.github/ISSUE_TEMPLATE/new-catalog-entry.yml
@@ -27,17 +27,21 @@ body:
     id: category
     attributes:
       label: 카테고리 후보
-      description: 정확하지 않다면 `etc`로 두고 토의해도 됩니다
+      description: 정확하지 않다면 기타로 두고 토의해도 됩니다
       options:
-        - finance
-        - messenger
-        - commerce
-        - delivery
-        - mobility
-        - content
-        - community
-        - travel
-        - etc
+        - 결제
+        - 메신저
+        - 커머스
+        - 배달
+        - 모빌리티
+        - 콘텐츠
+        - 커뮤니티
+        - 여행
+        - 공공
+        - 개발자도구
+        - 교육
+        - 커리어
+        - 기타
     validations:
       required: true
 


### PR DESCRIPTION
## 변경 요약

GitHub 이슈 폼 드롭다운에 남아 있던 영어를 한글로 통일했습니다. 안내·라벨·설명은 이미 전부 한국어였고, 영어로 남은 건 두 드롭다운의 **옵션값**뿐이라 그 부분만 한글화했습니다.

- **`new-catalog-entry.yml`** — 카테고리 후보 9종(영어 슬러그) → **13종 한글 라벨**. `src/lib/content-types.ts`의 `CATEGORIES` enum 순서 + `src/lib/category-style.ts`의 `koLabel`과 1:1 일치하도록 작성했고, 누락돼 있던 `gov`·`developer`·`education`·`career` 4종을 추가했습니다. `description`의 `` `etc` `` → `기타`.
- **`entry-correction.yml`** — 섹션 드롭다운의 design.md 영어 헤딩 7종(`Colors` 등)을 한글(`색상` 등)로 교체. 단, frontmatter 필드명(`name`/`slug`/`category`/`last_updated`/`sources`)은 파일 속 실제 YAML 키라서 `README.md`처럼 **코드 식별자로 보존**(한글 라벨 + 괄호 참조 형태).

> 드롭다운 값은 사람(메인테이너)만 읽고, 이를 파싱·검증하는 자동화는 없습니다(워크플로는 `ci.yml`뿐). 실제 frontmatter `category:`는 `/design-md` 스킬이 온보딩 때 별도 지정하므로, 한글화가 데이터/포맷에 영향을 주지 않습니다.

## 변경 종류

- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등) — GitHub 이슈 템플릿(`.github/ISSUE_TEMPLATE/`)

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 항목(`services/*.md`) 변경 아님.

## 일반 체크

- [ ] `pnpm typecheck && pnpm lint && pnpm build` — 이 워크트리에 `node_modules` 미설치로 로컬 미실행. 변경 대상은 `.github/ISSUE_TEMPLATE/*.yml`(GitHub 전용 메타데이터)로 TS/Vite 빌드 그래프 **밖**이라 빌드에 무영향이며, CI(`ci.yml`)가 PR에서 검증합니다.
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

### 수행한 검증

- 두 YAML 모두 정상 파싱(gray-matter/js-yaml로 구조 확인).
- 카테고리 13종이 **소스 오브 트루스와 정확히 일치** — `content-types.ts` `CATEGORIES` + `category-style.ts` `koLabel`에서 직접 추출해 대조(EXACT MATCH).
- `git diff` 범위 = 두 드롭다운 옵션 + 카테고리 `description` 1줄. 부수 변경 없음.

## 관련 이슈

없음.
