### PR TITLE
ci: claude-code-review를 자연어 단일 에이전트 방식으로 교체 (플러그인 → gh 코멘트)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,12 +34,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # 액션은 Bash·Task가 기본 비활성 — code-review 플러그인이 쓰는 gh/git/Task/Read를
-          # 명시 허용해야 서브에이전트 리뷰가 돌고 gh pr comment로 코멘트가 달린다.
-          # (append-system-prompt: 공식 플러그인 기본 출력 영어 → 한국어 강제)
-          claude_args: >-
-            --allowedTools "Task,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Bash(git diff:*),Read,Grep,Glob"
-            --append-system-prompt "리뷰 인라인 코멘트와 요약은 모두 한국어로 작성하세요."
+          # 블로그(CaesiumY.github.io)에서 검증된 자연어 단일 에이전트 리뷰 방식.
+          # 플러그인(멀티에이전트)은 헤드리스에서 서브에이전트 도구가 막혀 코멘트까지 도달 못 함
+          # → 자연어 프롬프트 + gh 도구로 교체. 단일 에이전트라 Task 상속 문제 없음.
+          prompt: |
+            이 풀 리퀘스트를 코드 리뷰하고 아래 관점으로 한국어 피드백을 주세요:
+            - 코드 품질과 베스트 프랙티스
+            - 잠재적 버그·이슈
+            - 성능 고려사항
+            - 보안 우려
+            - 레포 CLAUDE.md의 카탈로그/design.md 정책 준수 (해당 시)
+
+            레포의 CLAUDE.md를 스타일·컨벤션 가이드로 참고하고, 건설적이고 구체적으로 작성하세요.
+            리뷰는 `gh pr comment` (Bash 도구)로 PR에 코멘트로 남기세요. 모든 출력은 한국어로.
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## 문제
`/code-review` 플러그인 기반 자동 리뷰가 **실행은 성공인데 PR 코멘트가 안 달림**. #102에서 `--allowedTools`를 보강했지만(#103: denials 17→11→4) **여전히 코멘트 0건**.

## 진단 (모든 대안 가설 소거)
- **stale main 아님**: #103은 #102 머지(05:15) *뒤* 05:20에 생성, 두 런 모두 로그에 `--allowedTools` 확인.
- **콘텐츠 문제 아님**: 같은 #103에 **Gemini Code Assist는 리뷰 게시 성공** → 리뷰할 내용은 충분.
- **권한/tsconfig 에러 아님**: `permission_denials`는 도구-허용 레이어, `directory mismatch`는 액션의 무해 버그(잡 exit 0).
- **근본 원인**: `/code-review` 플러그인은 **Task 서브에이전트**로 멀티에이전트 리뷰를 돌리는데, claude-code-action 헤드리스에서 서브에이전트 도구 호출이 거부돼 **`gh pr comment` 게시까지 도달 못 함**.

## 해결: 검증된 레퍼런스 이식
블로그 레포 [`CaesiumY.github.io`](https://github.com/CaesiumY/CaesiumY.github.io/blob/main/.github/workflows/claude-code-review.yml)는 **동일 액션으로 잘 작동**합니다(예: [블로그 PR #57](https://github.com/CaesiumY/CaesiumY.github.io/pull/57)에서 `claude` 봇이 한국어 리뷰 게시). 차이는 **엔진**뿐 — 자연어 **단일 에이전트** 리뷰. 그 설정을 한국어화해 이식합니다.

### 변경
- ❌ 제거: `plugin_marketplaces`, `plugins: code-review@claude-code-plugins`, `prompt: /code-review:...`
- ✅ 추가: 자연어 한국어 리뷰 프롬프트 + **"`gh pr comment`로 코멘트 남겨라"** 명시 지시
- ✅ `--allowed-tools`를 **gh 읽기+코멘트 7종**으로 축소(`Task`/`git`/`Read` 제거)

### 왜 이게 되나
- **단일 에이전트** → Task 서브에이전트 권한 상속 문제 원천 제거 (denials ~0 기대)
- 프롬프트가 게시를 직접 지시 → **깨끗한 PR에도 항상 한국어 코멘트** (가시성 확보)
- 도구 표면 16종→7종(읽기+코멘트만) → **외부 크롤 콘텐츠 인젝션 표면 최소화**

하드닝(내부 PR 가드·concurrency·트리거)과 `permissions`는 유지.

## 검증
이 PR 자체는 워크플로 수정이라 App 토큰 401(정상)로 리뷰가 안 돕니다. **머지 후 다음 내부 PR**에서:
- `gh pr view <n> --json comments` → **`claude` 봇의 한국어 리뷰 코멘트** 게시 확인
- `gh run view <id> --log | grep permission_denials_count` → 0 기대
