### PR TITLE
feat(docs-crawler): 크롤 이미지·인라인 base64를 기본 로컬화 (--external-images opt-out)

### DIFF
--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -124,13 +124,13 @@ The auto-detect pattern for the catalog grid logo is exactly `public/logos/{slug
 
 If `docs_site_url` is empty or "없음", skip this stage and set `crawl_corpus_path = "none"`.
 
-Otherwise, crawl the brand's documentation site into the cache directory so research-collector can use it as a primary source. This runs the `docs-crawler` skill's engine — a sitemap-driven crawl with a JS-render fallback that keeps images as external URLs:
+Otherwise, crawl the brand's documentation site into the cache directory so research-collector can use it as a primary source. This runs the `docs-crawler` skill's engine — a sitemap-driven crawl with a JS-render fallback that also localizes images (external and inline base64) into `crawl/images/`, so the cached corpus is self-contained:
 
 ```bash
 cd "${repo_root}" && pnpm crawl:docs "${docs_site_url}" --out "${repo_root}/.claude/cache/design-md/{slug}"
 ```
 
-The crawl writes `crawl-corpus.md` (the merged corpus) plus `crawl/pages/*.md` and `crawl/manifest.json` into the cache directory. The first crawl of a JavaScript-rendered site auto-installs a headless browser (~150MB, one-time).
+The crawl writes `crawl-corpus.md` (the merged corpus) plus `crawl/pages/*.md`, the downloaded `crawl/images/`, and `crawl/manifest.json` into the (gitignored) cache directory. The first crawl of a JavaScript-rendered site auto-installs a headless browser (~150MB, one-time).
 
 After it returns, verify the corpus landed:
 

--- a/.claude/skills/docs-crawler/SKILL.md
+++ b/.claude/skills/docs-crawler/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Crawl an entire documentation or design-system website into one LLM-ready
   Markdown corpus. Discovers every page from the site's sitemap.xml (with a
   same-origin link-following fallback when there is no sitemap), extracts each
-  page's main content as clean Markdown, keeps images as their original
-  external URLs, and renders JavaScript-heavy pages with a headless browser.
+  page's main content as clean Markdown, downloads each page's images (and
+  inline base64 images) into a local folder referenced by relative paths, and
+  renders JavaScript-heavy pages with a headless browser.
   Use this whenever someone wants the WHOLE of a multi-page docs site,
   design-system site, API reference, component library, or knowledge base
   turned into Markdown — for example "crawl this docs site", "turn this design
@@ -46,7 +47,7 @@ If the user has not provided a URL, ask for one — do not guess.
 From the repository root:
 
 ```
-pnpm crawl:docs <site-url> [--out <dir>]
+pnpm crawl:docs <site-url> [--out <dir>] [--external-images]
 ```
 
 Equivalent direct form:
@@ -59,15 +60,24 @@ The engine discovers pages via `sitemap.xml` (falling back to same-origin
 link-following), fetches each page, extracts the main content, and converts it
 to Markdown. It prints per-page progress and a final summary line.
 
+By default it also **localizes images**: every external image and inline base64
+`data:` image is downloaded into `crawl/images/` and the Markdown is rewritten
+to relative paths, so the corpus is self-contained for renderers that can't
+fetch external URLs (Claude Design, offline previews). Pass `--external-images`
+to skip downloading and keep the original external URLs instead.
+
 ## Output
 
-Three artifacts are written under the output directory:
+These artifacts are written under the output directory:
 
 - **`crawl-corpus.md`** — every successful page merged into one document, with
   a table of contents and a `Source:` URL per page. This is the primary
   deliverable.
 - **`crawl/pages/{NNN}-{slug}.md`** — one file per page, each with
   `source_url` / `title` / `method` frontmatter.
+- **`crawl/images/`** — downloaded image files (skipped with
+  `--external-images`), referenced from the corpus and page files by relative
+  paths.
 - **`crawl/manifest.json`** — a per-URL audit log (status, fetch method,
   extracted character count, error reason).
 
@@ -89,9 +99,10 @@ file. The corpus can be large.
 The `--out` argument controls where everything is written. When the `design-md`
 skill calls this crawler during its research phase, it passes `--out` pointing
 at its cache directory (`.claude/cache/design-md/{slug}/`), so the resulting
-`crawl-corpus.md` lands where `research-collector` can read and cite it.
-Nothing special is needed for that case — just run the crawl with the given
-`--out`.
+`crawl-corpus.md` (and the localized `crawl/images/`) land where
+`research-collector` can read and cite them. The whole cache directory is
+gitignored, so downloaded images stay out of version control. Nothing special
+is needed for that case — just run the crawl with the given `--out`.
 
 ## Notes and edge cases
 
@@ -100,10 +111,14 @@ Nothing special is needed for that case — just run the crawl with the given
 - **JavaScript-rendered sites** — if a page returns an empty shell, the engine
   re-fetches it through a headless browser. Chromium is installed automatically
   on first need (~150 MB, one-time). Static sites never launch a browser.
-- **Images** are kept as their original external URLs — never downloaded.
-  Inline `data:` URI images are the exception: the embedded base64 blob is
-  replaced with an `inline-image-omitted` placeholder (alt and title text are kept),
-  because raw base64 is unreadable to an LLM and would bloat the corpus.
+- **Images** are downloaded into `crawl/images/` by default and referenced by
+  relative paths, so the corpus is self-contained — this covers external
+  `<img>` URLs and inline base64 `data:` images alike. A non-base64
+  (percent-encoded) `data:` URI, or any image whose bytes fail to download or
+  decode, instead becomes an `inline-image-omitted` placeholder (alt and title
+  text are kept) so raw base64 never bloats the corpus. With `--external-images`
+  the crawler downloads nothing: external URLs stay as-is and inline `data:`
+  images collapse to the placeholder.
 - **Few or no images is normal, especially for design-system sites** — modern
   docs and design-system sites (Docusaurus and similar) render icons and
   component visuals as inline `<svg>`, CSS, or live DOM rather than `<img>`

--- a/.claude/skills/docs-crawler/evals/evals.json
+++ b/.claude/skills/docs-crawler/evals/evals.json
@@ -4,13 +4,13 @@
     {
       "id": 1,
       "prompt": "https://socarframe.socar.kr/ — 이 디자인 시스템 공식 문서 사이트 전체를 크롤링해서 LLM 컨텍스트로 쓸 수 있는 단일 마크다운 파일로 만들어줘. 이미지는 원본 링크 그대로 두고.",
-      "expected_output": "A crawl-corpus.md (plus per-page files and a manifest.json) under an output directory, containing the SOCAR Frame documentation pages discovered from its sitemap, each with a Source: URL, images left as external URLs, and clean code blocks.",
+      "expected_output": "A crawl-corpus.md (plus per-page files and a manifest.json) under an output directory, containing the SOCAR Frame documentation pages discovered from its sitemap, each with a Source: URL and clean code blocks. Because the prompt explicitly asks to keep image links, the crawl is run with --external-images so images stay as external URLs.",
       "files": [],
       "expectations": [
         "A single merged Markdown corpus file is produced.",
         "The corpus aggregates 20 or more distinct pages of the site, not just one page.",
         "Every page in the corpus is labelled with its original source URL.",
-        "Images are preserved as external URLs; no image files were downloaded to disk.",
+        "The prompt asks to keep image links, so the crawl runs with --external-images: images stay as external URLs and no image files are downloaded.",
         "Content from the JavaScript-rendered pages is extracted as readable text, not empty shells.",
         "An audit record lists every attempted page with a success or failure status.",
         "The corpus content is clean: multi-line code blocks keep one line per source line (no collapsed commands like 'npmnpm install'), and no navigation chrome (heading-anchor links, breadcrumbs, prev/next pagers) leaks into the text."
@@ -25,7 +25,7 @@
         "A single merged Markdown corpus file is produced.",
         "The corpus aggregates 10 or more distinct documentation pages.",
         "Every page in the corpus is labelled with its original source URL.",
-        "Images are preserved as external URLs; no image files were downloaded to disk.",
+        "By default the crawl localizes images: any external or inline base64 images are downloaded into crawl/images/ and referenced by relative paths (a design-system site may legitimately have few or no <img> images, which is fine).",
         "The corpus contains clean Markdown of the documentation's main content, not navigation chrome.",
         "An audit record lists every attempted page with a success or failure status.",
         "The corpus content is clean: multi-line code blocks keep one line per source line (no collapsed commands like 'npmnpm install'), and no navigation chrome (heading-anchor links, breadcrumbs, prev/next pagers) leaks into the text."
@@ -40,7 +40,7 @@
         "The skill is invoked even though the prompt never says the word 'crawl'.",
         "A single merged Markdown corpus file is produced.",
         "The corpus aggregates many distinct documentation pages.",
-        "Images are preserved as external URLs; no image files were downloaded to disk.",
+        "By default the crawl localizes images: any external or inline base64 images are downloaded into crawl/images/ and referenced by relative paths (a design-system site may legitimately have few or no <img> images, which is fine).",
         "The corpus content is clean: multi-line code blocks keep one line per source line, and no navigation chrome leaks into the text."
       ]
     }

--- a/.claude/skills/docs-crawler/scripts/crawl.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl.ts
@@ -3,24 +3,26 @@
 // Usage:
 //   tsx crawl.ts <docs-site-url> [--out <dir>]
 //                                 [--seeds <url1,url2,...>]
-//                                 [--download-images]
+//                                 [--external-images]
 //
 // Crawls an entire documentation site (sitemap-driven, link-BFS fallback) and
 // writes a Markdown corpus. Static pages are fetched directly; JS-rendered
-// pages fall back to a headless browser. Images are kept as external URLs
-// unless `--download-images` is set.
+// pages fall back to a headless browser.
+//
+// Images are localized by default: every external image and inline base64
+// `data:` image is saved into `{outDir}/crawl/images/` and Markdown references
+// are rewritten to relative paths, so the corpus is self-contained for
+// renderers that can't fetch external URLs (Claude Design, offline previews,
+// packaged corpora). Pass `--external-images` to keep external URLs as-is and
+// drop inline data images to a placeholder instead.
 //
 // `--seeds` lets the caller supply explicit starting URLs for BFS. Use it for
 // SPA/SSG sites whose sidebar nav is client-rendered and so the default
 // `[rootUrl]` queue would miss pages that aren't linked from the root HTML.
-//
-// `--download-images` downloads every external image into
-// `{outDir}/crawl/images/` and rewrites Markdown references to relative
-// paths. Use this for renderers that can't fetch external URLs (Claude
-// Design, offline previews, packaged corpora).
 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join, resolve } from "node:path"
+import { join } from "node:path"
+import { parseArgs } from "./crawl/args"
 import { discoverUrls } from "./crawl/discover"
 import { htmlToMarkdown } from "./crawl/extract"
 import {
@@ -39,8 +41,11 @@ import {
 } from "./crawl/corpus"
 import {
   downloadAllImages,
+  extractDataUris,
   extractImageUrls,
+  INLINE_IMAGE_PLACEHOLDER,
   rewriteImageUrls,
+  saveDataUris,
 } from "./crawl/images"
 import type { CrawlOptions, PageResult } from "./crawl/types"
 
@@ -51,86 +56,6 @@ const USER_AGENT =
 const MIN_CONTENT_CHARS = 200
 const MAX_PAGES = 200
 const CONCURRENCY = 5
-
-interface CliArgs {
-  url: string
-  outDir: string
-  seeds: Array<string>
-  downloadImages: boolean
-}
-
-function parseArgs(argv: Array<string>): CliArgs {
-  const args = argv.slice(2)
-  let url = ""
-  let outDir = ""
-  let seedsRaw = ""
-  let downloadImages = false
-  const extraPositionals: Array<string> = []
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
-    if (arg === "--out") {
-      outDir = args[i + 1] ?? ""
-      i++
-    } else if (arg === "--seeds") {
-      seedsRaw = args[i + 1] ?? ""
-      i++
-    } else if (arg === "--download-images") {
-      downloadImages = true
-    } else if (arg.startsWith("--")) {
-      // Unknown flag — ignored.
-    } else if (!url) {
-      url = arg
-    } else {
-      // A second positional argument. The crawler takes exactly one URL; the
-      // sitemap is discovered automatically, so a sitemap URL passed here is a
-      // no-op. Collect it to warn rather than dropping it silently.
-      extraPositionals.push(arg)
-    }
-  }
-  if (!url) {
-    console.error(
-      "Usage: tsx crawl.ts <docs-site-url> [--out <dir>] [--seeds <url1,url2,...>] [--download-images]",
-    )
-    process.exit(1)
-  }
-  if (extraPositionals.length > 0) {
-    console.warn(
-      `[crawl] Ignoring extra argument(s): ${extraPositionals.join(", ")} — ` +
-        `the crawler uses only the first URL; the sitemap is found automatically.`,
-    )
-  }
-  let host = ""
-  let origin = ""
-  try {
-    const parsed = new URL(url)
-    host = parsed.host
-    origin = parsed.origin
-  } catch {
-    console.error(`[crawl] Invalid URL: ${url}`)
-    process.exit(1)
-  }
-  // Parse seeds: comma-separated, trim whitespace, resolve relatives against
-  // the site origin, and drop anything malformed.
-  const seeds = seedsRaw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      try {
-        return new URL(s, origin).toString()
-      } catch {
-        console.warn(`[crawl] Ignoring malformed seed URL: ${s}`)
-        return ""
-      }
-    })
-    .filter((s) => s.length > 0)
-  return {
-    url,
-    outDir: resolve(outDir || `./${host}-docs`),
-    seeds,
-    downloadImages,
-  }
-}
 
 /** Run `fn` over `items` with a fixed concurrency ceiling, preserving order. */
 async function mapLimit<T, R>(
@@ -238,11 +163,11 @@ async function main(): Promise<void> {
       `[crawl] Using ${seeds.length} explicit seed URL(s); sitemap discovery skipped`,
     )
   }
-  if (downloadImages) {
-    console.log(
-      `[crawl] Image downloading enabled — external images will be saved to crawl/images/`,
-    )
-  }
+  console.log(
+    downloadImages
+      ? `[crawl] Localizing images into crawl/images/ (pass --external-images to keep external URLs)`
+      : `[crawl] Keeping external image URLs (--external-images); inline data: images dropped to a placeholder`,
+  )
   console.log(`[crawl] Discovering pages from ${url} ...`)
   const urls = await discoverUrls(url, options)
   if (urls.length === 0) {
@@ -270,36 +195,64 @@ async function main(): Promise<void> {
   const crawledAt = new Date().toISOString()
   const okPages = pages.filter((page) => page.status === "ok")
 
-  // Optionally localize external images. Pages' Markdown still holds the raw
-  // external URLs at this point; we collect them, download in parallel into
-  // `crawl/images/`, then rewrite each page's Markdown with a per-output
-  // relative prefix below.
-  let imageMap: Map<string, string> = new Map()
-  if (downloadImages && okPages.length > 0) {
-    const allUrls = okPages.flatMap((page) => extractImageUrls(page.markdown))
-    const unique = Array.from(new Set(allUrls))
-    if (unique.length > 0) {
+  // Localize images so the corpus is self-contained. Two maps drive the rewrite
+  // below: `localized` maps an external URL or base64 data: URI to a file saved
+  // in `crawl/images/` (rewritten with a relative prefix), and `placeholders`
+  // maps a data: URI we won't keep to the bare INLINE_IMAGE_PLACEHOLDER (no
+  // prefix). With --external-images we download nothing, leave http(s) URLs
+  // untouched, and only collapse inline data: images to the placeholder.
+  const localized = new Map<string, string>()
+  const placeholders = new Map<string, string>()
+  if (okPages.length > 0) {
+    const httpUrls = Array.from(
+      new Set(okPages.flatMap((page) => extractImageUrls(page.markdown))),
+    )
+    const dataUris = Array.from(
+      new Set(okPages.flatMap((page) => extractDataUris(page.markdown))),
+    )
+    if (downloadImages && (httpUrls.length > 0 || dataUris.length > 0)) {
       const imagesDir = join(outDir, "crawl", "images")
       rmSync(imagesDir, { recursive: true, force: true })
       mkdirSync(imagesDir, { recursive: true })
-      console.log(
-        `[crawl] Downloading ${unique.length} unique image(s) into crawl/images/ ...`,
-      )
-      const reportEvery = Math.max(1, Math.floor(unique.length / 10))
-      imageMap = await downloadAllImages(
-        unique,
-        imagesDir,
-        USER_AGENT,
-        CONCURRENCY,
-        (done, total) => {
-          if (done === total || done % reportEvery === 0) {
-            console.log(`[crawl]   images ${done}/${total}`)
-          }
-        },
-      )
-      console.log(
-        `[crawl] Images: ${imageMap.size} downloaded, ${unique.length - imageMap.size} failed`,
-      )
+      if (httpUrls.length > 0) {
+        console.log(
+          `[crawl] Downloading ${httpUrls.length} external image(s) into crawl/images/ ...`,
+        )
+        const reportEvery = Math.max(1, Math.floor(httpUrls.length / 10))
+        const httpMap = await downloadAllImages(
+          httpUrls,
+          imagesDir,
+          USER_AGENT,
+          CONCURRENCY,
+          (done, total) => {
+            if (done === total || done % reportEvery === 0) {
+              console.log(`[crawl]   images ${done}/${total}`)
+            }
+          },
+        )
+        for (const [uri, name] of httpMap) localized.set(uri, name)
+        console.log(
+          `[crawl] External images: ${httpMap.size} downloaded, ${httpUrls.length - httpMap.size} failed`,
+        )
+      }
+      if (dataUris.length > 0) {
+        const dataMap = saveDataUris(dataUris, imagesDir)
+        for (const [uri, name] of dataMap) localized.set(uri, name)
+        // Inline images we couldn't decode collapse to the placeholder so raw
+        // base64 never reaches the corpus.
+        for (const uri of dataUris) {
+          if (!dataMap.has(uri)) placeholders.set(uri, INLINE_IMAGE_PLACEHOLDER)
+        }
+        console.log(
+          `[crawl] Inline images: ${dataMap.size}/${dataUris.length} saved to crawl/images/`,
+        )
+      }
+    } else if (!downloadImages) {
+      // External-images mode: http(s) URLs stay external; inline data: images
+      // are still stripped so base64 never bloats the corpus.
+      for (const uri of dataUris) {
+        placeholders.set(uri, INLINE_IMAGE_PLACEHOLDER)
+      }
     }
   }
 
@@ -310,14 +263,23 @@ async function main(): Promise<void> {
   rmSync(pagesDir, { recursive: true, force: true })
   mkdirSync(pagesDir, { recursive: true })
   const fileNames = new Map<string, string>()
-  // Two rewrite prefixes for the two output depths:
+  // Rewrite localized references with the per-depth relative prefix, then strip
+  // placeholder data: URIs with an empty prefix:
   //   - corpus.md lives at outDir/ → uses `crawl/images/`
   //   - page files live at outDir/crawl/pages/ → uses `../images/`
-  // When `--download-images` is off, imageMap is empty so rewrite is a no-op.
+  // Empty maps make either rewrite a no-op.
   const rewritePage = (md: string): string =>
-    rewriteImageUrls(md, imageMap, "../images/")
+    rewriteImageUrls(
+      rewriteImageUrls(md, localized, "../images/"),
+      placeholders,
+      "",
+    )
   const rewriteCorpus = (md: string): string =>
-    rewriteImageUrls(md, imageMap, "crawl/images/")
+    rewriteImageUrls(
+      rewriteImageUrls(md, localized, "crawl/images/"),
+      placeholders,
+      "",
+    )
   okPages.forEach((page, index) => {
     const fileName = pageFileName(page.url, index)
     fileNames.set(page.url, `crawl/pages/${fileName}`)

--- a/.claude/skills/docs-crawler/scripts/crawl.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl.ts
@@ -210,10 +210,15 @@ async function main(): Promise<void> {
     const dataUris = Array.from(
       new Set(okPages.flatMap((page) => extractDataUris(page.markdown))),
     )
-    if (downloadImages && (httpUrls.length > 0 || dataUris.length > 0)) {
+    if (downloadImages) {
       const imagesDir = join(outDir, "crawl", "images")
+      // Always wipe first so a re-run never leaves stale images from a prior
+      // crawl (e.g. an image that disappeared when the page set changed);
+      // recreate the directory only when there is something to save.
       rmSync(imagesDir, { recursive: true, force: true })
-      mkdirSync(imagesDir, { recursive: true })
+      if (httpUrls.length > 0 || dataUris.length > 0) {
+        mkdirSync(imagesDir, { recursive: true })
+      }
       if (httpUrls.length > 0) {
         console.log(
           `[crawl] Downloading ${httpUrls.length} external image(s) into crawl/images/ ...`,
@@ -247,7 +252,7 @@ async function main(): Promise<void> {
           `[crawl] Inline images: ${dataMap.size}/${dataUris.length} saved to crawl/images/`,
         )
       }
-    } else if (!downloadImages) {
+    } else {
       // External-images mode: http(s) URLs stay external; inline data: images
       // are still stripped so base64 never bloats the corpus.
       for (const uri of dataUris) {

--- a/.claude/skills/docs-crawler/scripts/crawl/args.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/args.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { parseArgs } from "./args"
+
+// parseArgs reads from a full argv array (it slices off the first two entries,
+// mirroring process.argv), so each case prepends two placeholder entries.
+const argv = (...rest: Array<string>): Array<string> => ["node", "crawl", ...rest]
+
+describe("parseArgs", () => {
+  it("localizes images by default", () => {
+    expect(parseArgs(argv("https://x.com")).downloadImages).toBe(true)
+  })
+
+  it("--external-images opts out of downloading", () => {
+    expect(
+      parseArgs(argv("https://x.com", "--external-images")).downloadImages,
+    ).toBe(false)
+  })
+
+  it("accepts --download-images as a no-op backward-compatible alias", () => {
+    expect(
+      parseArgs(argv("https://x.com", "--download-images")).downloadImages,
+    ).toBe(true)
+  })
+
+  it("applies the download flags in order (last wins)", () => {
+    expect(
+      parseArgs(argv("https://x.com", "--download-images", "--external-images"))
+        .downloadImages,
+    ).toBe(false)
+    expect(
+      parseArgs(argv("https://x.com", "--external-images", "--download-images"))
+        .downloadImages,
+    ).toBe(true)
+  })
+
+  it("parses --out into an absolute path", () => {
+    const { outDir } = parseArgs(argv("https://x.com", "--out", "./foo"))
+    expect(outDir.endsWith("foo")).toBe(true)
+    expect(outDir).not.toBe("./foo") // resolved to absolute
+  })
+
+  it("parses comma-separated --seeds resolved against the site origin", () => {
+    const { seeds } = parseArgs(argv("https://x.com/docs", "--seeds", "/a, /b"))
+    expect(seeds).toEqual(["https://x.com/a", "https://x.com/b"])
+  })
+
+  it("captures the first positional as the site URL", () => {
+    expect(parseArgs(argv("https://x.com/start")).url).toBe(
+      "https://x.com/start",
+    )
+  })
+})

--- a/.claude/skills/docs-crawler/scripts/crawl/args.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/args.ts
@@ -1,0 +1,91 @@
+// CLI argument parsing for the docs crawler. Kept in its own module so it can
+// be unit-tested directly: importing crawl.ts would run its top-level `main()`
+// and kick off a real crawl, so the parser lives here instead.
+
+import { resolve } from "node:path"
+
+export interface CliArgs {
+  url: string
+  outDir: string
+  seeds: Array<string>
+  downloadImages: boolean
+}
+
+export function parseArgs(argv: Array<string>): CliArgs {
+  const args = argv.slice(2)
+  let url = ""
+  let outDir = ""
+  let seedsRaw = ""
+  // Images are localized by default so the corpus is self-contained (renderers
+  // like Claude Design can't reach external URLs). Callers opt back into raw
+  // external URLs with --external-images. --download-images is still accepted
+  // as a now-redundant backward-compatible alias.
+  let downloadImages = true
+  const extraPositionals: Array<string> = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === "--out") {
+      outDir = args[i + 1] ?? ""
+      i++
+    } else if (arg === "--seeds") {
+      seedsRaw = args[i + 1] ?? ""
+      i++
+    } else if (arg === "--external-images" || arg === "--no-download-images") {
+      downloadImages = false
+    } else if (arg === "--download-images") {
+      downloadImages = true
+    } else if (arg.startsWith("--")) {
+      // Unknown flag — ignored.
+    } else if (!url) {
+      url = arg
+    } else {
+      // A second positional argument. The crawler takes exactly one URL; the
+      // sitemap is discovered automatically, so a sitemap URL passed here is a
+      // no-op. Collect it to warn rather than dropping it silently.
+      extraPositionals.push(arg)
+    }
+  }
+  if (!url) {
+    console.error(
+      "Usage: tsx crawl.ts <docs-site-url> [--out <dir>] [--seeds <url1,url2,...>] [--external-images]",
+    )
+    process.exit(1)
+  }
+  if (extraPositionals.length > 0) {
+    console.warn(
+      `[crawl] Ignoring extra argument(s): ${extraPositionals.join(", ")} — ` +
+        `the crawler uses only the first URL; the sitemap is found automatically.`,
+    )
+  }
+  let host = ""
+  let origin = ""
+  try {
+    const parsed = new URL(url)
+    host = parsed.host
+    origin = parsed.origin
+  } catch {
+    console.error(`[crawl] Invalid URL: ${url}`)
+    process.exit(1)
+  }
+  // Parse seeds: comma-separated, trim whitespace, resolve relatives against
+  // the site origin, and drop anything malformed.
+  const seeds = seedsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      try {
+        return new URL(s, origin).toString()
+      } catch {
+        console.warn(`[crawl] Ignoring malformed seed URL: ${s}`)
+        return ""
+      }
+    })
+    .filter((s) => s.length > 0)
+  return {
+    url,
+    outDir: resolve(outDir || `./${host}-docs`),
+    seeds,
+    downloadImages,
+  }
+}

--- a/.claude/skills/docs-crawler/scripts/crawl/args.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/args.ts
@@ -30,7 +30,7 @@ export function parseArgs(argv: Array<string>): CliArgs {
     } else if (arg === "--seeds") {
       seedsRaw = args[i + 1] ?? ""
       i++
-    } else if (arg === "--external-images" || arg === "--no-download-images") {
+    } else if (arg === "--external-images") {
       downloadImages = false
     } else if (arg === "--download-images") {
       downloadImages = true

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
@@ -75,24 +75,45 @@ describe("htmlToMarkdown", () => {
     )
   })
 
-  it("replaces inline data-URI images with a placeholder, keeping alt text", () => {
+  it("keeps base64 data-URI images so the crawler can localize them", () => {
     const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
-    // A data: URI is an embedded blob, not a link — its base64 payload must
-    // not leak into the corpus, where it is unreadable noise for an LLM.
-    expect(result.markdown).not.toContain("data:image")
-    // The alt text is the meaningful part and is preserved.
+    // A base64 data URI has no spaces or parens, so it is safe inside markdown
+    // link syntax. Extraction preserves it; crawl.ts later decodes it into a
+    // local file (or, with --external-images, collapses it to a placeholder).
     expect(result.markdown).toContain(
-      "![Inline status icon](inline-image-omitted)",
+      "![Inline status icon](data:image/svg+xml;base64,PHN2Zy8+)",
     )
   })
 
-  it("preserves the title attribute on inline data-URI images", () => {
+  it("preserves alt and title on base64 data-URI images", () => {
     const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
-    // A data: URI image must render exactly like any other image apart from
-    // the src — including the optional title attribute.
     expect(result.markdown).toContain(
-      '![Chart](inline-image-omitted "Quarterly chart")',
+      '![Chart](data:image/svg+xml;base64,PHN2Zy8+ "Quarterly chart")',
     )
+  })
+
+  it("replaces non-base64 data-URI images with a placeholder", () => {
+    // Percent-encoded (non-base64) data URIs can contain spaces/parens that
+    // break markdown link syntax, so they are dropped to a placeholder.
+    const page = `<!doctype html>
+<html lang="en">
+  <head><title>Inline SVG page</title></head>
+  <body>
+    <article>
+      <h1>Heading</h1>
+      <p>The accordion component groups related content into collapsible
+      sections so that long reference pages stay scannable without burying the
+      reader under every detail at once. Each section header toggles its panel.</p>
+      <p>Use it sparingly: collapsing content the reader almost always needs
+      adds a click for no benefit, and search engines may not index text that
+      is hidden behind an interaction on first paint.</p>
+      <img src="data:image/svg+xml,%3Csvg viewBox=%220 0 1 1%22%3E%3C/svg%3E" alt="Raw inline svg">
+    </article>
+  </body>
+</html>`
+    const result = htmlToMarkdown(page, "https://ds.example.com/accordion")
+    expect(result.markdown).not.toContain("data:image/svg+xml,")
+    expect(result.markdown).toContain("![Raw inline svg](inline-image-omitted)")
   })
 
   it("resolves relative links to absolute URLs", () => {

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.ts
@@ -92,11 +92,14 @@ export function htmlToMarkdown(html: string, pageUrl: string): ExtractResult {
     const article = new Readability(doc).parse()
     // Keep base64 `data:` image sources (the crawler decodes them into local
     // files), but replace non-base64 data URIs with a placeholder so their raw,
-    // possibly syntax-breaking payloads never reach the corpus. Rewriting
+    // possibly syntax-breaking payloads never reach the corpus. The `(?<![\w-])`
+    // lookbehind scopes the match to a standalone `src` attribute so we never
+    // clobber `data-src` and similar lazy-load attributes (a `\b` would not —
+    // there is a word boundary between the `-` and `src`). Rewriting
     // Readability's output (not the input DOM) keeps it ahead of Turndown so the
     // built-in image rule still renders alt/title.
     const contentHtml = (article?.content ?? "").replace(
-      /src="(data:[^"]*)"/gi,
+      /(?<![\w-])src="(data:[^"]*)"/gi,
       (whole, uri: string) =>
         isBase64ImageDataUri(uri) ? whole : `src="${INLINE_IMAGE_PLACEHOLDER}"`,
     )

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.ts
@@ -3,10 +3,15 @@
 import { JSDOM } from "jsdom"
 import { Readability } from "@mozilla/readability"
 import TurndownService from "turndown"
+import { INLINE_IMAGE_PLACEHOLDER, isBase64ImageDataUri } from "./images"
 
 export interface ExtractResult {
   title: string
-  /** Clean Markdown of the main content, images kept as external URLs. */
+  /**
+   * Clean Markdown of the main content. External images stay as absolute URLs
+   * and base64 `data:` images are preserved inline; the crawler localizes both
+   * afterward. Non-base64 data URIs are dropped to a placeholder here.
+   */
   markdown: string
   /** Length of extracted plain text — used to detect JS-shell pages. */
   chars: number
@@ -56,10 +61,6 @@ function preprocessDom(doc: Document): void {
   }
 }
 
-// Placeholder substituted for inline `data:` URI image sources — see
-// htmlToMarkdown for the rewrite and its rationale.
-const DATA_URI_PLACEHOLDER = "inline-image-omitted"
-
 function createTurndown(): TurndownService {
   return new TurndownService({
     headingStyle: "atx",
@@ -76,8 +77,10 @@ function createTurndown(): TurndownService {
  * `preprocessDom` runs first to drop doc-site chrome and repair code blocks.
  * Readability then strips nav/sidebar/footer chrome and, because the JSDOM is
  * constructed with the real page URL, rewrites relative `href`/`src` to
- * absolute URLs — so images end up as their original external links rather
- * than being downloaded.
+ * absolute URLs — so external images end up as their original links. Base64
+ * `data:` images are preserved inline (the crawler localizes them later);
+ * non-base64 data URIs are dropped to a placeholder because their payloads can
+ * contain characters that break markdown link syntax.
  */
 export function htmlToMarkdown(html: string, pageUrl: string): ExtractResult {
   const dom = new JSDOM(html, { url: pageUrl })
@@ -87,14 +90,15 @@ export function htmlToMarkdown(html: string, pageUrl: string): ExtractResult {
     const fallbackTitle = doc.title.trim() || pageUrl
 
     const article = new Readability(doc).parse()
-    // Replace inline `data:` URI image sources with a placeholder. A data: URI
-    // embeds the image as a base64 blob that would flood the corpus with bytes
-    // an LLM cannot read. Rewriting Readability's output (not the input DOM)
-    // avoids the placeholder being resolved into a bogus absolute URL, and
-    // keeps it ahead of Turndown so the built-in image rule renders alt/title.
+    // Keep base64 `data:` image sources (the crawler decodes them into local
+    // files), but replace non-base64 data URIs with a placeholder so their raw,
+    // possibly syntax-breaking payloads never reach the corpus. Rewriting
+    // Readability's output (not the input DOM) keeps it ahead of Turndown so the
+    // built-in image rule still renders alt/title.
     const contentHtml = (article?.content ?? "").replace(
-      /src="data:[^"]*"/gi,
-      `src="${DATA_URI_PLACEHOLDER}"`,
+      /src="(data:[^"]*)"/gi,
+      (whole, uri: string) =>
+        isBase64ImageDataUri(uri) ? whole : `src="${INLINE_IMAGE_PLACEHOLDER}"`,
     )
     const markdown = contentHtml
       ? createTurndown().turndown(contentHtml).trim()

--- a/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
@@ -232,4 +232,16 @@ describe("saveDataUris", () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it("skips inline images whose write fails instead of throwing", () => {
+    // Writing into a directory whose parent does not exist makes writeFileSync
+    // throw; saveDataUris must swallow it and omit the image, never abort the
+    // crawl (mirrors downloadImage's resilience).
+    const missingDir = join(tmpdir(), "docs-crawler-missing-zzz", "nested")
+    const result = saveDataUris(
+      ["data:image/svg+xml;base64,PHN2Zy8+"],
+      missingDir,
+    )
+    expect(result.size).toBe(0)
+  })
 })

--- a/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
@@ -1,8 +1,16 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
+  decodeDataUri,
+  extractDataUris,
   extractImageUrls,
+  INLINE_IMAGE_PLACEHOLDER,
+  localDataUriName,
   localImageName,
   rewriteImageUrls,
+  saveDataUris,
 } from "./images"
 
 describe("extractImageUrls", () => {
@@ -124,5 +132,104 @@ describe("rewriteImageUrls", () => {
     expect(rewriteImageUrls(md, map, "crawl/images/")).toBe(
       `![alt](crawl/images/aa00-a.png "title (something)")`,
     )
+  })
+
+  it("rewrites mapped data: URIs like any other image", () => {
+    // Localized inline images join the same map; rewrite must handle them too.
+    const dataMap = new Map([["data:image/png;base64,AAAA", "cc22.png"]])
+    const md = `![icon](data:image/png;base64,AAAA)`
+    expect(rewriteImageUrls(md, dataMap, "crawl/images/")).toBe(
+      "![icon](crawl/images/cc22.png)",
+    )
+  })
+
+  it("strips a data: URI to the bare placeholder with an empty prefix", () => {
+    // External-images mode collapses inline data URIs via an empty-prefix
+    // rewrite so no `crawl/images/` path is prepended to the placeholder.
+    const phMap = new Map([
+      ["data:image/png;base64,AAAA", INLINE_IMAGE_PLACEHOLDER],
+    ])
+    const md = `![icon](data:image/png;base64,AAAA)`
+    expect(rewriteImageUrls(md, phMap, "")).toBe(
+      `![icon](${INLINE_IMAGE_PLACEHOLDER})`,
+    )
+  })
+})
+
+describe("extractDataUris", () => {
+  it("collects base64 data: image URIs, keeping the full URI", () => {
+    const md = `
+![icon](data:image/svg+xml;base64,PHN2Zy8+)
+inline ![png](data:image/png;base64,AAAA "t") end
+`
+    expect(extractDataUris(md)).toEqual([
+      "data:image/svg+xml;base64,PHN2Zy8+",
+      "data:image/png;base64,AAAA",
+    ])
+  })
+
+  it("ignores http(s) and relative image URLs", () => {
+    const md = `![a](https://x.com/a.png) ![b](./b.png)`
+    expect(extractDataUris(md)).toEqual([])
+  })
+
+  it("ignores non-base64 data URIs", () => {
+    const md = `![a](data:image/svg+xml,%3Csvg%3E)`
+    expect(extractDataUris(md)).toEqual([])
+  })
+})
+
+describe("decodeDataUri", () => {
+  it("decodes a base64 image into a buffer with a mapped extension", () => {
+    const out = decodeDataUri("data:image/svg+xml;base64,PHN2Zy8+")
+    expect(out).not.toBeNull()
+    expect(out?.ext).toBe(".svg")
+    expect(out?.buffer.toString("utf8")).toBe("<svg/>")
+  })
+
+  it("maps common image MIME types to extensions", () => {
+    expect(decodeDataUri("data:image/png;base64,AAAA")?.ext).toBe(".png")
+    expect(decodeDataUri("data:image/jpeg;base64,AAAA")?.ext).toBe(".jpg")
+    expect(decodeDataUri("data:image/webp;base64,AAAA")?.ext).toBe(".webp")
+  })
+
+  it("returns null for non-base64, empty, or non-image data URIs", () => {
+    expect(decodeDataUri("data:image/png,rawtext")).toBeNull()
+    expect(decodeDataUri("data:image/png;base64,")).toBeNull()
+    expect(decodeDataUri("data:application/json;base64,e30=")).toBeNull()
+    expect(decodeDataUri("https://x.com/a.png")).toBeNull()
+  })
+})
+
+describe("localDataUriName", () => {
+  it("is deterministic and derives the extension from the MIME type", () => {
+    const uri = "data:image/png;base64,AAAA"
+    expect(localDataUriName(uri)).toBe(localDataUriName(uri))
+    expect(localDataUriName(uri)).toMatch(/^[0-9a-f]{8}\.png$/)
+  })
+
+  it("gives different names to different payloads", () => {
+    expect(localDataUriName("data:image/png;base64,AAAA")).not.toBe(
+      localDataUriName("data:image/png;base64,BBBB"),
+    )
+  })
+})
+
+describe("saveDataUris", () => {
+  it("writes decoded images to disk and returns a URI→filename map", () => {
+    const dir = mkdtempSync(join(tmpdir(), "docs-crawler-test-"))
+    try {
+      const uris = [
+        "data:image/svg+xml;base64,PHN2Zy8+",
+        "data:image/png;base64,", // undecodable → omitted from the map
+      ]
+      const result = saveDataUris(uris, dir)
+      expect(result.size).toBe(1)
+      const name = result.get("data:image/svg+xml;base64,PHN2Zy8+")
+      expect(name).toMatch(/^[0-9a-f]{8}\.svg$/)
+      expect(readFileSync(join(dir, name as string), "utf8")).toBe("<svg/>")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/.claude/skills/docs-crawler/scripts/crawl/images.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.ts
@@ -1,17 +1,41 @@
-// External-image localization: extract image URLs from extracted Markdown,
-// download them next to the corpus, and rewrite the Markdown to reference
-// the local copies. Pure helpers stay deterministic; only `downloadImage`
-// performs I/O.
+// Image localization: extract image references from extracted Markdown,
+// download external images (and decode inline base64 `data:` images) next to
+// the corpus, and rewrite the Markdown to reference the local copies. Pure
+// helpers stay deterministic; only `downloadImage` and `saveDataUris` do I/O.
 
 import { createHash } from "node:crypto"
 import { writeFileSync } from "node:fs"
 import { join } from "node:path"
 
-// Markdown image syntax: ![alt](url "optional title")
-// The url group is non-greedy and stops at the first space (title) or `)`.
-// We then filter to absolute http(s) URLs since relative paths are already
-// either local or unreachable.
+// Markdown image syntax: ![alt](url "optional title"). The url group is
+// non-greedy and stops at the first space (title) or `)`. Callers decide which
+// captured URLs they care about (http(s) externals vs base64 `data:` URIs).
 const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\((\S+?)(?:\s+"[^"]*")?\)/g
+
+// Substituted for inline images that cannot be turned into a local file (a
+// non-base64 data URI, or one whose bytes failed to decode). Exported so
+// extract.ts shares a single source of truth for the placeholder string.
+export const INLINE_IMAGE_PLACEHOLDER = "inline-image-omitted"
+
+// A base64 `data:` image URI: `data:<image-mime>;base64,<payload>`. The base64
+// payload has no spaces, parens, or quotes, so it is safe to capture from and
+// rewrite within markdown link syntax. Non-base64 (percent-encoded) data URIs
+// are excluded — they can contain characters that break that syntax.
+const DATA_URI_RE = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=]+)$/i
+
+// Allowlist of inline-image MIME types we localize, mapped to a file extension.
+const DATA_URI_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/gif": ".gif",
+  "image/svg+xml": ".svg",
+  "image/webp": ".webp",
+  "image/avif": ".avif",
+  "image/x-icon": ".ico",
+  "image/vnd.microsoft.icon": ".ico",
+  "image/bmp": ".bmp",
+}
 
 /** Pull every absolute http(s) image URL out of a Markdown string. Pure. */
 export function extractImageUrls(markdown: string): Array<string> {
@@ -23,6 +47,27 @@ export function extractImageUrls(markdown: string): Array<string> {
     urls.push(url)
   }
   return urls
+}
+
+/**
+ * Whether `value` is a base64 `data:` image URI — safe to carry through markdown
+ * link syntax and a candidate for localization. extract.ts shares this predicate
+ * so the data URIs it preserves are exactly the ones the crawler later collects,
+ * leaving no raw base64 unaccounted for in the corpus. Pure.
+ */
+export function isBase64ImageDataUri(value: string): boolean {
+  return DATA_URI_RE.test(value)
+}
+
+/** Pull every base64 `data:` image URI out of a Markdown string. Pure. */
+export function extractDataUris(markdown: string): Array<string> {
+  const uris: Array<string> = []
+  for (const match of markdown.matchAll(MARKDOWN_IMAGE_RE)) {
+    const url = match[1]
+    if (!url) continue
+    if (isBase64ImageDataUri(url)) uris.push(url)
+  }
+  return uris
 }
 
 /**
@@ -60,10 +105,59 @@ export function localImageName(url: string): string {
 }
 
 /**
- * Rewrite every absolute http(s) image URL in `markdown` to the mapped local
- * filename, prefixed with `pathPrefix`. URLs not in the map are left alone
- * (e.g. download failures should keep the original reference so the page is
- * still navigable). Pure.
+ * Decode a base64 `data:` image URI into its bytes plus a MIME-derived file
+ * extension. Returns null when the URI is not a base64 image, has an
+ * unsupported MIME type, or decodes to nothing. Pure.
+ */
+export function decodeDataUri(
+  uri: string,
+): { buffer: Buffer; ext: string } | null {
+  const match = DATA_URI_RE.exec(uri)
+  if (!match) return null
+  const ext = DATA_URI_EXT[match[1].toLowerCase()]
+  if (!ext) return null
+  const buffer = Buffer.from(match[2], "base64")
+  if (buffer.length === 0) return null
+  return { buffer, ext }
+}
+
+/**
+ * Map a base64 `data:` URI to a stable local filename: an 8-char SHA1 prefix of
+ * the full URI plus the MIME-derived extension. Different payloads hash to
+ * different names. Pure.
+ */
+export function localDataUriName(uri: string): string {
+  const hash = createHash("sha1").update(uri).digest("hex").slice(0, 8)
+  const match = DATA_URI_RE.exec(uri)
+  const ext = match ? (DATA_URI_EXT[match[1].toLowerCase()] ?? "") : ""
+  return `${hash}${ext}`
+}
+
+/**
+ * Decode each base64 `data:` URI and write it into `imagesDir`, returning a map
+ * of URI → local filename for the ones that decoded. Undecodable URIs are
+ * omitted so the caller can collapse them to INLINE_IMAGE_PLACEHOLDER instead.
+ */
+export function saveDataUris(
+  uris: Array<string>,
+  imagesDir: string,
+): Map<string, string> {
+  const result = new Map<string, string>()
+  for (const uri of Array.from(new Set(uris))) {
+    const decoded = decodeDataUri(uri)
+    if (!decoded) continue
+    const name = localDataUriName(uri)
+    writeFileSync(join(imagesDir, name), decoded.buffer)
+    result.set(uri, name)
+  }
+  return result
+}
+
+/**
+ * Rewrite every mapped image reference in `markdown` to the mapped local
+ * filename, prefixed with `pathPrefix`. References not in the map are left
+ * alone (e.g. download failures keep the original URL so the page is still
+ * navigable). Handles http(s) URLs and base64 `data:` URIs alike. Pure.
  */
 export function rewriteImageUrls(
   markdown: string,
@@ -71,7 +165,6 @@ export function rewriteImageUrls(
   pathPrefix: string,
 ): string {
   return markdown.replace(MARKDOWN_IMAGE_RE, (whole, rawUrl: string) => {
-    if (!/^https?:\/\//i.test(rawUrl)) return whole
     const local = urlToLocal.get(rawUrl)
     if (!local) return whole
     // Anchor on the alt-text closing `]` to find the URL group's opening `(`.

--- a/.claude/skills/docs-crawler/scripts/crawl/images.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.ts
@@ -135,8 +135,9 @@ export function localDataUriName(uri: string): string {
 
 /**
  * Decode each base64 `data:` URI and write it into `imagesDir`, returning a map
- * of URI → local filename for the ones that decoded. Undecodable URIs are
- * omitted so the caller can collapse them to INLINE_IMAGE_PLACEHOLDER instead.
+ * of URI → local filename for the ones that succeeded. URIs that fail to decode
+ * or whose write throws are omitted so the caller can collapse them to
+ * INLINE_IMAGE_PLACEHOLDER instead.
  */
 export function saveDataUris(
   uris: Array<string>,
@@ -147,8 +148,14 @@ export function saveDataUris(
     const decoded = decodeDataUri(uri)
     if (!decoded) continue
     const name = localDataUriName(uri)
-    writeFileSync(join(imagesDir, name), decoded.buffer)
-    result.set(uri, name)
+    // Mirror downloadImage: an I/O failure (disk full, permissions, a bad
+    // path) must not abort the crawl — skip the image instead of throwing.
+    try {
+      writeFileSync(join(imagesDir, name), decoded.buffer)
+      result.set(uri, name)
+    } catch (error) {
+      console.warn(`[crawl] Failed to save inline image ${name}:`, error)
+    }
   }
   return result
 }

--- a/.claude/skills/docs-crawler/scripts/crawl/types.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/types.ts
@@ -15,11 +15,12 @@ export interface CrawlOptions {
    */
   seeds?: Array<string>
   /**
-   * When true, external image URLs in extracted Markdown are downloaded to
-   * `{outDir}/crawl/images/` and the Markdown is rewritten to reference them
-   * via relative paths. Off by default — most LLM corpora don't need binary
-   * payloads, but renderers that can't reach external URLs (Claude Design,
-   * offline previews) require local images.
+   * When true (the default), external images and inline base64 `data:` images
+   * in extracted Markdown are saved to `{outDir}/crawl/images/` and the Markdown
+   * is rewritten to reference them via relative paths, so the corpus is
+   * self-contained for renderers that can't reach external URLs (Claude Design,
+   * offline previews). Set false (`--external-images`) to keep external URLs
+   * as-is and drop inline data images to a placeholder.
    */
   downloadImages?: boolean
 }


### PR DESCRIPTION
## 변경 요약

`docs-crawler`가 크롤 시 외부 이미지와 인라인 base64 `data:` 이미지를 **기본으로** `crawl/images/`에 다운로드하고 마크다운을 상대경로로 재작성합니다. 코퍼스가 자기완결(self-contained)되어 **Claude Design 등 외부 URL을 못 가져오는 렌더러에서 막힘 없이** 쓰입니다. 외부 URL 유지가 필요하면 `--external-images`로 opt-out합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [ ] 사이트 코드/UI
- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등) — `SKILL.md` × 2, `evals.json`
- [x] `/design-md` 스킬 — 정확히는 **docs-crawler 엔진**(design-md 리서치 파이프라인이 호출) + design-md `SKILL.md` Stage 4b 동기화

## 카탈로그 PR 체크 (해당 시)

- 해당 없음 (카탈로그 항목 변경 아님)

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

---

## 상세

### 왜
크롤 산출물은 `.claude/cache/design-md/{slug}/`(gitignore)에 머무는 중간 리서치 아티팩트입니다. 그동안 이미지는 **외부 URL 그대로** 남아, 다운스트림 렌더러(Claude Design 등)가 코퍼스를 쓸 때 외부 네트워크에 의존해 "막힘"이 생겼습니다.

> 참고: 다운로드 인프라(`images.ts`의 URL 추출·병렬 다운로드·재작성)는 이미 `--download-images` 플래그로 존재했습니다. 이번 변경의 핵심은 **이를 기본값으로 켜고, 인라인 `data:` 이미지까지 확장**한 것입니다.

### Part A — 다운로드를 기본값으로
- `parseArgs`를 **`crawl/args.ts`로 분리**(이유: `crawl.ts`는 import 시 top-level `main()`이 실행되어 단위 테스트가 실제 크롤을 유발 → 분리해야 테스트 가능, 기존 무테스트 갭도 해소).
- `downloadImages` 기본값 `true`, **`--external-images`** opt-out 추가, `--download-images`는 하위호환 별칭(no-op).
- `pnpm crawl:docs`·design-md 호출부는 플래그 하드코딩이 없어 자동 적용.

### Part B — `data:` URI 로컬화 (base64)
- `extract.ts`: base64 `data:` 이미지는 마크다운에 **보존**(다운로드 모드와 무관), 비-base64(공백·괄호로 링크 문법을 깨뜨릴 수 있음)는 placeholder.
- `images.ts`: `decodeDataUri`/`localDataUriName`/`saveDataUris`/`extractDataUris` + 공유 술어 `isBase64ImageDataUri`(extract가 보존하는 집합 = 크롤러가 수집하는 집합 보장 → raw base64 누출 차단). `rewriteImageUrls`를 http·data 공용으로 일반화.
- `crawl.ts`: http(다운로드) + data(디코드) 맵을 병합 후 **이중 `rewriteImageUrls`** — 실파일은 상대경로 접두사(`crawl/images/`·`../images/`), 디코드 불가/opt-out `data:` URI는 placeholder(빈 접두사).

### 검증
- **단위 테스트 69 passed** — `args.test.ts`(신규 7), `images.test.ts`(+11: extractDataUris/decodeDataUri/localDataUriName/saveDataUris/data-URI rewrite), `extract.test.ts`(base64 보존·비-base64 placeholder).
- `pnpm typecheck && pnpm lint && pnpm build` 통과.
- **헤르메틱 통합 검증 6/6 PASS** — 샌드박스가 포트 리슨(`EACCES`)을 막아 실서버 크롤 대신, 픽스처 HTML을 실제 파이프라인(`htmlToMarkdown`→추출→`saveDataUris`→이중 rewrite)에 그대로 흘려보내 검증(실제 PNG 파일 기록 + 코퍼스 상대경로 + raw base64 잔존 0).

### 리뷰어 참고
- **포맷터**: 레포 `.prettierrc`는 `trailingComma: es5`이나 커밋된 코드(앱 `src/` 포함)는 사실상 "all" 스타일로 전역 드리프트 상태입니다. 편집 파일은 **기존 "all" 스타일에 맞춰** 작성했습니다(무관한 줄 churn 방지). `.claude/`는 eslint ignore라 CI lint 게이트 밖입니다. 포맷 마이그레이션은 별도 작업으로 남깁니다.
- **다운스트림 무영향**: 크롤 산출물은 gitignore된 캐시에 머무는 중간 아티팩트이고, `research-collector`는 텍스트 사실·페이지 URL만 인용(이미지 URL 미사용)이라 커밋되는 산출물(`services/*.md`·preview·OG)엔 파급이 없습니다.