### PR TITLE
docs(contributing): ephemeral/label-only 출처 컨벤션 명문화

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] `/design-md` 스킬로 생성
 - [ ] frontmatter 필수 필드 검증 완료 (`name`, `slug`, `category`, `last_updated`, `sources`, `related_services`, `lang`)
 - [ ] `public/preview/{slug}/{light,dark}.html` 생성·확인
-- [ ] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
+- [ ] `[src:N]` 인용이 `## References`와 정합 (공개 URL은 `sources`에; ephemeral 핸드오프 등은 References label-only — CONTRIBUTING.md §3 참조)
 - [ ] 브랜드 자산 라이선스/상표 우려 검토 ([NOTICE](https://github.com/CaesiumY/ko-design-md/blob/main/NOTICE) 정책)
 - [ ] 데모 항목(`_` 접두) 변경 아님
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@
 ### 출처(`sources`)와 인용(`[src:N]`) 규칙
 
 - **frontmatter `sources`** 에는 누구나 열어 검증할 수 있는 **공개 `https://` URL만** 넣습니다 — 공식 사이트·디자인 가이드·GitHub·npm·공개 Storybook 등 1차 자료.
-- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`에는 frontmatter `sources`의 공개 URL을 (서로의 상대 순서를 유지해) 모두 포함하고, **공개 URL이 없는 ephemeral/비공개 1차 출처는 label-only 항목**(번호 + 설명, **URL 없음**)으로 함께 나열합니다. label-only 항목의 **위치는 끝으로 고정되지 않습니다** — 일반 참고문헌처럼 출처의 비중을 따라, 항목 합성의 1차 주력 출처면 앞쪽·보조 출처면 뒤쪽에 둡니다(아래 선례 참고). 주력/보조 판단이 애매하면 **기본값은 맨 끝**입니다 — 대부분의 ephemeral 핸드오프는 공개 출처를 보강하는 보조라 끝이 자연스럽습니다.
+- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`에는 frontmatter `sources`의 공개 URL을 (서로의 상대 순서를 유지해) 모두 포함하고, **공개 URL이 없는 ephemeral/비공개 1차 출처는 label-only 항목**(번호 + 설명, **URL 없음**)으로 함께 나열합니다. label-only 항목의 **기본 위치는 맨 끝**입니다 — 대부분의 ephemeral 핸드오프는 공개 출처를 보강하는 보조라 끝이 자연스럽습니다. 단, 항목을 합성한 **1차 주력 출처**라면 일반 참고문헌처럼 비중을 따라 앞쪽에 둘 수 있습니다(아래 선례 참고).
   - 예: 사용자가 제공한 Claude Design 핸드오프 번들(`api.anthropic.com/v1/design/h/...`), 로컬 `.claude/cache/...` 경로처럼 카탈로그 독자가 직접 열 수 없는 출처.
   - 이런 출처는 **frontmatter `sources`에 넣지 않습니다** — 만료(404)되거나 비공개라 외부 검증이 불가능하기 때문입니다.
 - 그 결과 **본문 최대 `[src:N]` 인덱스가 frontmatter `sources` 길이보다 클 수 있습니다(정상).** `[src:N]`은 `sources` 배열이 아니라 **`## References` 목록**으로 해석됩니다. `src/lib/content-parser.ts`에서 `sources`는 `string[]`로만 검증되고 `[src:N]` 마커는 표시용으로 스트립되므로, 둘의 길이 불일치는 스키마·빌드상 정상입니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@
   - `related_services` (관련 슬러그 배열, 없으면 `[]`)
   - `lang` (`ko` 또는 `en`)
   - `logo` (옵션: 절대 URL `https://getdesign.kr/logos/{slug}.{svg|png|webp|avif}`, 사이트 상대 경로 불가)
-- 본문의 `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
+- 본문의 `[src:N]` 인용이 `## References` 항목과 정합 — 공개 URL은 frontmatter `sources`에, ephemeral 출처(핸드오프 등)는 References에 label-only (§3 출처 규칙 참조; `[src:N]` 최대 인덱스 > `sources` 길이는 정상)
 - `pnpm dev` → `http://localhost:3000/{slug}` 미리보기 정상
 - `public/preview/{slug}/light.html` 과 `dark.html` 둘 다 자급자족형(self-contained) HTML로 단독 열기 가능
 - `public/og/{slug}.png` 생성 확인
@@ -94,7 +94,7 @@
 
 ---
 
-## 3. slug · 카테고리 · 언어 태그 규칙
+## 3. slug · 카테고리 · 언어 · 출처 규칙
 
 | 필드 | 규칙 |
 |------|------|
@@ -102,6 +102,18 @@
 | `category` | [content-types.ts](./src/lib/content-types.ts)의 `CATEGORIES` enum (`finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `gov`, `developer`, `education`, `career`, `etc`). 모르겠다면 `etc`로 두고 PR에서 토의 |
 | `lang` | 자료가 한국어 위주면 `ko`, 영어 위주면 `en` |
 | `last_updated` | YYYY-MM-DD ISO 형식 (`2026-05-10`) |
+| `sources` | 공개적으로 접근 가능한 `https://` URL **배열**만. ephemeral/비공개 출처는 제외 (아래 규칙) |
+
+### 출처(`sources`)와 인용(`[src:N]`) 규칙
+
+- **frontmatter `sources`** 에는 누구나 열어 검증할 수 있는 **공개 `https://` URL만** 넣습니다 — 공식 사이트·디자인 가이드·GitHub·npm·공개 Storybook 등 1차 자료.
+- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`는 frontmatter `sources`의 공개 URL을 같은 순서로 옮긴 뒤, **공개 URL이 없는 ephemeral/비공개 1차 출처를 label-only 항목**(번호 + 설명, **URL 없음**)으로 이어 적습니다.
+  - 예: 사용자가 제공한 Claude Design 핸드오프 번들(`api.anthropic.com/v1/design/h/...`), 로컬 `.claude/cache/...` 경로처럼 카탈로그 독자가 직접 열 수 없는 출처.
+  - 이런 출처는 **frontmatter `sources`에 넣지 않습니다** — 만료(404)되거나 비공개라 외부 검증이 불가능하기 때문입니다.
+- 그 결과 **본문 최대 `[src:N]` 인덱스가 frontmatter `sources` 길이보다 클 수 있습니다(정상).** `[src:N]`은 `sources` 배열이 아니라 **`## References` 목록**으로 해석됩니다. `src/lib/content-parser.ts`에서 `sources`는 `string[]`로만 검증되고 `[src:N]` 마커는 표시용으로 스트립되므로, 둘의 길이 불일치는 스키마·빌드상 정상입니다.
+- **공개 출처 우선.** ephemeral 출처에서 온 값이라도 공개 패키지·문서에서 동일하게 확인된다면 공개 URL로 재귀속하길 권장합니다(예: #109에서 라인 항목의 ephemeral 번들 소스를 공개 LDSG URL로 정리). label-only는 **공개 대응이 없을 때의 폴백**입니다.
+
+> **선례** — `services/vapor-ui.md`: frontmatter `sources` 5개 < 본문 `[src:6]`, `## References` #1이 핸드오프 label-only. `services/bezier.md`: `sources` 4개 < `[src:5]`, References #5가 핸드오프 label-only.
 
 ---
 
@@ -111,7 +123,7 @@ PR 생성 시 자동으로 표시되는 체크리스트와 동일합니다.
 
 - [ ] frontmatter 필수 필드 검증 완료
 - [ ] preview HTML 두 본 (light/dark) 검증
-- [ ] `[src:N]` 인용 정합성
+- [ ] `[src:N]` 인용이 `## References`와 정합 (ephemeral 출처는 `sources` 제외·label-only)
 - [ ] 브랜드 자산 라이선스/상표 우려 검토
 - [ ] `pnpm typecheck && pnpm lint && pnpm build` 통과
 - [ ] DCO 서명 (`git commit -s`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,13 +107,13 @@
 ### 출처(`sources`)와 인용(`[src:N]`) 규칙
 
 - **frontmatter `sources`** 에는 누구나 열어 검증할 수 있는 **공개 `https://` URL만** 넣습니다 — 공식 사이트·디자인 가이드·GitHub·npm·공개 Storybook 등 1차 자료.
-- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`는 frontmatter `sources`의 공개 URL을 같은 순서로 옮긴 뒤, **공개 URL이 없는 ephemeral/비공개 1차 출처를 label-only 항목**(번호 + 설명, **URL 없음**)으로 이어 적습니다.
+- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`에는 frontmatter `sources`의 공개 URL을 (서로의 상대 순서를 유지해) 모두 포함하고, **공개 URL이 없는 ephemeral/비공개 1차 출처는 label-only 항목**(번호 + 설명, **URL 없음**)으로 함께 나열합니다. label-only 항목의 **위치는 끝으로 고정되지 않습니다** — 일반 참고문헌처럼 출처의 비중을 따라, 항목 합성의 1차 주력 출처면 앞쪽·보조 출처면 뒤쪽에 둡니다(아래 선례 참고).
   - 예: 사용자가 제공한 Claude Design 핸드오프 번들(`api.anthropic.com/v1/design/h/...`), 로컬 `.claude/cache/...` 경로처럼 카탈로그 독자가 직접 열 수 없는 출처.
   - 이런 출처는 **frontmatter `sources`에 넣지 않습니다** — 만료(404)되거나 비공개라 외부 검증이 불가능하기 때문입니다.
 - 그 결과 **본문 최대 `[src:N]` 인덱스가 frontmatter `sources` 길이보다 클 수 있습니다(정상).** `[src:N]`은 `sources` 배열이 아니라 **`## References` 목록**으로 해석됩니다. `src/lib/content-parser.ts`에서 `sources`는 `string[]`로만 검증되고 `[src:N]` 마커는 표시용으로 스트립되므로, 둘의 길이 불일치는 스키마·빌드상 정상입니다.
 - **공개 출처 우선.** ephemeral 출처에서 온 값이라도 공개 패키지·문서에서 동일하게 확인된다면 공개 URL로 재귀속하길 권장합니다(예: #109에서 라인 항목의 ephemeral 번들 소스를 공개 LDSG URL로 정리). label-only는 **공개 대응이 없을 때의 폴백**입니다.
 
-> **선례** — `services/vapor-ui.md`: frontmatter `sources` 5개 < 본문 `[src:6]`, `## References` #1이 핸드오프 label-only. `services/bezier.md`: `sources` 4개 < `[src:5]`, References #5가 핸드오프 label-only.
+> **선례 (위치는 비중을 따라감)** — `services/vapor-ui.md`: frontmatter `sources` 5개 < 본문 `[src:6]`, `## References` **#1**이 핸드오프 label-only — 항목 전체를 핸드오프(README·CSS·preview)로 합성한 **1차 주력 출처**라 맨 앞. `services/bezier.md`: `sources` 4개 < `[src:5]`, References **#5**(맨 끝)가 핸드오프 label-only — 공개 4종(GitHub·Chromatic·npm×2)이 주력이고 핸드오프는 alpha 토큰·도메인만 보강한 **보조 출처**라 맨 뒤.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@
 ### 출처(`sources`)와 인용(`[src:N]`) 규칙
 
 - **frontmatter `sources`** 에는 누구나 열어 검증할 수 있는 **공개 `https://` URL만** 넣습니다 — 공식 사이트·디자인 가이드·GitHub·npm·공개 Storybook 등 1차 자료.
-- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`에는 frontmatter `sources`의 공개 URL을 (서로의 상대 순서를 유지해) 모두 포함하고, **공개 URL이 없는 ephemeral/비공개 1차 출처는 label-only 항목**(번호 + 설명, **URL 없음**)으로 함께 나열합니다. label-only 항목의 **위치는 끝으로 고정되지 않습니다** — 일반 참고문헌처럼 출처의 비중을 따라, 항목 합성의 1차 주력 출처면 앞쪽·보조 출처면 뒤쪽에 둡니다(아래 선례 참고).
+- 본문의 모든 구체적 주장은 **`[src:N]` 마커**로 `## References` 섹션의 번호에 대응시킵니다. `## References`에는 frontmatter `sources`의 공개 URL을 (서로의 상대 순서를 유지해) 모두 포함하고, **공개 URL이 없는 ephemeral/비공개 1차 출처는 label-only 항목**(번호 + 설명, **URL 없음**)으로 함께 나열합니다. label-only 항목의 **위치는 끝으로 고정되지 않습니다** — 일반 참고문헌처럼 출처의 비중을 따라, 항목 합성의 1차 주력 출처면 앞쪽·보조 출처면 뒤쪽에 둡니다(아래 선례 참고). 주력/보조 판단이 애매하면 **기본값은 맨 끝**입니다 — 대부분의 ephemeral 핸드오프는 공개 출처를 보강하는 보조라 끝이 자연스럽습니다.
   - 예: 사용자가 제공한 Claude Design 핸드오프 번들(`api.anthropic.com/v1/design/h/...`), 로컬 `.claude/cache/...` 경로처럼 카탈로그 독자가 직접 열 수 없는 출처.
   - 이런 출처는 **frontmatter `sources`에 넣지 않습니다** — 만료(404)되거나 비공개라 외부 검증이 불가능하기 때문입니다.
 - 그 결과 **본문 최대 `[src:N]` 인덱스가 frontmatter `sources` 길이보다 클 수 있습니다(정상).** `[src:N]`은 `sources` 배열이 아니라 **`## References` 목록**으로 해석됩니다. `src/lib/content-parser.ts`에서 `sources`는 `string[]`로만 검증되고 `[src:N]` 마커는 표시용으로 스트립되므로, 둘의 길이 불일치는 스키마·빌드상 정상입니다.


### PR DESCRIPTION
## 변경 요약

자동 리뷰어가 카탈로그 PR마다 "본문 `[src:N]`이 frontmatter `sources`에 없다"고 반복 오인하는 **근본 원인** — CONTRIBUTING.md·PR 템플릿이 `[src:N] = frontmatter sources 인덱스`라고 잘못 안내한 것 — 을 바로잡습니다. 실제 컨벤션(`[src:N] → ## References`, ephemeral 출처는 label-only)을 명문화합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [ ] 사이트 코드/UI
- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 항목 변경이 아니라 문서/템플릿만 수정합니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

PR #106(채널톡 Bezier) 리뷰에서 claude-review·gemini가 `[src:5]`/`[src:6]` label-only 출처를 "sources 누락"으로 8라운드에 걸쳐 반복 오인 → 근본 원인이 **문서 오안내**임을 확인하고 분리 수정.

---

### 무엇을 바꿨나

**CONTRIBUTING §3에 "출처(`sources`)와 인용(`[src:N]`) 규칙" 추가:**
- frontmatter `sources` = **공개 `https://` URL만**.
- ephemeral/비공개 1차 출처(Claude Design 핸드오프 `api.anthropic.com/v1/design/h/...`, 로컬 `.claude/cache/...`)는 `## References`에 **label-only**(URL 없음)로만 기재, frontmatter `sources` 제외.
- **본문 max `[src:N]` > `sources` 길이는 정상** — `[src:N]`은 `## References`로 해석. 파서 근거: `content-parser.ts`에서 `sources`는 `string[]` 검증만, `[src:N]`은 표시용으로 스트립(교차검증 없음).
- **공개 출처 우선**(#109 선례 — 라인 ephemeral 소스를 공개 LDSG URL로 정리), label-only는 공개 대응이 없을 때의 폴백.
- 선례: `vapor-ui.md`(`sources` 5 < `[src:6]`), `bezier.md`(`sources` 4 < `[src:5]`).

**오해 문구 정정:** §1-4 산출물 검증 · §4 PR 체크리스트 · `.github/PULL_REQUEST_TEMPLATE.md`의 `[src:N]이 frontmatter sources 인덱스와 일치` → `## References와 정합`.

이후 카탈로그 PR에서 리뷰어가 label-only 핸드오프 출처를 버그로 오인하지 않게 됩니다.
