### PR TITLE
ci: 매 PR 자동 Claude Code 코드 리뷰 워크플로 추가

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,12 +21,30 @@ jobs:
     permissions:
       contents: read # diff/파일 읽기
       pull-requests: write # 인라인·요약 코멘트 게시
+      id-token: write # claude-code-action이 GitHub App 토큰 교환에 OIDC 사용 (필수)
     steps:
-      - uses: actions/checkout@v6
+      # 시크릿 미설정 시 리뷰를 '실패'가 아니라 '건너뜀'으로 처리 — PR을 빨간 X로 막지 않음
+      - name: Check for Claude token
+        id: token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN 시크릿이 없어 자동 리뷰를 건너뜁니다. (Settings → Secrets and variables → Actions에 등록)"
+          fi
+
+      - name: Checkout
+        if: steps.token.outputs.present == 'true'
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Claude Code Review
+        if: steps.token.outputs.present == 'true'
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 신뢰 가능한 값(repo·PR번호)만 보간 — PR 제목/본문은 인젝션 위험이라 넣지 않음

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,57 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# 같은 PR에 새 커밋이 푸시되면 진행 중이던 이전 리뷰는 취소 (중복 비용 방지)
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # 내부 PR(메인테이너 브랜치·dependabot)만 리뷰.
+    # 포크 PR은 시크릿이 전달되지 않으므로 스킵(조건 false → 잡 자체가 생성 안 됨).
+    # 드래프트 PR도 스킵.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # diff/파일 읽기
+      pull-requests: write # 인라인·요약 코멘트 게시
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 신뢰 가능한 값(repo·PR번호)만 보간 — PR 제목/본문은 인젝션 위험이라 넣지 않음
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            이 PR을 한국어로 리뷰해 주세요. ko-design-md는 한국 브랜드 디자인 시스템을
+            Stitch v0.1 마크다운으로 정리하는 OSS 카탈로그입니다
+            (TanStack Start 사이트 + 빌드 스크립트 + `.claude` 스킬 정의).
+
+            다음을 중심으로 봐 주세요:
+            - 정확성: 버그, 깨지기 쉬운 로직, 누락된 엣지 케이스
+            - 보안: 입력 검증, 시크릿/토큰 노출, 의존성 위험
+            - 컨벤션: 기존 코드 스타일·패턴과의 일관성, TypeScript 타입 안전성
+            - 카탈로그 항목(`services/*.md`) 변경 시: frontmatter 필수 필드
+              (name, slug, category, last_updated, sources, related_services, lang)와
+              본문 `[src:N]` 인용이 frontmatter sources 인덱스와 일치하는지
+
+            중요한 문제는 mcp__github_inline_comment__create_inline_comment 로 해당 코드 줄에
+            인라인 코멘트를 남기고, 마지막에 `gh pr comment`로 전체 요약
+            (잘된 점 + 핵심 지적 + 머지 권장 여부)을 한국어로 작성해 주세요.
+            기계적 검사(typecheck/lint/build)는 별도 CI가 담당하니 중복하지 말고,
+            사소한 취향 문제로 막지 말며, 잘된 점은 칭찬해 주세요.
+          claude_args: |
+            --model sonnet
+            --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 변경 요약

매 PR마다 Anthropic 공식 GitHub Action(`anthropics/claude-code-action@v1`)으로 자동 코드 리뷰를 돌리는 워크플로 [`.github/workflows/claude-code-review.yml`](https://github.com/CaesiumY/ko-design-md/blob/main/.github/workflows/claude-code-review.yml)를 추가합니다. 기존 [`ci.yml`](https://github.com/CaesiumY/ko-design-md/blob/main/.github/workflows/ci.yml)의 typecheck/lint/build(기계적 게이트)를 대체하지 않고, 로직·설계·컨벤션 관점의 판단형 리뷰 레이어로 **보완**합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [ ] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬
- [x] **기타: CI/자동화** — GitHub Actions 워크플로 추가 (위 카테고리에 CI 항목이 없어 별도 표기)

## 동작 방식

- **트리거**: `pull_request` (opened / synchronize)
- **대상 제한**: `if: head.repo.full_name == github.repository && !draft` → 내부 PR(메인테이너 브랜치·dependabot)만 리뷰. 포크 PR은 시크릿이 전달되지 않아 잡 자체가 생성되지 않고 스킵. 드래프트도 스킵.
- **인증**: `CLAUDE_CODE_OAUTH_TOKEN` (구독 OAuth 토큰) — 별도 API 과금 없음
- **모델**: `--model sonnet` (비용 효율, 별칭이라 모델 은퇴에도 안 깨짐)
- **권한**: `contents: read` + `pull-requests: write` + `id-token: write` — `id-token`은 액션이 GitHub App 토큰 교환에 OIDC를 쓰므로 **필수**(OAuth 토큰 방식이어도 동일)
- **안전장치(graceful skip)**: `CLAUDE_CODE_OAUTH_TOKEN` 시크릿이 없으면 리뷰 스텝을 건너뛰고 잡은 성공 처리(`::notice::`로 사유 안내). 시크릿 등록 전에도 PR을 빨간 X로 막지 않음.
- **비용 가드**: `concurrency` cancel-in-progress + 드래프트 스킵 + `--max-turns 15`
- **출력**: 중요 지점은 인라인 코멘트, 마지막에 한국어 전체 요약 코멘트
- **프롬프트 안전**: PR 제목/본문 같은 사용자 입력은 프롬프트에 보간하지 않음(인젝션 회피), repo·PR번호만 사용

## ⚠️ 머지 후 필요한 설정 (admin)

이 워크플로가 실제로 리뷰를 달려면 레포 시크릿이 선행되어야 합니다. (없으면 위 graceful skip으로 조용히 건너뜁니다)

1. `claude setup-token`(또는 `/install-github-app`)으로 OAuth 토큰 발급
2. **Settings → Secrets and variables → Actions** 에 `CLAUDE_CODE_OAUTH_TOKEN` 등록

## 카탈로그 PR 체크 (해당 시)

N/A — 카탈로그(`services/*.md`) 변경이 아닙니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` — 워크플로 YAML만 추가했고 빌드 대상 소스는 무변경. 이 PR의 `build` 체크 통과 확인.
- [x] 워크플로 YAML 파싱·구조 검증 (PyYAML)
- [x] 라이브 CI에서 `review` 체크 통과 확인 (시크릿 부재 → graceful skip → green)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- 없음 -->
