### PR TITLE
ci: claude-code-review가 코멘트를 달도록 --allowedTools 추가

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # gh pr comment로 리뷰 코멘트 게시 (App 토큰 미가용 시 GITHUB_TOKEN 폴백 대비)
+      issues: write # PR 대화 코멘트는 issue 코멘트 API를 사용
       id-token: write # claude-code-action이 GitHub App 토큰 교환에 OIDC 사용 (필수)
 
     steps:
@@ -37,5 +37,9 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # 공식 플러그인 기본 출력은 영어 — 시스템 프롬프트로 한국어 강제
-          claude_args: '--append-system-prompt "리뷰 인라인 코멘트와 요약은 모두 한국어로 작성하세요."'
+          # 액션은 Bash·Task가 기본 비활성 — code-review 플러그인이 쓰는 gh/git/Task/Read를
+          # 명시 허용해야 서브에이전트 리뷰가 돌고 gh pr comment로 코멘트가 달린다.
+          # (append-system-prompt: 공식 플러그인 기본 출력 영어 → 한국어 강제)
+          claude_args: >-
+            --allowedTools "Task,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Bash(git diff:*),Read,Grep,Glob"
+            --append-system-prompt "리뷰 인라인 코멘트와 요약은 모두 한국어로 작성하세요."


### PR DESCRIPTION
## 문제
PR #92~#94에서 매 PR 자동 Claude 코드 리뷰 워크플로를 추가했지만, 리뷰 잡이 "성공"으로 끝나도 PR에 **코멘트가 전혀 달리지 않았다**.

## 원인 (실행 로그 증거 기반)
- `code-review@claude-code-plugins` 플러그인(`/code-review:code-review`)은 단계마다 **Task 서브에이전트**를 스폰하고 최종 **`gh pr comment`**로 요약 코멘트를 단다.
- 그러나 `claude-code-action`은 보안상 **`Bash`·`Task`가 기본 비활성**이다. 워크플로의 `claude_args`엔 `--append-system-prompt`만 있고 **`--allowedTools`가 없어** PR 조회(`gh pr diff`)·서브에이전트(`Task`)·코멘트 게시(`gh pr comment`)가 전부 거부됐다.
- #95(SOCAR) 실행 로그: `is_error:false`인데 **`permission_denials_count: 17`**, 마지막 단계 `No buffered inline comments`, 코멘트 0건.

## 수정
- `claude_args`에 `--allowedTools "Task,Bash(gh ...),Bash(git ...),Read,Grep,Glob"` 추가 — 플러그인의 멀티에이전트 리뷰가 돌고 `gh pr comment`로 코멘트가 달리게 함.
- `permissions`의 `pull-requests`·`issues`를 `write`로 승격 — App 토큰 미가용 시 `GITHUB_TOKEN` 폴백 대비(공식 예시와 동일).

## 검증
코멘트 인증은 OIDC→Claude GitHub App 토큰이 담당하며, **워크플로를 수정하는 PR은 App token 401로 실패하는 게 정상**(GitHub 보안 정책: 워크플로가 default 브랜치와 동일해야 토큰 발급).
- ⚠️ 따라서 **이 PR 자체의 `Claude Code Review` 잡 실패/스킵은 예상된 동작**.
- ✅ 진짜 검증은 **머지 후 다음 내부 PR**에서: `gh run view <id> --log | grep permission_denials_count`(0 기대) + 한국어 `### Code review` 코멘트 게시 확인.
