### PR TITLE
fix(web): colorChroma — oklab 채도를 hypot(a,b)로 계산

### DIFF
--- a/src/lib/token-curation.test.ts
+++ b/src/lib/token-curation.test.ts
@@ -40,8 +40,10 @@ describe("colorChroma / isAlphaColor", () => {
     expect(colorChroma("oklch(0.971 0 0)")).toBe(0)
   })
 
-  it("reads lch chroma (2nd component)", () => {
+  it("reads lch chroma (2nd component), incl. explicit + sign", () => {
     expect(colorChroma("lch(52% 40 30)")).toBeCloseTo(40)
+    // CSS <number> permits an explicit leading "+"
+    expect(colorChroma("lch(52% +40 30)")).toBeCloseTo(40)
   })
 
   it("computes oklab chroma as hypot(a, b), not the bare a component", () => {
@@ -50,6 +52,8 @@ describe("colorChroma / isAlphaColor", () => {
     expect(colorChroma("oklab(0.6 0.02 0.20)")).toBeCloseTo(0.201, 2)
     // a-dominant with a negative b axis
     expect(colorChroma("oklab(0.7 0.15 -0.05)")).toBeCloseTo(0.158, 2)
+    // CSS permits explicit "+" signs on the a/b axes
+    expect(colorChroma("oklab(0.6 +0.02 +0.20)")).toBeCloseTo(0.201, 2)
   })
 
   it("treats non-oklch values as chromatic", () => {

--- a/src/lib/token-curation.test.ts
+++ b/src/lib/token-curation.test.ts
@@ -40,6 +40,18 @@ describe("colorChroma / isAlphaColor", () => {
     expect(colorChroma("oklch(0.971 0 0)")).toBe(0)
   })
 
+  it("reads lch chroma (2nd component)", () => {
+    expect(colorChroma("lch(52% 40 30)")).toBeCloseTo(40)
+  })
+
+  it("computes oklab chroma as hypot(a, b), not the bare a component", () => {
+    // a small, b large → a saturated hue. The 2nd component alone (0.02) would
+    // wrongly read as neutral; real chroma = hypot(0.02, 0.20) ≈ 0.201.
+    expect(colorChroma("oklab(0.6 0.02 0.20)")).toBeCloseTo(0.201, 2)
+    // a-dominant with a negative b axis
+    expect(colorChroma("oklab(0.7 0.15 -0.05)")).toBeCloseTo(0.158, 2)
+  })
+
   it("treats non-oklch values as chromatic", () => {
     expect(colorChroma("#ff0000")).toBe(1)
   })

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -12,10 +12,18 @@ const NEUTRAL_CHROMA = 0.04
 // Shared by color curation here and the flat type/spacing/radius collapse.
 export const MIN_COLLAPSE = 6
 
-/** OKLCH chroma (2nd component); non-oklch values read as chromatic. */
+/**
+ * Chroma of a color value. oklch / lch carry chroma directly as the 2nd
+ * component; oklab carries Cartesian a/b axes, so its chroma is hypot(a, b) —
+ * the bare 2nd component (a) would misread a b-dominant hue as neutral. Non-LCh
+ * values (hex, rgb, named) read as chromatic.
+ */
 export function colorChroma(value: string): number {
-  const m = value.match(/^(?:oklch|oklab|lch)\(\s*[\d.]+%?\s+([\d.]+)/i)
-  return m ? Number(m[1]) : 1
+  const lch = value.match(/^(?:oklch|lch)\(\s*[\d.]+%?\s+([\d.]+)/i)
+  if (lch) return Number(lch[1])
+  const lab = value.match(/^oklab\(\s*[\d.]+%?\s+(-?[\d.]+)\s+(-?[\d.]+)/i)
+  if (lab) return Math.hypot(Number(lab[1]), Number(lab[2]))
+  return 1
 }
 
 /** Semi-transparent (`oklch(... / a)`) — an overlay/scrim, not a signature hue. */

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -19,9 +19,9 @@ export const MIN_COLLAPSE = 6
  * values (hex, rgb, named) read as chromatic.
  */
 export function colorChroma(value: string): number {
-  const lch = value.match(/^(?:oklch|lch)\(\s*[\d.]+%?\s+([\d.]+)/i)
+  const lch = value.match(/^(?:oklch|lch)\(\s*[\d.]+%?\s+([+-]?[\d.]+)/i)
   if (lch) return Number(lch[1])
-  const lab = value.match(/^oklab\(\s*[\d.]+%?\s+(-?[\d.]+)\s+(-?[\d.]+)/i)
+  const lab = value.match(/^oklab\(\s*[\d.]+%?\s+([+-]?[\d.]+)\s+([+-]?[\d.]+)/i)
   if (lab) return Math.hypot(Number(lab[1]), Number(lab[2]))
   return 1
 }


### PR DESCRIPTION
## 변경 요약

`src/lib/token-curation.ts`의 `colorChroma()`가 `oklab(L a b)` 값의 **2번째 컴포넌트(a축)** 를 chroma로 잘못 읽던 것을 수정합니다. oklab의 chroma는 `Math.hypot(a, b)`입니다(oklch/lch는 2번째가 chroma라 그대로). b가 큰 채도 높은 색이 회색으로 오분류돼 시그니처 큐레이션의 `chroma < 0.04` 필터에서 잘못 접힐 수 있던 잠재 버그입니다.

현재 사이드카 색값은 **전부 `oklch`**(674/674)라 즉시 영향은 없는 잠재 정확성 수정입니다. PR #127 코드리뷰(claude bot Round 4) 후속.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 주요 변경

- `colorChroma`: 포맷별 분기 — `oklch`/`lch`는 2번째 컴포넌트, `oklab`은 `Math.hypot(a, b)`. 비-LCh(hex/rgb 등)는 chromatic 기본값.
- `token-curation.test.ts`: TDD — b-dominant oklab 실패 테스트(`oklab(0.6 0.02 0.20)` → 0.02 ❌ → 0.201 ✓) + lch 회귀가드 추가.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (+ `pnpm test` 232 passed)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 검증

TDD(RED→GREEN): 현재 코드에서 `colorChroma("oklab(0.6 0.02 0.20)")`가 `0.02` 반환(회색 오분류) → 실패 확인 → `hypot(a,b)`로 수정 → `0.201`(chromatic) 통과. 기존 데이터는 전부 oklch라 동작 불변(13개 항목 시그니처 카운트 무변화).
