### PR TITLE
fix(detail): sticky 액션 사이드바에 max-height·overflow 추가 — 짧은 뷰포트 접근성

### DIFF
--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -163,7 +163,7 @@ export function ServiceDetailLayout({
         <ServiceMeta frontmatter={doc.frontmatter} tagline={doc.tagline} />
       </div>
 
-      <aside className="md:sticky md:top-24 md:col-start-2 md:row-start-1 md:row-span-2 md:self-start">
+      <aside className="md:sticky md:top-24 md:col-start-2 md:row-start-1 md:row-span-2 md:max-h-[calc(100svh-6rem)] md:self-start md:overflow-y-auto">
         <p className="text-meta-caps mb-4">
           {primaryAction.mark}{" "}
           <span className="text-brand font-extrabold">


### PR DESCRIPTION
## 변경 요약

서비스 상세 페이지(`src/routes/services/$slug.tsx`)의 sticky 액션 사이드바에 `md:max-h-[calc(100svh-6rem)] md:overflow-y-auto`를 추가합니다. 홈 카테고리 사이드바(#111)와 동일한 방어 패턴으로, 고정된 aside가 뷰포트보다 길어질 때 하단(면책 문구)이 잘려 접근 불가해지는 것을 막습니다.

PR #111 리뷰(claude-code-review)에서 "상세 페이지 aside에도 동일 잠재 이슈가 있으니 별개 이슈로 적용하면 좋겠다"는 지적을 반영한 **후속 작업**입니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음 — UI 변경입니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (CSS-only 변경)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 구현 메모

`<aside>`(line ~166)에 `md:max-h-[calc(100svh-6rem)] md:overflow-y-auto` 2개 클래스 추가:

- **`md:max-h-[calc(100svh-6rem)]`** — aside는 `md:top-24`(96px=6rem)에 고정됩니다. `box-sizing: border-box`라 max-h는 패딩 포함 박스 전체에 적용되므로, 오프셋 `6rem`만 빼면 고정 박스 하단이 뷰포트 하단에 정확히 닿습니다. 단위는 코드베이스 `min-h-[calc(100svh-3.5rem)]` 컨벤션에 맞춰 `svh` 사용.
- **`md:overflow-y-auto`** — 콘텐츠가 가용 높이를 넘으면 aside 내부 스크롤.
- **`md:self-start`** — 기존부터 존재 → grid 기본 `align-items: stretch`로 인한 sticky 무력화는 이미 방지됨.
- overflow 클리핑 우려: aside 내부는 버튼(Copy/Open Raw)·토큰 배지·텍스트뿐이고 팝업/드롭다운이 없어 안전.

## 측정·검증 (preview MCP)

- **오버플로 빈도는 낮음**: aside 콘텐츠 높이 측정 결과 **~293px**(toss·line-design-system 동일, 서비스 간 안정적). `top-24`(96px) 기준 **뷰포트 높이 < ~389px**에서만 오버플로 — 주로 devtools 하단 도킹/매우 짧은 창에서 발생. 따라서 흔한 버그 수정이라기보다 홈 sticky aside(#111)와의 **동작 일관성·방어** 목적입니다.
- **360px (짧음)**: max-h 264px로 제한, 내부 스크롤로 마지막 면책 문단까지 완전 접근, top 96px 고정 유지 ✓
- **900px (정상)**: 오버플로 미발생(스크롤바 없음, 기존 동작 유지), top 96px 고정 ✓
- `pnpm typecheck` ✓ · `pnpm lint` ✓

## 관련

- #111 (홈 카테고리 사이드바 sticky + 동일 패턴)의 후속