### PR TITLE
feat(home): 카탈로그 카테고리 필터 사이드바를 데스크톱에서 sticky로 고정

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -54,7 +54,7 @@ function HomePage() {
           </p>
         ) : (
           <div className="lg:grid lg:grid-cols-[220px_1fr] lg:gap-10">
-            <aside className="mb-4 lg:mb-0 lg:pt-8">
+            <aside className="mb-4 lg:mb-0 lg:pt-8 lg:sticky lg:top-14 lg:self-start">
               <CategorySidebar
                 totalCount={filter.totalCount}
                 counts={filter.counts}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -54,7 +54,7 @@ function HomePage() {
           </p>
         ) : (
           <div className="lg:grid lg:grid-cols-[220px_1fr] lg:gap-10">
-            <aside className="mb-4 lg:mb-0 lg:pt-8 lg:sticky lg:top-14 lg:self-start">
+            <aside className="mb-4 lg:mb-0 lg:pt-8 lg:sticky lg:top-14 lg:max-h-[calc(100svh-3.5rem)] lg:self-start lg:overflow-y-auto">
               <CategorySidebar
                 totalCount={filter.totalCount}
                 counts={filter.counts}


### PR DESCRIPTION
## 변경 요약

메인 화면 카탈로그의 카테고리 필터 사이드바를 **데스크톱(lg+)에서 헤더 바로 아래에 sticky로 고정**합니다. 카탈로그 항목이 늘어 목록이 길어지면서 스크롤 시 왼쪽 필터가 화면 밖으로 사라져 카테고리 전환이 불편했던 문제를 해결합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 콘텐츠 변경이 아닌 UI 변경입니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 구현 메모

[`src/routes/index.tsx`](https://github.com/CaesiumY/ko-design-md/blob/main/src/routes/index.tsx)의 `<aside>` className에 `lg:sticky lg:top-14 lg:self-start` 3개 클래스만 추가한 **한 줄 변경**입니다.

- **`lg:top-14`** — 헤더 높이(`h-14`, 56px)와 동일 오프셋. 고정 시 헤더 바로 아래에 붙고, 기존 `lg:pt-8`(32px)가 헤더와 "Find Designs" 사이 여백을 만듭니다.
- **`lg:self-start`** — *필수*. 그리드 자식은 기본 `align-items: stretch`라 aside가 행 전체 높이로 늘어나면 sticky 이동 범위가 0이 되어 무력화됩니다. `self-start`로 콘텐츠 높이만큼 줄여야 동작합니다.
- 상세 페이지 `src/routes/services/$slug.tsx`의 sticky aside(`md:sticky md:top-24 md:self-start`)와 동일 패턴을 홈 그리드에 맞춰 적용했습니다.

## 범위 제외 (YAGNI)

- **모바일 가로 칩 줄** — `lg:` 프리픽스만 사용해 모바일은 기존 동작 그대로 유지. 모바일 sticky는 칩 줄의 부모(`<aside>`)가 짧아 긴 컨테이너로 옮기는 구조 변경이 필요하므로 별도 작업으로 분리했습니다.
- **z-index / max-height** — 사이드바·목록이 가로로 겹치지 않고(`gap-10`) 카테고리 수가 적어 불필요합니다.

## 검증

- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm build` ✓
- `pnpm test` — **183/183 PASS** (22 파일)
- 프리뷰(1440×900): 스크롤 0→820px 구간에서 사이드바 viewport top이 `578 → 278 → 56px`로, **헤더 높이(56px)에 고정**되는 전환을 측정 확인. 콘솔 에러 없음.