### PR TITLE
feat: use-design-md 소비자 스킬 + 루트 /llms.txt 카탈로그 인덱스

### DIFF
--- a/.claude/skills/use-design-md/SKILL.md
+++ b/.claude/skills/use-design-md/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: use-design-md
+description: Pull a Korean brand's published design.md from the ko-design-md catalog (getdesign.kr) and apply its design language — colors, typography, spacing, radius, components, do's & don'ts — to the UI you are building in the CURRENT project. Use this skill whenever the user wants to build or restyle UI in the *style of* a catalogued Korean service: phrases like "토스 디자인으로 만들어줘", "당근 스타일로 이 화면 다시 꾸며줘", "getdesign 카탈로그에서 배민 디자인 가져와서 적용", "KRDS 톤으로 폼 잡아줘", "make this look like Toss", "use the Karrot design system here", or "/use-design-md". Works in ANY repository — it fetches over the network, no local catalog needed. Do NOT use this to ADD a brand to the catalog or edit catalog entries — that is the separate `design-md` producer skill, which only runs inside the ko-design-md repo. If the requested brand isn't in the catalog, say so plainly rather than inventing a design.md.
+---
+
+# use-design-md — consumer skill for the ko/design.md catalog
+
+## Mental model
+
+The ko-design-md catalog (https://getdesign.kr) publishes one `design.md` per Korean
+service — a compact, machine-readable description of that brand's visual language:
+colors in OKLCH, typography, spacing, radius, signature components, and do's & don'ts.
+This skill is the **consumer** side: it pulls the right entry and uses it as the design
+brief for UI work in **whatever project you are currently in**.
+
+It does three things, in order:
+
+1. **Discover** — resolve the brand the user named to a catalog `slug`.
+2. **Fetch** — download that entry's raw `design.md` (and, if useful, its token sidecar).
+3. **Apply** — translate that design language into the current project's styling system.
+
+## This skill vs. `design-md` (don't mix them up)
+
+- **`use-design-md` (this skill)** — CONSUME an existing entry. Runs in any repo.
+  "Make my dashboard look like Toss", "apply Karrot's style to this screen".
+- **`design-md` (the other skill)** — PRODUCE a new entry, adding a brand to the catalog.
+  Only runs inside the ko-design-md repo.
+
+If the user wants to *add* or *edit* a catalog entry, stop and point them at `design-md`.
+That is a different job in a different place.
+
+## Step 1 — Discover: resolve the brand to a slug
+
+Fetch the catalog index (llms.txt format, ~one line per entry):
+
+```
+curl -s https://getdesign.kr/llms.txt
+```
+
+Each entry line looks like:
+
+```
+- [토스](https://getdesign.kr/services/toss/llms.txt): finance — <tagline>
+```
+
+Match the user's mention to a slug. The user may say a Korean name ("토스", "당근"), an
+English name ("Toss", "Karrot"), a design-system name ("SEED Design", "Vapor UI"), or the
+slug itself ("seed-design"). Match against the link text (name) AND the slug in the URL;
+the tagline often names the design system, which helps disambiguate.
+
+Outcomes:
+- **One clear match** → take its slug, go to Step 2.
+- **Several plausible matches** → ask which one with `AskUserQuestion`.
+- **No match** → the brand isn't in the catalog. Tell the user plainly, optionally list a
+  few catalogued brands in the nearest category, and mention that *adding* it is a
+  separate job (the `design-md` skill, inside the ko-design-md repo). Do not fabricate a
+  design.md for an uncatalogued brand — that defeats the point of citing a real source.
+
+See `references/endpoints.md` for the full endpoint map and fallbacks.
+
+## Step 2 — Fetch the design.md (and tokens if needed)
+
+Fetch the raw entry:
+
+```
+curl -s https://getdesign.kr/services/<slug>/llms.txt
+```
+
+**Use `curl` (Bash), not WebFetch, for the entry.** WebFetch summarizes and transforms
+content through a model, which silently drops exact token values — an OKLCH triple, a
+13px spacing step, a specific weight. The whole reason to pull from the catalog is
+fidelity to the brand's *real* numbers, so fetch the bytes verbatim. WebFetch is an
+acceptable last resort only when Bash/curl is genuinely unavailable.
+
+If you need tokens as structured data (e.g. to generate a Tailwind theme or a CSS
+variable block programmatically), also fetch the sidecar from GitHub raw — there is no
+getdesign.kr endpoint for it yet:
+
+```
+curl -s https://raw.githubusercontent.com/CaesiumY/ko-design-md/main/services/<slug>.tokens.json
+```
+
+Read the design.md fully before applying anything. The prose carries intent — the do's &
+don'ts, the voice — that the token JSON alone doesn't capture.
+
+## Step 3 — Apply to the current project
+
+This is the real work, and it's project-specific. Read `references/apply-guide.md` and
+follow it. In short:
+
+1. **Detect the target styling system first** (Tailwind config, CSS custom properties,
+   CSS-in-JS, plain CSS) before changing anything.
+2. **Map tokens onto that system** rather than pasting raw values everywhere — change
+   them at the source so the whole surface moves together.
+3. **Honor the Do's & Don'ts.** They're the brand's guardrails, not decoration.
+4. For a large or structural change, route through `superpowers:brainstorming` first;
+   for a small restyle, just go.
+5. **Verify** the result (preview/screenshot, or the project's tests) before claiming done
+   (`superpowers:verification-before-completion`).
+
+## Scope guardrails
+
+- Don't gate on the current repo — this skill is meant to run anywhere.
+- Don't invent values absent from the fetched design.md. If the user wants something the
+  brand's tokens don't cover, say so and propose a reasonable extension marked as *your*
+  inference, not the brand's spec.
+- The catalog covers Korean services. A brand that isn't listed simply isn't available
+  here — be honest about that instead of approximating from memory.

--- a/.claude/skills/use-design-md/SKILL.md
+++ b/.claude/skills/use-design-md/SKILL.md
@@ -93,10 +93,11 @@ follow it. In short:
 2. **Map tokens onto that system** rather than pasting raw values everywhere — change
    them at the source so the whole surface moves together.
 3. **Honor the Do's & Don'ts.** They're the brand's guardrails, not decoration.
-4. For a large or structural change, route through `superpowers:brainstorming` first;
+4. For a large or structural change, design it first before coding (in Claude Code:
+   `superpowers:brainstorming`; in other agents, an equivalent brainstorming step);
    for a small restyle, just go.
-5. **Verify** the result (preview/screenshot, or the project's tests) before claiming done
-   (`superpowers:verification-before-completion`).
+5. **Verify** the result (preview/screenshot, or the project's tests) before claiming
+   done — evidence before assertions (in Claude Code: `superpowers:verification-before-completion`).
 
 ## Scope guardrails
 

--- a/.claude/skills/use-design-md/references/apply-guide.md
+++ b/.claude/skills/use-design-md/references/apply-guide.md
@@ -1,0 +1,58 @@
+# Apply guide — translating a design.md into the current project
+
+The fetched design.md is a *brief*, not code. The job is to express its intent in the
+target project's own styling system without flattening the brand's character or fighting
+the codebase you're in.
+
+## 1. Detect the target styling system first
+
+Before editing, figure out how this project styles UI, and work with its grain:
+
+- **Tailwind** — look for `tailwind.config.{js,ts}` or an `@theme` block in CSS, plus
+  utility classes in JSX. Map tokens into the theme (colors, fontFamily, spacing,
+  borderRadius), then use utilities. Don't scatter arbitrary `[#hex]` values.
+- **CSS custom properties** — a `:root { --… }` block or a design-token file. Add/override
+  variables there; don't sprinkle literals through components.
+- **CSS-in-JS** (styled-components, emotion, vanilla-extract) — find the theme object and
+  extend it.
+- **Plain CSS / inline** — introduce a small variable block at the top scope and reference
+  it.
+
+A brand restyle that fights the project's system creates debt; one that flows through its
+tokens stays maintainable.
+
+## 2. Map the design.md sections
+
+| design.md section   | Where it lands in the target |
+|---------------------|------------------------------|
+| Colors (OKLCH)      | color tokens / theme palette; keep semantic roles (primary, surface, ink) |
+| Typography          | font-family + size/weight/line-height scale; load webfonts if the md gives a `font-*-src` URL |
+| Spacing             | spacing scale — gap & padding steps |
+| Rounded (radius)    | border-radius scale |
+| Elevation & Depth   | shadow tokens |
+| Components          | reference patterns for buttons, cards, inputs — match structure & states, don't clone pixel-for-pixel |
+| Do's & Don'ts       | hard constraints to honor (e.g. "pure black 금지", "CTA fill은 1차 액션에만") |
+
+## 3. OKLCH values
+
+The catalog expresses color in OKLCH. Modern CSS supports `oklch()` directly — prefer
+keeping it (wider gamut, perceptually uniform, and it's what the brand actually specified).
+Only convert to hex/rgb when the target toolchain genuinely can't consume `oklch()`, and
+when you do, note that the converted value is an approximation, not the brand's exact spec.
+
+## 4. Fidelity & attribution
+
+- Pull the real numbers from the md; don't approximate when the value is given.
+- When you must go beyond what the brand documents, mark it as *your* inference, not the
+  brand's spec — the user should know which parts are faithful and which are filled in.
+- A design.md cites its sources with `[src:N]`; you don't need to carry those into the
+  target project, but do preserve the brand's stated intent when it's explicit.
+
+## 5. Scope & verification
+
+- Large or structural work → run `superpowers:brainstorming` before coding.
+- Restyle of an existing screen → proceed, but change tokens at the source so the whole
+  surface moves together rather than patching one component at a time.
+- Verify visually (preview/screenshot) or via the project's tests before saying it's done
+  (`superpowers:verification-before-completion`). A brand restyle is a visual claim —
+  back it with a visual check.

--- a/.claude/skills/use-design-md/references/apply-guide.md
+++ b/.claude/skills/use-design-md/references/apply-guide.md
@@ -50,9 +50,10 @@ when you do, note that the converted value is an approximation, not the brand's 
 
 ## 5. Scope & verification
 
-- Large or structural work → run `superpowers:brainstorming` before coding.
+- Large or structural work → design it first before coding (Claude Code:
+  `superpowers:brainstorming`; other agents: an equivalent design step).
 - Restyle of an existing screen → proceed, but change tokens at the source so the whole
   surface moves together rather than patching one component at a time.
 - Verify visually (preview/screenshot) or via the project's tests before saying it's done
-  (`superpowers:verification-before-completion`). A brand restyle is a visual claim —
-  back it with a visual check.
+  — evidence before assertions (Claude Code: `superpowers:verification-before-completion`).
+  A brand restyle is a visual claim — back it with a visual check.

--- a/.claude/skills/use-design-md/references/endpoints.md
+++ b/.claude/skills/use-design-md/references/endpoints.md
@@ -1,0 +1,56 @@
+# Endpoints — ko-design-md catalog (getdesign.kr)
+
+Fetch order and fallbacks for the consumer skill. All getdesign.kr endpoints below are
+`text/plain`, CORS-open (`access-control-allow-origin: *`), and CDN-cached ~1h.
+
+## 1. Catalog index (discover)
+
+```
+GET https://getdesign.kr/llms.txt
+```
+
+llms.txt format — a header plus one markdown link per entry:
+
+```
+- [<name>](https://getdesign.kr/services/<slug>/llms.txt): <category> — <tagline>
+```
+
+Use it to resolve a brand name to a slug and to browse by category. It is generated
+server-side from the live catalog, so it is always current — no stale hardcoded list.
+
+## 2. Single entry (fetch)
+
+```
+GET https://getdesign.kr/services/<slug>/llms.txt
+```
+
+Returns the raw `design.md` (Stitch v0.1 markdown with YAML frontmatter). Prefer
+`curl -s` over WebFetch to preserve exact token values (see SKILL.md Step 2 for why).
+
+## 3. Token sidecar (optional, structured tokens)
+
+```
+GET https://raw.githubusercontent.com/CaesiumY/ko-design-md/main/services/<slug>.tokens.json
+```
+
+JSON shape: `{ colors[], typography[], spacing[], radius[] }`. Each color has
+`name`/`value` (value usually OKLCH) plus optional `note`/`group`. There is no
+getdesign.kr endpoint for tokens yet — GitHub raw is the source of record. If a tokens
+endpoint appears on getdesign.kr later, prefer it and update this file.
+
+## Fallbacks
+
+- If getdesign.kr is unreachable, the same markdown is on GitHub raw:
+  `https://raw.githubusercontent.com/CaesiumY/ko-design-md/main/services/<slug>.md`
+- The index has no GitHub-raw equivalent (it's generated server-side). To list entries
+  without the index, read the repo's `services/` directory via the GitHub API, or fall
+  back to `https://getdesign.kr/sitemap.xml` (URLs only — no names/categories/taglines).
+
+## Example
+
+```bash
+slug=toss
+curl -s https://getdesign.kr/llms.txt                                                   # find the slug
+curl -s https://getdesign.kr/services/$slug/llms.txt                                     # the design.md
+curl -s https://raw.githubusercontent.com/CaesiumY/ko-design-md/main/services/$slug.tokens.json  # tokens (optional)
+```

--- a/.claude/skills/use-design-md/trigger-eval-queries.json
+++ b/.claude/skills/use-design-md/trigger-eval-queries.json
@@ -1,0 +1,82 @@
+[
+  {
+    "query": "내 사이드프로젝트 대시보드를 토스처럼 보이게 다시 꾸며줘. 지금 tailwind 쓰고 있어",
+    "should_trigger": true
+  },
+  {
+    "query": "당근마켓 스타일로 이 로그인 화면 색이랑 버튼 톤 맞춰줄래? getdesign 카탈로그에 있던데",
+    "should_trigger": true
+  },
+  {
+    "query": "make my pricing page look like Baemin — that mint + rounded card vibe. it's a next.js project with css modules",
+    "should_trigger": true
+  },
+  {
+    "query": "KRDS 톤으로 공공서비스 느낌나게 폼 컴포넌트 스타일 잡아줘. 정부과제라 그 신뢰감 있는 톤이 필요해",
+    "should_trigger": true
+  },
+  {
+    "query": "쏘카 디자인 시스템 가져와서 우리 모빌리티 앱 프로토타입 색이랑 컴포넌트에 적용해줘",
+    "should_trigger": true
+  },
+  {
+    "query": "/use-design-md 원티드",
+    "should_trigger": true
+  },
+  {
+    "query": "이 버튼들 getdesign.kr에 있는 토스 design.md 기준으로 다시 만들어줘. oklch 색은 그대로 써도 돼",
+    "should_trigger": true
+  },
+  {
+    "query": "우리 회사 내부 툴이 너무 밋밋한데, 한국 서비스 중에 당근 같은 친근한 디자인을 입히고 싶어. 카탈로그에서 찾아서 적용 가능?",
+    "should_trigger": true
+  },
+  {
+    "query": "apply the SEED design system tokens to my component library — at least the colors and the radius scale",
+    "should_trigger": true
+  },
+  {
+    "query": "스타벅스코리아 느낌으로 카페 주문 앱 ui 잡아줘 — 한국 서비스 디자인 카탈로그에 있으면 그거 참고해서",
+    "should_trigger": true
+  },
+  {
+    "query": "토스를 ko-design-md 카탈로그에 새 항목으로 추가하고 싶어. design.md랑 preview HTML 만들어줘",
+    "should_trigger": false
+  },
+  {
+    "query": "services/toss.md의 spacing 섹션에 오타 하나 있어 — 'spacng'을 'spacing'으로 고쳐줘",
+    "should_trigger": false
+  },
+  {
+    "query": "design.md 포맷이 뭐야? Stitch v0.1이랑 일반 마크다운이랑 뭐가 다른지 설명해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "Figma에서 토스 디자인 키트 받아서 내 프로젝트에 적용하는 방법 알려줘",
+    "should_trigger": false
+  },
+  {
+    "query": "shadcn/ui 테마를 우리 브랜드 색으로 커스터마이즈해줘. 브랜드 메인 컬러는 #1B64DA야",
+    "should_trigger": false
+  },
+  {
+    "query": "getdesign.kr 같은 디자인 카탈로그 사이트를 처음부터 직접 하나 만들고 싶어. 스택 추천해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "ko-design-md repo의 src/routes/llms[.]txt.ts 라우트에 버그 있나 한 번 봐줘. 404가 이상해",
+    "should_trigger": false
+  },
+  {
+    "query": "우리 스타트업용 디자인 시스템을 처음부터 하나 정의해줘. 보라색 계열에 둥근 느낌으로",
+    "should_trigger": false
+  },
+  {
+    "query": "Material Design 3 가이드라인대로 안드로이드 앱 ui 컴포넌트 만들어줘",
+    "should_trigger": false
+  },
+  {
+    "query": "내 프로젝트에 있는 design-tokens.json 파일을 css 변수 블록으로 변환해줘",
+    "should_trigger": false
+  }
+]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 토스 디자인으로 이 대시보드 다시 꾸며줘
 ```
 
-내부적으로는 카탈로그 인덱스([`getdesign.kr/llms.txt`](https://getdesign.kr/llms.txt))로 슬러그를 찾고, 항목별 원본(`getdesign.kr/services/{slug}/llms.txt`)을 평문으로 받아 적용합니다. 다른 프로젝트에서 쓰려면 이 스킬 디렉터리를 에이전트의 전역/프로젝트 스킬 경로(예: `~/.claude/skills/`)로 복사하세요. 가져올 수 있는 브랜드 목록은 라이브 카탈로그 **[getdesign.kr](https://getdesign.kr)**에서 확인할 수 있습니다.
+내부적으로는 카탈로그 인덱스([`getdesign.kr/llms.txt`](https://getdesign.kr/llms.txt))로 슬러그를 찾고, 항목별 원본(`getdesign.kr/services/{slug}/llms.txt`)을 평문으로 받아 적용합니다. 다른 프로젝트에서 쓰려면 이 스킬 디렉터리를 에이전트의 전역/프로젝트 스킬 경로(Claude Code 기준 `~/.claude/skills/`; 다른 도구는 해당 도구의 스킬 설정 경로)로 복사하세요. 가져올 수 있는 브랜드 목록은 라이브 카탈로그 **[getdesign.kr](https://getdesign.kr)**에서 확인할 수 있습니다.
 
 ## 항목 구성
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@
 
 `## Components`가 도메인 특화 이름(`button-cta`="구매하기", `EtaBanner`)을 쓰는 것은 출처를 정확히 기록하기 위함이지, 그 도메인을 함께 복사하라는 뜻이 아닙니다.
 
+## 카탈로그를 코딩 에이전트에서 바로 쓰기 — `use-design-md` 스킬
+
+호환되는 AI 코딩 에이전트라면 위 "차용" 과정을 [`use-design-md` 스킬](./.claude/skills/use-design-md/SKILL.md)로 자동화할 수 있습니다. 브랜드명만 주면 카탈로그에서 해당 `design.md`를 찾아 받아와 **지금 작업 중인 프로젝트**의 UI에 그 디자인 언어(색·타이포·간격·둥글기·컴포넌트)를 입힙니다. 카탈로그를 *읽는* 쪽이라 **어느 repo에서든 동작**합니다(새 항목을 *추가*하는 `/design-md` 생산자 스킬과 역할이 반대).
+
+```text
+토스 디자인으로 이 대시보드 다시 꾸며줘
+```
+
+내부적으로는 카탈로그 인덱스([`getdesign.kr/llms.txt`](https://getdesign.kr/llms.txt))로 슬러그를 찾고, 항목별 원본(`getdesign.kr/services/{slug}/llms.txt`)을 평문으로 받아 적용합니다. 다른 프로젝트에서 쓰려면 이 스킬 디렉터리를 에이전트의 전역/프로젝트 스킬 경로(예: `~/.claude/skills/`)로 복사하세요. 가져올 수 있는 브랜드 목록은 라이브 카탈로그 **[getdesign.kr](https://getdesign.kr)**에서 확인할 수 있습니다.
+
 ## 항목 구성
 
 각 항목은 다음 4종으로 구성됩니다.

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -277,6 +277,27 @@ describe("buildLlmsTxt", () => {
     )
   })
 
+  it("falls back to the service name when the tagline is whitespace-only", () => {
+    const txt = buildLlmsTxt({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Whitespace Tagline",
+          slug: "whitespace-tagline",
+          lastUpdated: "2026-05-10",
+          body: "body",
+          tagline: "   \n\t ",
+        }),
+      ],
+    })
+
+    expect(txt).toContain(
+      "- [Whitespace Tagline](https://ko-design.example/services/whitespace-tagline/llms.txt): etc — Whitespace Tagline",
+    )
+    // a whitespace-only tagline must not leave a dangling "— " at the line end
+    expect(txt).not.toMatch(/— *$/m)
+  })
+
   it("collapses whitespace so every entry stays on a single line", () => {
     const txt = buildLlmsTxt({
       siteUrl: SITE_URL,

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from "vitest"
 import {
+  buildLlmsTxt,
   buildRobotsTxt,
   buildRssXml,
   buildSitemapXml,
@@ -232,6 +233,96 @@ describe("buildRssXml with real /services/*.md content", () => {
       // textContent decodes entities, so the bound matches truncateForMeta
       // exactly: max=500 + "…" = 501.
       expect(desc.length).toBeLessThanOrEqual(501)
+    }
+  })
+})
+
+describe("buildLlmsTxt", () => {
+  it("lists each service as a markdown link to its raw llms.txt endpoint with category and tagline", () => {
+    const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: docs })
+
+    expect(txt).toContain(
+      "- [토스](https://ko-design.example/services/toss/llms.txt): etc — 토스 디자인 원칙 전체 본문입니다.",
+    )
+    expect(txt).toContain(
+      "- [A&B <Design>](https://ko-design.example/services/a-b/llms.txt): etc — 요약에도 & 문자가 들어갑니다.",
+    )
+    // links point at the raw endpoint, not the human detail page
+    expect(txt).not.toContain("/services/toss):")
+  })
+
+  it("emits the llmstxt.org header (title + summary + Catalog section)", () => {
+    const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: docs })
+
+    expect(txt).toContain("# ko/design.md")
+    expect(txt).toContain("## Catalog")
+  })
+
+  it("falls back to the service name when the tagline is empty", () => {
+    const txt = buildLlmsTxt({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Heading Only",
+          slug: "heading-only",
+          lastUpdated: "2026-05-10",
+          body: "# 헤딩만 있음",
+          tagline: "",
+        }),
+      ],
+    })
+
+    expect(txt).toContain(
+      "- [Heading Only](https://ko-design.example/services/heading-only/llms.txt): etc — Heading Only",
+    )
+  })
+
+  it("collapses whitespace so every entry stays on a single line", () => {
+    const txt = buildLlmsTxt({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "Multiline",
+          slug: "multiline",
+          lastUpdated: "2026-05-10",
+          body: "body",
+          tagline: "첫 줄\n둘째 줄",
+        }),
+      ],
+    })
+
+    expect(txt).toContain("— 첫 줄 둘째 줄") // newline collapsed to a space
+    // the catalog list must have exactly one line beginning with "- ["
+    const entryLines = txt.split("\n").filter((line) => line.startsWith("- ["))
+    expect(entryLines).toHaveLength(1)
+  })
+
+  it("does not throw and still emits the header for an empty catalog", () => {
+    const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: [] })
+
+    expect(txt).toContain("# ko/design.md")
+    expect(txt).toContain("## Catalog")
+    expect(txt.split("\n").filter((line) => line.startsWith("- ["))).toHaveLength(
+      0,
+    )
+  })
+})
+
+describe("buildLlmsTxt with real /services/*.md content", () => {
+  const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: getAllServices() })
+
+  it("emits exactly one catalog entry per service", () => {
+    const entryLines = txt.split("\n").filter((line) => line.startsWith("- ["))
+    expect(entryLines).toHaveLength(getAllServices().length)
+    expect(entryLines.length).toBeGreaterThan(0)
+  })
+
+  it("links every entry to a /services/{slug}/llms.txt endpoint", () => {
+    const entryLines = txt.split("\n").filter((line) => line.startsWith("- ["))
+    for (const line of entryLines) {
+      expect(line).toMatch(
+        /\]\(https:\/\/ko-design\.example\/services\/[^/]+\/llms\.txt\): /,
+      )
     }
   })
 })

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -298,6 +298,26 @@ describe("buildLlmsTxt", () => {
     expect(txt).not.toMatch(/— *$/m)
   })
 
+  it("escapes markdown link-text brackets in the service name", () => {
+    const txt = buildLlmsTxt({
+      siteUrl: SITE_URL,
+      services: [
+        serviceDoc({
+          name: "서비스]X",
+          slug: "bracket-name",
+          lastUpdated: "2026-05-10",
+          body: "본문",
+          tagline: "괄호 포함 이름",
+        }),
+      ],
+    })
+
+    // the `]` is escaped so the link text doesn't terminate early
+    expect(txt).toContain(
+      "- [서비스\\]X](https://ko-design.example/services/bracket-name/llms.txt): etc — 괄호 포함 이름",
+    )
+  })
+
   it("collapses whitespace so every entry stays on a single line", () => {
     const txt = buildLlmsTxt({
       siteUrl: SITE_URL,

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -140,11 +140,12 @@ export function buildLlmsTxt({ siteUrl, services }: FeedInput): string {
     const { name, slug, category } = doc.frontmatter
     const url = canonicalUrl(origin, `/services/${slug}/llms.txt`)
     // Collapse whitespace before truncating: taglines are derived from prose and
-    // may contain newlines, which would break the one-line-per-entry list.
-    const tagline = truncateForMeta(
-      (doc.tagline || name).replace(/\s+/g, " ").trim(),
-      160,
-    )
+    // may contain newlines, which would break the one-line-per-entry list. Clean
+    // first, THEN fall back to the brand name — a whitespace-only tagline is
+    // truthy, so `doc.tagline || name` alone would let it through and trim to an
+    // empty string, leaving a dangling "— " at the end of the entry.
+    const cleaned = (doc.tagline || "").replace(/\s+/g, " ").trim()
+    const tagline = truncateForMeta(cleaned || name, 160)
     return `- [${name}](${url}): ${category} — ${tagline}`
   })
 

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -139,6 +139,10 @@ export function buildLlmsTxt({ siteUrl, services }: FeedInput): string {
   const entries = services.map((doc) => {
     const { name, slug, category } = doc.frontmatter
     const url = canonicalUrl(origin, `/services/${slug}/llms.txt`)
+    // Escape markdown link-text brackets in the name: a `]` in a brand name would
+    // otherwise close the link text early and corrupt the entry. No current entry
+    // hits this, but the index must stay valid markdown as the catalog grows.
+    const safeName = name.replace(/[[\]]/g, "\\$&")
     // Collapse whitespace before truncating: taglines are derived from prose and
     // may contain newlines, which would break the one-line-per-entry list. Clean
     // first, THEN fall back to the brand name — a whitespace-only tagline is
@@ -146,7 +150,7 @@ export function buildLlmsTxt({ siteUrl, services }: FeedInput): string {
     // empty string, leaving a dangling "— " at the end of the entry.
     const cleaned = (doc.tagline || "").replace(/\s+/g, " ").trim()
     const tagline = truncateForMeta(cleaned || name, 160)
-    return `- [${name}](${url}): ${category} — ${tagline}`
+    return `- [${safeName}](${url}): ${category} — ${tagline}`
   })
 
   return [

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -128,6 +128,39 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
     .join("\n")
 }
 
+// Agent-facing catalog index following the llms.txt convention
+// (https://llmstxt.org). Complements the per-entry `/services/{slug}/llms.txt`
+// raw-markdown endpoints: this root index is what an agent reads first to learn
+// which entries exist and resolve a brand name to a slug. Built from the same
+// `getAllServices()` source as the sitemap, so new entries appear automatically
+// — no hand-maintained list to drift.
+export function buildLlmsTxt({ siteUrl, services }: FeedInput): string {
+  const origin = normalizeSiteUrl(siteUrl)
+  const entries = services.map((doc) => {
+    const { name, slug, category } = doc.frontmatter
+    const url = canonicalUrl(origin, `/services/${slug}/llms.txt`)
+    // Collapse whitespace before truncating: taglines are derived from prose and
+    // may contain newlines, which would break the one-line-per-entry list.
+    const tagline = truncateForMeta(
+      (doc.tagline || name).replace(/\s+/g, " ").trim(),
+      160,
+    )
+    return `- [${name}](${url}): ${category} — ${tagline}`
+  })
+
+  return [
+    `# ${SITE_TITLE}`,
+    "",
+    `> ${SITE_DESCRIPTION}`,
+    "> 각 항목의 원본 design.md는 링크(.../llms.txt)에서 평문 마크다운으로 받을 수 있습니다.",
+    "",
+    "## Catalog",
+    "",
+    ...entries,
+    "",
+  ].join("\n")
+}
+
 export function buildRobotsTxt(siteUrl: string): string {
   const origin = normalizeSiteUrl(siteUrl)
   return [

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ServicesSlugRouteImport } from './routes/services/$slug'
 import { Route as ServicesSlugLlmsDottxtRouteImport } from './routes/services/$slug/llms[.]txt'
@@ -29,6 +30,11 @@ const RssDotxmlRoute = RssDotxmlRouteImport.update({
 const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
   id: '/robots.txt',
   path: '/robots.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -49,6 +55,7 @@ const ServicesSlugLlmsDottxtRoute = ServicesSlugLlmsDottxtRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
@@ -57,6 +64,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
@@ -66,6 +74,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
@@ -76,6 +85,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/llms.txt'
     | '/robots.txt'
     | '/rss.xml'
     | '/sitemap.xml'
@@ -84,6 +94,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/llms.txt'
     | '/robots.txt'
     | '/rss.xml'
     | '/sitemap.xml'
@@ -92,6 +103,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/llms.txt'
     | '/robots.txt'
     | '/rss.xml'
     | '/sitemap.xml'
@@ -101,6 +113,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   RssDotxmlRoute: typeof RssDotxmlRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
@@ -128,6 +141,13 @@ declare module '@tanstack/react-router' {
       path: '/robots.txt'
       fullPath: '/robots.txt'
       preLoaderRoute: typeof RobotsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -168,6 +188,7 @@ const ServicesSlugRouteWithChildren = ServicesSlugRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LlmsDottxtRoute: LlmsDottxtRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
   RssDotxmlRoute: RssDotxmlRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,

--- a/src/routes/llms[.]txt.ts
+++ b/src/routes/llms[.]txt.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { getAllServices } from "@/lib/content-collection"
+import { SITE_URL } from "@/lib/site-config"
+import { buildLlmsTxt, siteUrlFromRequest } from "@/lib/seo-feed"
+
+const TEXT_HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "public, max-age=0, s-maxage=3600",
+  // Open CORS so client-side agents (browser extensions, custom GPTs, web IDEs)
+  // can fetch the catalog index directly — matches the per-entry llms.txt route.
+  "access-control-allow-origin": "*",
+}
+
+export const Route = createFileRoute("/llms.txt")({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        return new Response(
+          buildLlmsTxt({
+            siteUrl: siteUrlFromRequest(SITE_URL, request),
+            services: getAllServices(),
+          }),
+          { headers: TEXT_HEADERS },
+        )
+      },
+    },
+  },
+})


### PR DESCRIPTION
## 변경 요약

카탈로그의 design.md를 다른 프로젝트에서 **가져와 적용**하는 소비자용 스킬 `use-design-md`를 추가하고, 그 스킬이 카탈로그를 탐색할 수 있도록 에이전트용 인덱스 `/llms.txt`(llmstxt.org 표준)를 사이트에 추가합니다. 기존 생산자 스킬 `design-md`(항목 *추가*)의 정반대 방향 — 카탈로그의 실사용(소비) 경로를 채웁니다.

**A. 웹앱 — 루트 `/llms.txt` 인덱스** (`9cde543`)
- `sitemap.xml`과 동일하게 `getAllServices()`로 매 요청 시 **동적 생성** → 카탈로그 업데이트 시 수동 관리 0
- 이름·슬러그·카테고리·태그라인 + 항목별 `/services/{slug}/llms.txt` 링크 노출, CORS 개방(기존 per-entry 라우트와 동일)
- `buildLlmsTxt()` 단위 테스트 7개 추가

**B. 스킬 — `use-design-md`** (`bd32a28`)
- discover(`/llms.txt`로 브랜드→슬러그 해석) → fetch(`/services/{slug}/llms.txt`를 curl로 정밀 수신) → apply(대상 스타일 시스템에 토큰 매핑, Do's·Don'ts 준수)
- repo 게이트 없이 **어느 프로젝트에서나** 동작(생산자 `design-md`와 명확히 구분), `references/`(endpoints·apply-guide)·트리거 평가 쿼리 동봉
- README에 사용법 안내 추가

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

> 신규 **소비자 스킬 `use-design-md`**(`.claude/skills/`)도 포함됩니다 — 기존 `/design-md`(생산자)와는 별개의 스킬입니다.

## 카탈로그 PR 체크 (해당 시)

N/A — 카탈로그 항목 변경이 아닙니다.

## 일반 체크

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm exec vite build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

> `pnpm build`의 `build:og` 단계(OG 이미지, sharp 네이티브)는 이 변경과 무관하며, 본 워크트리에서 sharp 빌드 스크립트가 미승인이라 로컬에서 실행하지 않았습니다 — CI가 커버합니다. 사이트 빌드 자체는 `vite build`로 성공 검증했습니다.

## 검증

- **인덱스**: 로컬 dev에서 `GET /llms.txt` → 200, 13개 항목(이름·카테고리·태그라인·링크), `Access-Control-Allow-Origin: *` 확인. 엔드포인트 스모크 테스트(per-entry 200 / tokens 200 / 루트 인덱스는 배포 후 라이브).
- **스킬 콜드 테스트**: 스킬 파일만 가진 서브에이전트가 토스 design.md를 받아 샘플 가격표 페이지에 적용 — 실제 OKLCH 값(`blue-500: oklch(0.624 0.176 254)` 등)과 Do's/Don'ts(화면당 단일 액센트·순수 검정 금지·tabular-nums)가 반영됨을 before/after로 확인.

> 참고: 스킬의 discover 단계가 쓰는 루트 `/llms.txt`는 이 PR 배포 후 프로덕션에서 라이브가 됩니다. 그 전까지는 항목별 엔드포인트/ GitHub raw fallback으로 graceful degrade합니다.
