### PR TITLE
ci: claude-code-review 워크플로 하드닝 (포크 가드·한국어·비용)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,31 +3,29 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+# 같은 PR에 새 커밋이 푸시되면 진행 중이던 이전 리뷰는 취소 (중복 비용 방지)
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # 내부 PR(메인테이너 브랜치·dependabot)만 리뷰.
+    # 포크 PR은 시크릿이 전달되지 않아 인증 실패하므로 스킵(조건 false → 잡 미생성). 드래프트도 스킵.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
+      id-token: write # claude-code-action이 GitHub App 토큰 교환에 OIDC 사용 (필수)
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -39,6 +37,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+          # 공식 플러그인 기본 출력은 영어 — 시스템 프롬프트로 한국어 강제
+          claude_args: '--append-system-prompt "리뷰 인라인 코멘트와 요약은 모두 한국어로 작성하세요."'


### PR DESCRIPTION
## 변경 요약

#93(`/install-github-app`)이 추가한 공식 [`claude-code-review.yml`](https://github.com/CaesiumY/ko-design-md/blob/main/.github/workflows/claude-code-review.yml)에 운영 하드닝을 더합니다. **리뷰 엔진(공식 `/code-review` 플러그인)은 그대로 유지**하고, 포크 안전·비용·언어만 보강합니다.

## 변경 종류

- [x] **기타: CI/자동화** (기존 워크플로 보강)

## 무엇을 바꿨나 (#93 대비)

- **내부 PR 전용 가드** — `if: head.repo.full_name == github.repository && !draft`. 포크 PR은 시크릿이 전달되지 않아 인증 실패(빨간 X)하므로 스킵. 드래프트도 스킵.
- **concurrency** cancel-in-progress — 연속 푸시 시 진행 중이던 이전 리뷰 취소(토큰/러너 비용 절감)
- **한국어 리뷰 강제** — `claude_args: --append-system-prompt`. 공식 플러그인 기본 출력이 영어라 인라인/요약을 한국어로.
- **checkout@v4 → @v6** — 레포 CI(`ci.yml`)와 액션 버전 통일

## 유지한 것 (#93 그대로)

- 공식 `/code-review` 플러그인 엔진 (`plugin_marketplaces` + `plugins` + `prompt`)
- 권한 구조 (`contents`/`pull-requests`/`issues: read`, `id-token: write`)
- 트리거 (`opened, synchronize, ready_for_review, reopened`)

## 일반 체크

- [x] 워크플로 YAML 파싱·구조 검증 (PyYAML)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 관련

- #93 위에 하드닝 / #92 대체(닫음)
