### PR TITLE
fix(preview): 테마 토글이 뒤로 가기 히스토리를 오염시키지 않게

### DIFF
--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -95,17 +95,18 @@ function ServiceDetailPage() {
   const filename = `${doc.frontmatter.slug}.md`
 
   // Preview theme is independent of the site theme (which is locked to light).
-  // Default to dark to match the editorial reference (BMW M / Apple).
+  // Default to light: the site itself is light-only and the audience skews
+  // desktop, so the preview opens matching the surrounding page.
   //
-  // Why useState("dark") + reconcile useEffect instead of a lazy initializer:
+  // Why useState("light") + reconcile useEffect instead of a lazy initializer:
   // a lazy useState initializer that reads localStorage diverges between SSR
-  // (window undefined → "dark") and client (saved value → "light"). React 19
+  // (window undefined → "light") and client (saved value → "dark"). React 19
   // surfaces this as a hydration mismatch and refuses to patch the tree, which
   // breaks all subsequent interactivity. Hydrating to the server value first
   // and reconciling in an effect is the supported pattern. Persistence happens
   // inline in handleThemeChange so the SSR default never overwrites a saved
   // value before the reconcile lands.
-  const [previewTheme, setPreviewTheme] = useState<PreviewTheme>("dark")
+  const [previewTheme, setPreviewTheme] = useState<PreviewTheme>("light")
   useEffect(() => {
     const saved = window.localStorage.getItem(PREVIEW_THEME_STORAGE_KEY)
     if (saved === "light" || saved === "dark") setPreviewTheme(saved)

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -250,7 +250,12 @@ export function ServiceDetailLayout({
 
           <DetailTabsPanel value="preview">
             {previewAvailable ? (
+              // key by slug → remount (resets the frozen initialSrc + height
+              // inside PreviewFrame) when the service changes. Theme toggles
+              // keep the same key, so they stay on the no-history-entry
+              // location.replace path instead of remounting.
               <PreviewFrame
+                key={doc.frontmatter.slug}
                 slug={doc.frontmatter.slug}
                 theme={previewTheme}
               />

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -250,12 +250,7 @@ export function ServiceDetailLayout({
 
           <DetailTabsPanel value="preview">
             {previewAvailable ? (
-              // key by slug → remount (resets the frozen initialSrc + height
-              // inside PreviewFrame) when the service changes. Theme toggles
-              // keep the same key, so they stay on the no-history-entry
-              // location.replace path instead of remounting.
               <PreviewFrame
-                key={doc.frontmatter.slug}
                 slug={doc.frontmatter.slug}
                 theme={previewTheme}
               />

--- a/src/routes/services/-components/preview-frame.tsx
+++ b/src/routes/services/-components/preview-frame.tsx
@@ -64,27 +64,19 @@ export function PreviewFrame({ slug, theme }: Props) {
     }
   }, [theme, slug])
 
-  // The iframe's src is set only on first mount. Re-assigning src on an
-  // already-loaded iframe pushes a joint session-history entry, so the browser
-  // Back button would undo a theme switch. After mount we swap the document
-  // with contentWindow.location.replace(), which replaces the current history
-  // entry instead of pushing (the iframe is same-origin, so this is allowed).
+  // Keyed by src so a theme/slug change remounts the iframe as a fresh element
+  // instead of re-assigning src on the existing one. A new iframe's initial
+  // navigation REPLACES its blank history entry, whereas re-assigning src on a
+  // live iframe PUSHES onto the joint session history — which would make the
+  // browser Back button undo a theme switch. The remount keeps it out of
+  // history (same approach as the reference site, getdesign.md).
   const src = `/preview/${slug}/${theme}.html`
-  const initialSrc = useRef(src).current
-
-  const isFirstSrcEffect = useRef(true)
-  useEffect(() => {
-    if (isFirstSrcEffect.current) {
-      isFirstSrcEffect.current = false
-      return
-    }
-    iframeRef.current?.contentWindow?.location.replace(src)
-  }, [src])
 
   return (
     <iframe
+      key={src}
       ref={iframeRef}
-      src={initialSrc}
+      src={src}
       title={`${slug} design preview (${theme})`}
       scrolling="no"
       style={{

--- a/src/routes/services/-components/preview-frame.tsx
+++ b/src/routes/services/-components/preview-frame.tsx
@@ -64,12 +64,27 @@ export function PreviewFrame({ slug, theme }: Props) {
     }
   }, [theme, slug])
 
+  // The iframe's src is set only on first mount. Re-assigning src on an
+  // already-loaded iframe pushes a joint session-history entry, so the browser
+  // Back button would undo a theme switch. After mount we swap the document
+  // with contentWindow.location.replace(), which replaces the current history
+  // entry instead of pushing (the iframe is same-origin, so this is allowed).
   const src = `/preview/${slug}/${theme}.html`
+  const initialSrc = useRef(src).current
+
+  const isFirstSrcEffect = useRef(true)
+  useEffect(() => {
+    if (isFirstSrcEffect.current) {
+      isFirstSrcEffect.current = false
+      return
+    }
+    iframeRef.current?.contentWindow?.location.replace(src)
+  }, [src])
 
   return (
     <iframe
       ref={iframeRef}
-      src={src}
+      src={initialSrc}
       title={`${slug} design preview (${theme})`}
       scrolling="no"
       style={{


### PR DESCRIPTION
프리뷰(라이트/다크) 관련 동작 두 가지를 다룬다.

## 1. 테마 토글이 뒤로 가기 히스토리를 오염시키던 문제 수정

이미 로드된 `<iframe>`의 `src`를 재할당하면 joint session history에 항목이 push되어, Back 버튼이 페이지를 떠나는 대신 테마를 직전 값으로 되돌렸다.

**해결**: `<iframe>`에 `key={src}`를 부여해 테마/슬러그 변경 시 iframe을 **새 엘리먼트로 리마운트**한다. 새로 생성된 iframe의 초기 navigation은 `about:blank` 항목을 **replace**하므로 joint session history에 push되지 않는다. (모티브 사이트 [getdesign.md](https://getdesign.md/bmw-m/design-md)도 동일하게 토글 시 iframe을 리마운트한다.)

파일: `src/routes/services/-components/preview-frame.tsx` — `<iframe key={src} src={src}>` (선언적 1줄, 히스토리 처리에 추가 `useEffect`/`useRef` 없음).

## 2. 프리뷰 기본 테마를 dark → light로

사이트가 light 고정(`<html data-theme="light">`)이고 사용자가 데스크탑 위주라, 프리뷰도 주변 페이지와 맞게 light로 기본 진입한다.

파일: `src/routes/services/$slug.tsx` — SSR 기본값 `useState<PreviewTheme>("light")`만 변경. `localStorage`에 저장된 사용자 선택은 그대로 우선한다(reconcile `useEffect` 패턴 유지).

## 변경 종류

- [x] 사이트 코드/UI

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

---

## 구현 노트 (1번 관련)

### key의 위치 — 컴포넌트가 아니라 `<iframe>` 엘리먼트

`key`는 `<iframe>` 엘리먼트에만 있다. `PreviewFrame` **컴포넌트는 리마운트되지 않는다**(테마 변경 시 re-render만). 따라서:

- **높이 state는 유지된다** — 토글 시 `DEFAULT_HEIGHT(1200px)`로 리셋되지 않는다. 실측: dark↔light 토글 시 높이가 직전 값(~18,400px)을 유지하다 새 콘텐츠 높이로 재측정될 뿐, 1200px로 떨어지는 구간 없음.
- **높이 측정 effect의 deps `[theme, slug]`는 필요하다** — 컴포넌트가 유지되므로, 토글 시 effect가 재실행돼 **리마운트된 새 iframe에 load 리스너·ResizeObserver를 다시 붙인다**. deps를 `[]`로 바꾸면 새 iframe에 옵저버가 붙지 않아 측정이 깨진다. 실측: light 토글 후 높이가 콘텐츠 `scrollHeight`와 정확히 일치(재측정 동작 확인).

### 트레이드오프

토글마다 iframe이 새 엘리먼트로 교체되어 프리뷰 HTML을 다시 로드한다. 단, 이는 직전 `src` 재할당 방식·`location.replace` 방식과 **동일**(회귀 아님)하고, 정적 파일이라 브라우저 캐시(`Cache-Control`/ETag)가 적용된다.

## 검증 (dev 서버 실측)

- 테마 토글 반복 시 `history.length` **불변**, 토글 시 iframe **리마운트**(엘리먼트 마커 소멸)
- 토글 후 Back → 테마 복원이 아니라 **직전 라우트(홈)로 이동**
- 높이: 1200px 리셋 없음, 콘텐츠 `scrollHeight`와 일치하게 재측정
- 기본 테마: `localStorage` 비운 상태에서 **light** 기본 진입, dark 선택 후 reload 시 dark 유지(override)
- `typecheck` · `lint` · `build` 통과
