### PR TITLE
feat(web): Vercel Web Analytics 연동 (supersedes #107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@tanstack/react-router-ssr-query": "^1.167.1",
     "@tanstack/react-start": "^1.168.20",
     "@tanstack/router-plugin": "^1.168.14",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.14
         version: 1.168.14(@tanstack/react-router@1.170.11(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1876,6 +1879,35 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -5977,6 +6009,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vercel/analytics@2.0.1(react@19.2.7)':
+    optionalDependencies:
+      react: 19.2.7
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-r
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools"
 import { TanStackDevtools } from "@tanstack/react-devtools"
 import { Provider as JotaiProvider } from "jotai"
+import { Analytics } from "@vercel/analytics/react"
 import appCss from "../styles.css?url"
 import { absoluteUrl } from "@/lib/site-config"
 
@@ -108,6 +109,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             { name: "Tanstack Router", render: <TanStackRouterDevtoolsPanel /> },
           ]}
         />
+        <Analytics />
         <Scripts />
       </body>
     </html>


### PR DESCRIPTION
## 배경
Vercel 봇이 만든 드래프트 #107이 `@vercel/analytics` + 루트 `<Analytics />`를 추가하지만, 06-03 기준 옛 main에서 분기해 그동안의 의존성 범프(#97~#101)·#113·#114·#116과 lockfile/소스가 충돌합니다.

## 변경
#107의 의도를 **현재 main 위에 깨끗하게 재적용**했습니다:
- `package.json`: `@vercel/analytics` ^2.0.1 추가
- `src/routes/__root.tsx`: `<Analytics />` 렌더 + import
- `pnpm-lock.yaml`: `pnpm install`로 재생성 — @vercel/analytics 엔트리만 +36줄 순삽입(다른 의존성 영향 없음)

## #107 대신 새 PR인 이유
봇이 작성한 브랜치 히스토리를 force-push로 다시 쓰는 대신, 동일 변경을 별도 브랜치로 재작성했습니다. 머지 후 #107은 이 PR로 대체되어 닫힙니다.

## 검증
로컬에서 `pnpm typecheck` + `pnpm build` 통과(나머지 게이트는 CI). 쿠키리스 분석이라 동의 배너 불필요.

Closes #107