### PR TITLE
ci: claude-review에서 dependabot PR 스킵 (false-failure 제거)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,11 +11,12 @@ concurrency:
 
 jobs:
   claude-review:
-    # 내부 PR(메인테이너 브랜치·dependabot)만 리뷰.
-    # 포크 PR은 시크릿이 전달되지 않아 인증 실패하므로 스킵(조건 false → 잡 미생성). 드래프트도 스킵.
+    # 메인테이너 브랜치의 내부 PR만 리뷰.
+    # 포크·dependabot PR은 시크릿이 격리 컨텍스트로 전달되지 않아(GITHUB_TOKEN read-only 강등) 인증 실패하므로 스킵(조건 false → 잡 미생성). 드래프트도 스킵.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 배경
열린 dependabot PR 5종(#97~#101)이 모두 `claude-review` 체크에서 FAILURE를 남기고 있었습니다. 원인은 코드 결함이 아니라 **dependabot 트리거 런의 권한 인프라**입니다.

## 근본 원인
- dependabot이 트리거한 워크플로 런은 GitHub가 격리 보안 컨텍스트로 실행합니다 (`Secret source: Dependabot`).
- 이 컨텍스트에서는 일반 Actions secret(`secrets.CLAUDE_CODE_OAUTH_TOKEN`)이 비어 있고, 워크플로가 선언한 `id-token: write`·`pull-requests: write`가 무시되며 `GITHUB_TOKEN`이 read-only로 강등됩니다.
- 그래서 `Run Claude Code Review` 스텝이 인증/게시에 실패 → dependabot PR마다 항상 빨간 X.

## 변경
`if` 가드에 `github.event.pull_request.user.login != 'dependabot[bot]'` 한 줄 추가. 기존에 포크 PR을 스킵하던 것과 **동일한 시크릿 미전달 논리**를 dependabot에도 적용합니다. 봇 전체가 아닌 dependabot만 제외하므로, ready-for-review된 내부 PR은 계속 리뷰됩니다.

## 영향
- 향후 dependabot PR은 claude-review 잡이 생성되지 않아 CLEAN 상태가 됩니다.
- 의존성 범프는 AI 코드리뷰 가치가 낮아 손실이 없습니다.