### PR TITLE
feat(web): Tokens 탭에 JSON 복사 버튼

### DIFF
--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -163,6 +163,11 @@ export function ServiceDetailLayout({
   const hasTokens =
     !!t &&
     t.colors.length + t.typography.length + t.spacing.length + t.radius.length > 0
+  // Full token set serialized for the Tokens-tab copy button. The cards show a
+  // curated signature, but the copy hands over everything (colors / typography /
+  // spacing / radius) for AI prompts or Tailwind themes. Re-serializing the
+  // parsed sidecar reproduces the original JSON (2-space, key order preserved).
+  const tokensJson = t ? JSON.stringify(t, null, 2) : ""
 
   return (
     <div className="mx-auto grid max-w-[1400px] grid-cols-1 gap-x-12 gap-y-10 px-8 pt-12 pb-32 md:grid-cols-[minmax(0,1fr)_280px] md:gap-x-20 md:pt-16">
@@ -206,9 +211,9 @@ export function ServiceDetailLayout({
               checks the outer's width.
 
               The right slot is tab-aware: Live Preview gets the
-              light/dark toggle (relevant), DESIGN.md gets a quick copy
-              shortcut (the action you reach for once you've opened the
-              raw source). */}
+              light/dark toggle (relevant), Tokens gets a "Copy JSON"
+              shortcut (the full sidecar for AI prompts / Tailwind themes),
+              and DESIGN.md gets a quick copy shortcut for the raw source. */}
           <div className="@container">
             <div className="flex flex-col items-start gap-3 @sm:flex-row @sm:items-center">
               <DetailTabsList>
@@ -222,6 +227,14 @@ export function ServiceDetailLayout({
                 <PreviewThemeToggle
                   theme={previewTheme}
                   onChange={onThemeChange}
+                  className="@sm:ml-auto"
+                />
+              )}
+              {hasTokens && searchTab === "tokens" && (
+                <InlineCopyButton
+                  raw={tokensJson}
+                  filename={`${doc.frontmatter.slug}.tokens.json`}
+                  label="Copy JSON"
                   className="@sm:ml-auto"
                 />
               )}

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, notFound } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { SERVICE_DETAIL_COPY } from "./-copy"
 import { CopyButton } from "./-components/copy-button"
 import {
@@ -163,11 +163,10 @@ export function ServiceDetailLayout({
   const hasTokens =
     !!t &&
     t.colors.length + t.typography.length + t.spacing.length + t.radius.length > 0
-  // Full token set serialized for the Tokens-tab copy button. The cards show a
-  // curated signature, but the copy hands over everything (colors / typography /
-  // spacing / radius) for AI prompts or Tailwind themes. Re-serializing the
-  // parsed sidecar reproduces the original JSON (2-space, key order preserved).
-  const tokensJson = t ? JSON.stringify(t, null, 2) : ""
+  // Serialize the FULL sidecar (not just the signature cards) so a copy hands AI
+  // prompts / Tailwind themes every token. Memoized on the stable doc.tokens ref
+  // so it stringifies once, not on every tab switch or preview theme toggle.
+  const tokensJson = useMemo(() => (t ? JSON.stringify(t, null, 2) : ""), [t])
 
   return (
     <div className="mx-auto grid max-w-[1400px] grid-cols-1 gap-x-12 gap-y-10 px-8 pt-12 pb-32 md:grid-cols-[minmax(0,1fr)_280px] md:gap-x-20 md:pt-16">

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils"
 interface Props {
   raw: string
   filename: string
+  /** Idle-state button text. Defaults to "Copy". */
+  label?: string
   className?: string
 }
 
@@ -43,7 +45,12 @@ function CheckIcon({ className }: { className?: string }) {
   )
 }
 
-export function InlineCopyButton({ raw, filename, className }: Props) {
+export function InlineCopyButton({
+  raw,
+  filename,
+  label = "Copy",
+  className,
+}: Props) {
   const [copied, setCopied] = useState(false)
 
   async function onCopy() {
@@ -74,7 +81,7 @@ export function InlineCopyButton({ raw, filename, className }: Props) {
       ) : (
         <CopyIcon className="size-3.5" />
       )}
-      <span>{copied ? "Copied" : "Copy"}</span>
+      <span>{copied ? "Copied" : label}</span>
     </button>
   )
 }


### PR DESCRIPTION
## 변경 요약

Tokens 탭에 **"Copy JSON" 버튼**을 추가합니다. DESIGN.md 탭처럼 디자인 토큰을 통째로 떠서 **AI 프롬프트에 첨부하거나 Tailwind 테마를 만들 때** 쓸 수 있습니다. 카드는 시그니처 팔레트만 보여주지만, 복사는 사이드카 전체(colors/typography/spacing/radius)를 넘깁니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 주요 변경

- `inline-copy-button.tsx`: 옵셔널 `label?: string` prop 추가(기본 `"Copy"`). 하위호환 — DESIGN.md 탭 버튼 무변경.
- `$slug.tsx`: 탭 우측 슬롯에 `searchTab === "tokens"`일 때 `<InlineCopyButton label="Copy JSON" raw={JSON.stringify(doc.tokens, null, 2)} filename="{slug}.tokens.json" />` 조건부 렌더. 클립보드·"Copied" 피드백 로직은 기존 컴포넌트 재사용(신규 컴포넌트 0).
- 복사 내용 = `doc.tokens` 전체. 파싱된 토큰 재직렬화가 사이드카 원본 JSON과 사실상 동일(2-space, 키 순서 colors→typography→spacing→radius 보존).

## 비범위

Tailwind `@theme` / CSS `:root` / Markdown 등 다른 형식 직렬화, 형식 선택 드롭다운, raw HTTP 엔드포인트 — 모두 비채택(JSON 단일 형식으로 결정). 추후 확장 여지.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (+ `pnpm test` 230 passed)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 검증

Playwright로 확인: Tokens 탭에 "Copy JSON" 버튼 표시 → 클릭 시 `navigator.clipboard.writeText`가 유효 JSON(4키, vapor-ui 112색 전체) 수신 → "Copied" 토글. DESIGN.md 탭은 "Copy" 그대로(무회귀), preview 탭은 복사 버튼 없음.
