### PR TITLE
Add explicit "Copy MD" label to DESIGN.md copy button

### DIFF
--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -212,7 +212,7 @@ export function ServiceDetailLayout({
               The right slot is tab-aware: Live Preview gets the
               light/dark toggle (relevant), Tokens gets a "Copy JSON"
               shortcut (the full sidecar for AI prompts / Tailwind themes),
-              and DESIGN.md gets a quick copy shortcut for the raw source. */}
+              and DESIGN.md gets a "Copy MD" shortcut for the raw source. */}
           <div className="@container">
             <div className="flex flex-col items-start gap-3 @sm:flex-row @sm:items-center">
               <DetailTabsList>
@@ -241,6 +241,7 @@ export function ServiceDetailLayout({
                 <InlineCopyButton
                   raw={doc.raw}
                   filename={filename}
+                  label="Copy MD"
                   className="@sm:ml-auto"
                 />
               )}


### PR DESCRIPTION
## 변경 요약

DESIGN.md 탭의 복사 버튼에 명시적인 "Copy MD" 레이블을 추가하여 사용자 경험을 개선합니다. 주석도 함께 업데이트되어 일관성을 유지합니다.

## 변경 종류

- [x] 사이트 코드/UI

## 상세 설명

`InlineCopyButton` 컴포넌트에 `label="Copy MD"` prop을 추가하여 DESIGN.md 파일 복사 버튼의 목적을 명확하게 표시합니다. 이는 다른 탭의 버튼들(Live Preview의 light/dark toggle, Tokens의 "Copy JSON")과 일관된 UX를 제공합니다.

주석도 "quick copy shortcut"에서 "Copy MD" shortcut으로 변경하여 코드와 문서의 일관성을 유지합니다.

## 일반 체크

- [ ] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [ ] DCO 서명 (`git commit -s`)
- [ ] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

https://claude.ai/code/session_01F9mafuUMqDmY3dU2aK6iDh