### PR TITLE
fix(web): 인앱 브라우저 히어로 타이틀 오버플로 수정 + 가로 오버플로 보강

### DIFF
--- a/src/components/site/contribute-dialog.tsx
+++ b/src/components/site/contribute-dialog.tsx
@@ -52,7 +52,7 @@ export function ContributeDialog() {
         <Dialog.Backdrop className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
         <Dialog.Popup
           className={cn(
-            "fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2",
+            "fixed top-1/2 left-4 right-4 z-50 -translate-y-1/2 sm:left-1/2 sm:right-auto sm:w-full sm:max-w-xl sm:-translate-x-1/2",
             "rounded-2xl border bg-background p-6 shadow-2xl outline-none",
             "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
             "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",

--- a/src/components/site/contribute-dialog.tsx
+++ b/src/components/site/contribute-dialog.tsx
@@ -52,7 +52,7 @@ export function ContributeDialog() {
         <Dialog.Backdrop className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
         <Dialog.Popup
           className={cn(
-            "fixed top-1/2 left-1/2 z-50 w-[calc(100vw-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2",
+            "fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2",
             "rounded-2xl border bg-background p-6 shadow-2xl outline-none",
             "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
             "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",

--- a/src/components/site/header.tsx
+++ b/src/components/site/header.tsx
@@ -17,6 +17,8 @@ export function SiteHeader() {
       className="sticky top-0 z-30 border-b bg-background/85 backdrop-blur-md"
       style={{
         borderColor: "var(--rule-strong)",
+        // Header bg absorbs the notch (safe-area-inset-top); the inner h-14 bar
+        // sits below it. env()=0 on non-notch browsers, so height stays 56px there.
         paddingTop: "env(safe-area-inset-top)",
       }}
     >

--- a/src/components/site/header.tsx
+++ b/src/components/site/header.tsx
@@ -15,7 +15,10 @@ export function SiteHeader() {
   return (
     <header
       className="sticky top-0 z-30 border-b bg-background/85 backdrop-blur-md"
-      style={{ borderColor: "var(--rule-strong)" }}
+      style={{
+        borderColor: "var(--rule-strong)",
+        paddingTop: "env(safe-area-inset-top)",
+      }}
     >
       <div className="mx-auto flex h-14 max-w-[1400px] items-center justify-between px-8">
         <Link to="/" className="group inline-flex items-baseline">

--- a/src/routes/-home/components/hero.tsx
+++ b/src/routes/-home/components/hero.tsx
@@ -1,6 +1,6 @@
 export function HomeHero() {
   return (
-    <section className="mx-auto max-w-[1400px] break-keep px-8">
+    <section className="mx-auto max-w-[1400px] break-keep px-8 [container-type:inline-size]">
       {/* Issue mark — top divider */}
       <div
         className="text-meta-caps animate-fade-in-up flex flex-wrap items-baseline gap-x-5 gap-y-2 border-b pt-12 pb-3.5 sm:gap-x-6 sm:pt-20"
@@ -16,7 +16,7 @@ export function HomeHero() {
       <h1
         className="text-display-massive animate-fade-in-up mt-10 sm:mt-16"
         style={{
-          fontSize: "clamp(2.25rem, 13vw, 14rem)",
+          fontSize: "clamp(2.25rem, 15cqi, 14rem)",
           animationDelay: "60ms",
         }}
       >

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -12,7 +12,7 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" },
       { title: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그" },
       {
         name: "description",

--- a/src/styles.css
+++ b/src/styles.css
@@ -135,12 +135,14 @@
     }
   body {
     @apply bg-background text-foreground break-keep;
+    overflow-x: clip;
     }
   button:not(:disabled), [role="button"]:not(:disabled) {
     cursor: pointer;
     }
   html {
     @apply font-sans;
+    overflow-x: clip;
     }
   ::selection {
     background: var(--accent-glow);

--- a/src/styles.css
+++ b/src/styles.css
@@ -135,7 +135,6 @@
     }
   body {
     @apply bg-background text-foreground break-keep;
-    overflow-x: clip;
     }
   button:not(:disabled), [role="button"]:not(:disabled) {
     cursor: pointer;


### PR DESCRIPTION
## 변경 요약

Threads 등 인앱 브라우저(WebView)에서 히어로 타이틀 `ko/design.md`가 오른쪽 거터를 넘어 삐지던 문제를 고치고, 인앱 브라우저 전반의 가로 오버플로를 보강했습니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 사이트 UI 수정입니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- 없음 -->

---

### 루트 원인

히어로 타이틀 폰트가 `clamp(2.25rem, 13vw, 14rem)` — **뷰포트 전체 폭(`vw`)** 기준인데, 타이틀 컨테이너 `<section>`은 `px-8`(좌우 64px) 거터를 가집니다. 데스크톱에선 64px이 미미하지만 인앱 브라우저(≈375px)에선 폭의 ~17%라, "뷰포트의 13%"로 잰 글자가 거터 안쪽 콘텐츠 폭을 넘습니다. 게다가 `ko/design.md`는 공백 없는 한 단어 + `break-keep`이라 줄바꿈이 안 되고, `overflow-x` 가드도 없어 가로로 그대로 노출됐습니다. Threads WebView의 visual viewport·`vw` 계산 편차가 이 경계를 "넘침"으로 드러냅니다.

### 변경

| 파일 | 변경 |
|---|---|
| `hero.tsx` | section에 `container-type:inline-size`, h1 `13vw` → `15cqi` — **콘텐츠 박스(거터 안쪽) 폭** 기준 스케일 |
| `styles.css` | `html { overflow-x: clip }` 전역 가드 (루트 스크롤러 단일 적용) |
| `contribute-dialog.tsx` | 모바일 `left-4 right-4` 인셋 + `sm:` 중앙정렬 `max-w-xl` (`100vw` quirk 제거 + transform 서브픽셀 블러 회피) |
| `__root.tsx` | viewport meta에 `viewport-fit=cover` |
| `header.tsx` | `paddingTop: env(safe-area-inset-top)` |

`cqi`(컨테이너 쿼리 단위)는 컨테이너 **콘텐츠 박스**를 직접 재므로 `px-8` 거터를 자동 반영하고, 인앱 브라우저가 `vw`를 어떻게 계산하든 *실제 사용 가능한 폭*에 맞춰져 root-cause에 강합니다.

### 검증 (Playwright 폭별 실측)

- **320 / 375 / 430 / 768 / 1280 / 1440px 전 폭**에서 타이틀 `fill 0.882`로 균일, `h1Overflow: false`, `docOverflowX: false`
- `overflow-x: clip` 적용 후에도 sticky 헤더 고정·세로 스크롤 정상 (800px 스크롤 후 `headerTop: 0`) — `clip`은 `hidden`과 달리 스크롤 컨테이너를 만들지 않음
- 다이얼로그(360px) `calc(100%-2rem)` 적용, 가로 오버플로 없음
- `typecheck` · `lint` · `build` 모두 통과

### 리뷰어 참고

- **safe-area(노치/홈 인디케이터)**는 프리뷰로 완전 검증 불가합니다. `env(safe-area-inset-top)`은 일반 브라우저에서 `0`으로 풀려 시각 변화가 없음을 확인했으나(스크린샷 정상), 실제 노치 동작은 **실기기/DevTools 디바이스 모드 확인**을 권장합니다. Threads 웹뷰는 호스트 앱이 이미 상단을 차지해 inset이 0일 가능성이 커, 이번 PR의 핵심 효과는 가로 오버플로 수정입니다.
- 초광폭(>~1700px) 데스크톱에서 타이틀이 `max-w-[1400px]` 컨테이너에 캡되어 최대 ~200px(기존 224px)로 약간 작아집니다 — 의도된 부수효과이며, 데스크톱 룩은 스크린샷으로 확인했습니다.

