### PR TITLE
chore(ci): prettier 포맷 일괄 정리 + format:check 게이트 + .gitattributes(eol=lf)

### DIFF
--- a/.claude/skills/docs-crawler/scripts/crawl.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl.ts
@@ -61,7 +61,7 @@ const CONCURRENCY = 5
 async function mapLimit<T, R>(
   items: Array<T>,
   limit: number,
-  fn: (item: T) => Promise<R>,
+  fn: (item: T) => Promise<R>
 ): Promise<Array<R>> {
   const results: Array<R> = new Array(items.length)
   let cursor = 0
@@ -83,7 +83,7 @@ function errorMessage(error: unknown): string {
 
 async function crawlPage(
   url: string,
-  robots: RobotsRules,
+  robots: RobotsRules
 ): Promise<PageResult> {
   if (!isAllowed(url, robots)) {
     return {
@@ -111,7 +111,7 @@ async function crawlPage(
         }
       } catch (error) {
         console.warn(
-          `[crawl] JS fallback unavailable for ${url}: ${errorMessage(error)}`,
+          `[crawl] JS fallback unavailable for ${url}: ${errorMessage(error)}`
         )
       }
     }
@@ -160,13 +160,13 @@ async function main(): Promise<void> {
 
   if (seeds.length > 0) {
     console.log(
-      `[crawl] Using ${seeds.length} explicit seed URL(s); sitemap discovery skipped`,
+      `[crawl] Using ${seeds.length} explicit seed URL(s); sitemap discovery skipped`
     )
   }
   console.log(
     downloadImages
       ? `[crawl] Localizing images into crawl/images/ (pass --external-images to keep external URLs)`
-      : `[crawl] Keeping external image URLs (--external-images); inline data: images dropped to a placeholder`,
+      : `[crawl] Keeping external image URLs (--external-images); inline data: images dropped to a placeholder`
   )
   console.log(`[crawl] Discovering pages from ${url} ...`)
   const urls = await discoverUrls(url, options)
@@ -183,7 +183,7 @@ async function main(): Promise<void> {
     pages = await mapLimit(urls, options.concurrency, async (pageUrl) => {
       const result = await crawlPage(pageUrl, robots)
       console.log(
-        `[crawl]   ${result.status === "ok" ? "ok  " : "fail"} ${pageUrl}`,
+        `[crawl]   ${result.status === "ok" ? "ok  " : "fail"} ${pageUrl}`
       )
       return result
     })
@@ -205,10 +205,10 @@ async function main(): Promise<void> {
   const placeholders = new Map<string, string>()
   if (okPages.length > 0) {
     const httpUrls = Array.from(
-      new Set(okPages.flatMap((page) => extractImageUrls(page.markdown))),
+      new Set(okPages.flatMap((page) => extractImageUrls(page.markdown)))
     )
     const dataUris = Array.from(
-      new Set(okPages.flatMap((page) => extractDataUris(page.markdown))),
+      new Set(okPages.flatMap((page) => extractDataUris(page.markdown)))
     )
     if (downloadImages) {
       const imagesDir = join(outDir, "crawl", "images")
@@ -221,7 +221,7 @@ async function main(): Promise<void> {
       }
       if (httpUrls.length > 0) {
         console.log(
-          `[crawl] Downloading ${httpUrls.length} external image(s) into crawl/images/ ...`,
+          `[crawl] Downloading ${httpUrls.length} external image(s) into crawl/images/ ...`
         )
         const reportEvery = Math.max(1, Math.floor(httpUrls.length / 10))
         const httpMap = await downloadAllImages(
@@ -233,11 +233,11 @@ async function main(): Promise<void> {
             if (done === total || done % reportEvery === 0) {
               console.log(`[crawl]   images ${done}/${total}`)
             }
-          },
+          }
         )
         for (const [uri, name] of httpMap) localized.set(uri, name)
         console.log(
-          `[crawl] External images: ${httpMap.size} downloaded, ${httpUrls.length - httpMap.size} failed`,
+          `[crawl] External images: ${httpMap.size} downloaded, ${httpUrls.length - httpMap.size} failed`
         )
       }
       if (dataUris.length > 0) {
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
           if (!dataMap.has(uri)) placeholders.set(uri, INLINE_IMAGE_PLACEHOLDER)
         }
         console.log(
-          `[crawl] Inline images: ${dataMap.size}/${dataUris.length} saved to crawl/images/`,
+          `[crawl] Inline images: ${dataMap.size}/${dataUris.length} saved to crawl/images/`
         )
       }
     } else {
@@ -277,13 +277,13 @@ async function main(): Promise<void> {
     rewriteImageUrls(
       rewriteImageUrls(md, localized, "../images/"),
       placeholders,
-      "",
+      ""
     )
   const rewriteCorpus = (md: string): string =>
     rewriteImageUrls(
       rewriteImageUrls(md, localized, "crawl/images/"),
       placeholders,
-      "",
+      ""
     )
   okPages.forEach((page, index) => {
     const fileName = pageFileName(page.url, index)
@@ -294,25 +294,25 @@ async function main(): Promise<void> {
     }
     writeFileSync(
       join(outDir, "crawl", "pages", fileName),
-      buildPageFile(localPage, crawledAt),
+      buildPageFile(localPage, crawledAt)
     )
   })
   const corpusPages: Array<PageResult> = pages.map((page) =>
     page.status === "ok"
       ? { ...page, markdown: rewriteCorpus(page.markdown) }
-      : page,
+      : page
   )
   writeFileSync(
     join(outDir, "crawl-corpus.md"),
-    buildCorpus(url, corpusPages, crawledAt),
+    buildCorpus(url, corpusPages, crawledAt)
   )
   writeFileSync(
     join(outDir, "crawl", "manifest.json"),
-    `${JSON.stringify(buildManifest(url, pages, fileNames, crawledAt), null, 2)}\n`,
+    `${JSON.stringify(buildManifest(url, pages, fileNames, crawledAt), null, 2)}\n`
   )
 
   console.log(
-    `[crawl] Done — ${okPages.length} ok, ${pages.length - okPages.length} failed`,
+    `[crawl] Done — ${okPages.length} ok, ${pages.length - okPages.length} failed`
   )
   console.log(`[crawl] Corpus: ${join(outDir, "crawl-corpus.md")}`)
   if (okPages.length === 0) {

--- a/.claude/skills/docs-crawler/scripts/crawl/args.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/args.test.ts
@@ -3,7 +3,11 @@ import { parseArgs } from "./args"
 
 // parseArgs reads from a full argv array (it slices off the first two entries,
 // mirroring process.argv), so each case prepends two placeholder entries.
-const argv = (...rest: Array<string>): Array<string> => ["node", "crawl", ...rest]
+const argv = (...rest: Array<string>): Array<string> => [
+  "node",
+  "crawl",
+  ...rest,
+]
 
 describe("parseArgs", () => {
   it("localizes images by default", () => {
@@ -12,24 +16,24 @@ describe("parseArgs", () => {
 
   it("--external-images opts out of downloading", () => {
     expect(
-      parseArgs(argv("https://x.com", "--external-images")).downloadImages,
+      parseArgs(argv("https://x.com", "--external-images")).downloadImages
     ).toBe(false)
   })
 
   it("accepts --download-images as a no-op backward-compatible alias", () => {
     expect(
-      parseArgs(argv("https://x.com", "--download-images")).downloadImages,
+      parseArgs(argv("https://x.com", "--download-images")).downloadImages
     ).toBe(true)
   })
 
   it("applies the download flags in order (last wins)", () => {
     expect(
       parseArgs(argv("https://x.com", "--download-images", "--external-images"))
-        .downloadImages,
+        .downloadImages
     ).toBe(false)
     expect(
       parseArgs(argv("https://x.com", "--external-images", "--download-images"))
-        .downloadImages,
+        .downloadImages
     ).toBe(true)
   })
 
@@ -46,7 +50,7 @@ describe("parseArgs", () => {
 
   it("captures the first positional as the site URL", () => {
     expect(parseArgs(argv("https://x.com/start")).url).toBe(
-      "https://x.com/start",
+      "https://x.com/start"
     )
   })
 })

--- a/.claude/skills/docs-crawler/scripts/crawl/args.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/args.ts
@@ -47,14 +47,14 @@ export function parseArgs(argv: Array<string>): CliArgs {
   }
   if (!url) {
     console.error(
-      "Usage: tsx crawl.ts <docs-site-url> [--out <dir>] [--seeds <url1,url2,...>] [--external-images]",
+      "Usage: tsx crawl.ts <docs-site-url> [--out <dir>] [--seeds <url1,url2,...>] [--external-images]"
     )
     process.exit(1)
   }
   if (extraPositionals.length > 0) {
     console.warn(
       `[crawl] Ignoring extra argument(s): ${extraPositionals.join(", ")} — ` +
-        `the crawler uses only the first URL; the sitemap is found automatically.`,
+        `the crawler uses only the first URL; the sitemap is found automatically.`
     )
   }
   let host = ""

--- a/.claude/skills/docs-crawler/scripts/crawl/corpus.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/corpus.test.ts
@@ -31,7 +31,7 @@ const AT = "2026-05-20T00:00:00.000Z"
 describe("pageFileName", () => {
   it("builds a zero-padded, slugified name", () => {
     expect(pageFileName("https://x.com/docs/getting-started", 0)).toBe(
-      "001-docs-getting-started.md",
+      "001-docs-getting-started.md"
     )
   })
 
@@ -41,7 +41,7 @@ describe("pageFileName", () => {
 
   it("keeps the index prefix unique across same-slug paths", () => {
     expect(pageFileName("https://x.com/page", 0)).not.toBe(
-      pageFileName("https://x.com/page", 1),
+      pageFileName("https://x.com/page", 1)
     )
   })
 })

--- a/.claude/skills/docs-crawler/scripts/crawl/corpus.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/corpus.ts
@@ -42,14 +42,16 @@ export function buildPageFile(page: PageResult, crawledAt: string): string {
 export function buildCorpus(
   docsSiteUrl: string,
   pages: Array<PageResult>,
-  crawledAt: string,
+  crawledAt: string
 ): string {
   const okPages = pages.filter((page) => page.status === "ok")
   const toc = okPages
     .map((page, i) => `${i + 1}. ${page.title} — ${page.url}`)
     .join("\n")
   const sections = okPages
-    .map((page) => `## ${page.title}\n\nSource: ${page.url}\n\n${page.markdown}`)
+    .map(
+      (page) => `## ${page.title}\n\nSource: ${page.url}\n\n${page.markdown}`
+    )
     .join("\n\n---\n\n")
   return [
     "# Crawled documentation corpus",
@@ -74,7 +76,7 @@ export function buildManifest(
   docsSiteUrl: string,
   pages: Array<PageResult>,
   fileNames: Map<string, string>,
-  crawledAt: string,
+  crawledAt: string
 ): CrawlManifest {
   const ok = pages.filter((page) => page.status === "ok").length
   return {

--- a/.claude/skills/docs-crawler/scripts/crawl/discover.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/discover.test.ts
@@ -41,7 +41,7 @@ describe("filterUrls", () => {
     const result = filterUrls(
       ["https://x.com/a", "https://other.com/b", "https://x.com/c"],
       origin,
-      100,
+      100
     )
     expect(result).toEqual(["https://x.com/a/", "https://x.com/c/"])
   })
@@ -50,7 +50,7 @@ describe("filterUrls", () => {
     const result = filterUrls(
       ["https://x.com/a", "https://x.com/a#top", "https://x.com/a"],
       origin,
-      100,
+      100
     )
     expect(result).toEqual(["https://x.com/a/"])
   })
@@ -59,7 +59,7 @@ describe("filterUrls", () => {
     const result = filterUrls(
       ["https://x.com/dialog", "https://x.com/dialog/"],
       origin,
-      100,
+      100
     )
     expect(result).toEqual(["https://x.com/dialog/"])
   })
@@ -68,20 +68,16 @@ describe("filterUrls", () => {
     const result = filterUrls(
       ["https://x.com/", "https://x.com/index.html"],
       origin,
-      100,
+      100
     )
     expect(result).toEqual(["https://x.com/", "https://x.com/index.html"])
   })
 
   it("drops non-HTML asset URLs", () => {
     const result = filterUrls(
-      [
-        "https://x.com/page",
-        "https://x.com/style.css",
-        "https://x.com/app.js",
-      ],
+      ["https://x.com/page", "https://x.com/style.css", "https://x.com/app.js"],
       origin,
-      100,
+      100
     )
     expect(result).toEqual(["https://x.com/page/"])
   })
@@ -107,7 +103,10 @@ describe("extractLinks", () => {
   })
 
   it("handles unquoted href attributes", () => {
-    const links = extractLinks(`<a href=/docs/intro>Intro</a>`, "https://x.com/")
+    const links = extractLinks(
+      `<a href=/docs/intro>Intro</a>`,
+      "https://x.com/"
+    )
     expect(links).toContain("https://x.com/docs/intro")
   })
 })

--- a/.claude/skills/docs-crawler/scripts/crawl/discover.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/discover.ts
@@ -92,7 +92,7 @@ export function extractLinks(html: string, baseUrl: string): Array<string> {
 export function filterUrls(
   urls: Array<string>,
   origin: string,
-  maxPages: number,
+  maxPages: number
 ): Array<string> {
   const seen = new Set<string>()
   const result: Array<string> = []
@@ -124,7 +124,10 @@ export function filterUrls(
   return result
 }
 
-async function fetchText(url: string, userAgent: string): Promise<string | null> {
+async function fetchText(
+  url: string,
+  userAgent: string
+): Promise<string | null> {
   try {
     const res = await fetch(url, {
       headers: { "user-agent": userAgent },
@@ -139,7 +142,7 @@ async function fetchText(url: string, userAgent: string): Promise<string | null>
 
 async function collectSitemapUrls(
   origin: string,
-  userAgent: string,
+  userAgent: string
 ): Promise<Array<string>> {
   const rootXml = await fetchText(`${origin}/sitemap.xml`, userAgent)
   if (!rootXml) return []
@@ -158,7 +161,7 @@ async function bfsDiscover(
   rootUrl: string,
   origin: string,
   opts: CrawlOptions,
-  initialQueue?: Array<string>,
+  initialQueue?: Array<string>
 ): Promise<Array<string>> {
   const startUrls =
     initialQueue && initialQueue.length > 0 ? initialQueue : [rootUrl]
@@ -203,7 +206,7 @@ async function bfsDiscover(
  */
 export async function discoverUrls(
   rootUrl: string,
-  opts: CrawlOptions,
+  opts: CrawlOptions
 ): Promise<Array<string>> {
   const origin = new URL(rootUrl).origin
   // Explicit seed URLs win over sitemap discovery — the caller already knows

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.test.ts
@@ -71,7 +71,7 @@ describe("htmlToMarkdown", () => {
   it("keeps images as absolute external URLs", () => {
     const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
     expect(result.markdown).toContain(
-      "https://ds.example.com/assets/button-example.png",
+      "https://ds.example.com/assets/button-example.png"
     )
   })
 
@@ -81,14 +81,14 @@ describe("htmlToMarkdown", () => {
     // link syntax. Extraction preserves it; crawl.ts later decodes it into a
     // local file (or, with --external-images, collapses it to a placeholder).
     expect(result.markdown).toContain(
-      "![Inline status icon](data:image/svg+xml;base64,PHN2Zy8+)",
+      "![Inline status icon](data:image/svg+xml;base64,PHN2Zy8+)"
     )
   })
 
   it("preserves alt and title on base64 data-URI images", () => {
     const result = htmlToMarkdown(ARTICLE_PAGE, PAGE_URL)
     expect(result.markdown).toContain(
-      '![Chart](data:image/svg+xml;base64,PHN2Zy8+ "Quarterly chart")',
+      '![Chart](data:image/svg+xml;base64,PHN2Zy8+ "Quarterly chart")'
     )
   })
 
@@ -139,7 +139,7 @@ describe("htmlToMarkdown", () => {
     // Highlighter line spans must rejoin on exactly one newline each — not
     // collapsed onto one line, and not doubled into blank lines.
     expect(result.markdown).toContain(
-      "# npm\nnpm install acme-ui\n# pnpm\npnpm add acme-ui",
+      "# npm\nnpm install acme-ui\n# pnpm\npnpm add acme-ui"
     )
     expect(result.markdown).not.toMatch(/npmnpm|acme-ui#\s?pnpm/)
   })

--- a/.claude/skills/docs-crawler/scripts/crawl/extract.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/extract.ts
@@ -101,7 +101,7 @@ export function htmlToMarkdown(html: string, pageUrl: string): ExtractResult {
     const contentHtml = (article?.content ?? "").replace(
       /(?<![\w-])src="(data:[^"]*)"/gi,
       (whole, uri: string) =>
-        isBase64ImageDataUri(uri) ? whole : `src="${INLINE_IMAGE_PLACEHOLDER}"`,
+        isBase64ImageDataUri(uri) ? whole : `src="${INLINE_IMAGE_PLACEHOLDER}"`
     )
     const markdown = contentHtml
       ? createTurndown().turndown(contentHtml).trim()

--- a/.claude/skills/docs-crawler/scripts/crawl/fetch-page.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/fetch-page.test.ts
@@ -3,13 +3,15 @@ import { isAllowed, parseRobots } from "./fetch-page"
 
 describe("parseRobots", () => {
   it("collects Disallow rules for the wildcard agent", () => {
-    const rules = parseRobots("User-agent: *\nDisallow: /private\nDisallow: /tmp")
+    const rules = parseRobots(
+      "User-agent: *\nDisallow: /private\nDisallow: /tmp"
+    )
     expect(rules.disallow).toEqual(["/private", "/tmp"])
   })
 
   it("ignores rules that belong to other named agents", () => {
     const rules = parseRobots(
-      "User-agent: BadBot\nDisallow: /\n\nUser-agent: *\nDisallow: /admin",
+      "User-agent: BadBot\nDisallow: /\n\nUser-agent: *\nDisallow: /admin"
     )
     expect(rules.disallow).toEqual(["/admin"])
   })

--- a/.claude/skills/docs-crawler/scripts/crawl/fetch-page.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/fetch-page.ts
@@ -22,7 +22,7 @@ function delay(ms: number): Promise<void> {
 /** Fetch a page over plain HTTP with bounded retries. Throws on final failure. */
 export async function fetchStatic(
   url: string,
-  userAgent: string,
+  userAgent: string
 ): Promise<string> {
   let lastError: unknown
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -54,16 +54,16 @@ async function launchBrowser(): Promise<Browser> {
     return await chromium.launch()
   } catch {
     console.log(
-      "[crawl] Chromium not installed — running 'playwright install chromium' (one-time, ~150MB)...",
+      "[crawl] Chromium not installed — running 'playwright install chromium' (one-time, ~150MB)..."
     )
     const result = spawnSync(
       "npx",
       ["--yes", "playwright", "install", "chromium"],
-      { stdio: "inherit", shell: process.platform === "win32" },
+      { stdio: "inherit", shell: process.platform === "win32" }
     )
     if (result.status !== 0) {
       throw new Error(
-        "Chromium install failed — run 'pnpm exec playwright install chromium' manually",
+        "Chromium install failed — run 'pnpm exec playwright install chromium' manually"
       )
     }
     return await chromium.launch()
@@ -96,7 +96,7 @@ export async function closeBrowser(): Promise<void> {
  */
 export async function fetchRendered(
   url: string,
-  userAgent: string,
+  userAgent: string
 ): Promise<string> {
   const browser = await getBrowser()
   const context = await browser.newContext({ userAgent })
@@ -109,9 +109,8 @@ export async function fetchRendered(
     await page
       .waitForFunction(
         () =>
-          document.body !== null &&
-          document.body.innerText.trim().length > 500,
-        { timeout: RENDER_SETTLE_MS },
+          document.body !== null && document.body.innerText.trim().length > 500,
+        { timeout: RENDER_SETTLE_MS }
       )
       .catch(() => {
         // Content never crossed the threshold — proceed with what rendered.
@@ -162,7 +161,7 @@ export function isAllowed(url: string, rules: RobotsRules): boolean {
 /** Fetch and parse a site's robots.txt; missing/unreachable means no rules. */
 export async function fetchRobots(
   origin: string,
-  userAgent: string,
+  userAgent: string
 ): Promise<RobotsRules> {
   try {
     const res = await fetch(`${origin}/robots.txt`, {

--- a/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.test.ts
@@ -39,7 +39,7 @@ inline ![](https://x.com/b.jpg) end
 
   it("returns an empty list when no images are present", () => {
     expect(extractImageUrls("just text and [a link](https://x.com)")).toEqual(
-      [],
+      []
     )
   })
 })
@@ -47,7 +47,7 @@ inline ![](https://x.com/b.jpg) end
 describe("localImageName", () => {
   it("uses the URL basename and an 8-char hash prefix", () => {
     const name = localImageName(
-      "https://design.11stcorp.com/static/abc/123/accordion_type01.png",
+      "https://design.11stcorp.com/static/abc/123/accordion_type01.png"
     )
     expect(name).toMatch(/^[0-9a-f]{8}-accordion_type01\.png$/)
   })
@@ -66,11 +66,9 @@ describe("localImageName", () => {
   })
 
   it("drops unsafe extensions and keeps allowlisted image ones", () => {
-    expect(localImageName("https://x.com/foo.exe")).toMatch(
-      /^[0-9a-f]{8}-foo$/,
-    )
+    expect(localImageName("https://x.com/foo.exe")).toMatch(/^[0-9a-f]{8}-foo$/)
     expect(localImageName("https://x.com/foo.png")).toMatch(
-      /^[0-9a-f]{8}-foo\.png$/,
+      /^[0-9a-f]{8}-foo\.png$/
     )
   })
 
@@ -96,20 +94,20 @@ describe("rewriteImageUrls", () => {
 ![alt two](https://x.com/b.png)
 `
     expect(rewriteImageUrls(md, map, "crawl/images/")).toContain(
-      "![alt one](crawl/images/aa00-a.png)",
+      "![alt one](crawl/images/aa00-a.png)"
     )
     expect(rewriteImageUrls(md, map, "crawl/images/")).toContain(
-      "![alt two](crawl/images/bb11-b.png)",
+      "![alt two](crawl/images/bb11-b.png)"
     )
   })
 
   it("supports different prefixes for corpus vs page files", () => {
     const md = `![x](https://x.com/a.png)`
     expect(rewriteImageUrls(md, map, "crawl/images/")).toBe(
-      "![x](crawl/images/aa00-a.png)",
+      "![x](crawl/images/aa00-a.png)"
     )
     expect(rewriteImageUrls(md, map, "../images/")).toBe(
-      "![x](../images/aa00-a.png)",
+      "![x](../images/aa00-a.png)"
     )
   })
 
@@ -121,7 +119,7 @@ describe("rewriteImageUrls", () => {
   it("preserves alt text containing special characters", () => {
     const md = `![1. Brand Color: 탭 활성](https://x.com/a.png)`
     expect(rewriteImageUrls(md, map, "crawl/images/")).toBe(
-      "![1. Brand Color: 탭 활성](crawl/images/aa00-a.png)",
+      "![1. Brand Color: 탭 활성](crawl/images/aa00-a.png)"
     )
   })
 
@@ -130,7 +128,7 @@ describe("rewriteImageUrls", () => {
     // because the title's `(` is closer to the trailing `)` than the URL's.
     const md = `![alt](https://x.com/a.png "title (something)")`
     expect(rewriteImageUrls(md, map, "crawl/images/")).toBe(
-      `![alt](crawl/images/aa00-a.png "title (something)")`,
+      `![alt](crawl/images/aa00-a.png "title (something)")`
     )
   })
 
@@ -139,7 +137,7 @@ describe("rewriteImageUrls", () => {
     const dataMap = new Map([["data:image/png;base64,AAAA", "cc22.png"]])
     const md = `![icon](data:image/png;base64,AAAA)`
     expect(rewriteImageUrls(md, dataMap, "crawl/images/")).toBe(
-      "![icon](crawl/images/cc22.png)",
+      "![icon](crawl/images/cc22.png)"
     )
   })
 
@@ -151,7 +149,7 @@ describe("rewriteImageUrls", () => {
     ])
     const md = `![icon](data:image/png;base64,AAAA)`
     expect(rewriteImageUrls(md, phMap, "")).toBe(
-      `![icon](${INLINE_IMAGE_PLACEHOLDER})`,
+      `![icon](${INLINE_IMAGE_PLACEHOLDER})`
     )
   })
 })
@@ -210,7 +208,7 @@ describe("localDataUriName", () => {
 
   it("gives different names to different payloads", () => {
     expect(localDataUriName("data:image/png;base64,AAAA")).not.toBe(
-      localDataUriName("data:image/png;base64,BBBB"),
+      localDataUriName("data:image/png;base64,BBBB")
     )
   })
 })
@@ -240,7 +238,7 @@ describe("saveDataUris", () => {
     const missingDir = join(tmpdir(), "docs-crawler-missing-zzz", "nested")
     const result = saveDataUris(
       ["data:image/svg+xml;base64,PHN2Zy8+"],
-      missingDir,
+      missingDir
     )
     expect(result.size).toBe(0)
   })

--- a/.claude/skills/docs-crawler/scripts/crawl/images.ts
+++ b/.claude/skills/docs-crawler/scripts/crawl/images.ts
@@ -110,7 +110,7 @@ export function localImageName(url: string): string {
  * unsupported MIME type, or decodes to nothing. Pure.
  */
 export function decodeDataUri(
-  uri: string,
+  uri: string
 ): { buffer: Buffer; ext: string } | null {
   const match = DATA_URI_RE.exec(uri)
   if (!match) return null
@@ -141,7 +141,7 @@ export function localDataUriName(uri: string): string {
  */
 export function saveDataUris(
   uris: Array<string>,
-  imagesDir: string,
+  imagesDir: string
 ): Map<string, string> {
   const result = new Map<string, string>()
   for (const uri of Array.from(new Set(uris))) {
@@ -169,7 +169,7 @@ export function saveDataUris(
 export function rewriteImageUrls(
   markdown: string,
   urlToLocal: Map<string, string>,
-  pathPrefix: string,
+  pathPrefix: string
 ): string {
   return markdown.replace(MARKDOWN_IMAGE_RE, (whole, rawUrl: string) => {
     const local = urlToLocal.get(rawUrl)
@@ -198,7 +198,7 @@ export async function downloadImage(
   url: string,
   destPath: string,
   userAgent: string,
-  timeoutMs = 20_000,
+  timeoutMs = 20_000
 ): Promise<boolean> {
   try {
     const res = await fetch(url, {
@@ -226,7 +226,7 @@ export async function downloadAllImages(
   imagesDir: string,
   userAgent: string,
   concurrency: number,
-  onProgress?: (done: number, total: number, ok: boolean) => void,
+  onProgress?: (done: number, total: number, ok: boolean) => void
 ): Promise<Map<string, string>> {
   const dedupedUrls = Array.from(new Set(urls))
   // Assign local names ahead of time; if two URLs happen to collide on the

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# 모든 텍스트 파일을 LF로 통일 (.prettierrc endOfLine: lf와 일치).
+# Windows working copy도 LF로 체크아웃되어 prettier --check 오탐(CRLF) 방지.
+# 바이너리는 text=auto가 자동 감지해 변환 제외.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Format check
+        run: pnpm format:check
+
       - name: Test
         run: pnpm test
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+# 생성 파일 (TanStack Router) — 빌드 시 재생성되므로 포맷 대상에서 제외
+src/routeTree.gen.ts

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "vitest run",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx}\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/public/preview/_runtime/iframe.js
+++ b/public/preview/_runtime/iframe.js
@@ -11,23 +11,23 @@
  * height number, so broadcasting it is safe. The same-origin parent listener
  * still verifies event.origin matches its own origin before reacting.
  */
-(function () {
-  if (window.parent === window) return;
+;(function () {
+  if (window.parent === window) return
 
   function send() {
-    var height = document.body.scrollHeight;
-    window.parent.postMessage({ type: "preview-height", value: height }, "*");
+    var height = document.body.scrollHeight
+    window.parent.postMessage({ type: "preview-height", value: height }, "*")
   }
 
   if (document.readyState === "complete") {
-    send();
+    send()
   } else {
-    window.addEventListener("load", send);
+    window.addEventListener("load", send)
   }
 
   if (typeof ResizeObserver !== "undefined") {
-    new ResizeObserver(send).observe(document.body);
+    new ResizeObserver(send).observe(document.body)
   } else {
-    window.addEventListener("resize", send);
+    window.addEventListener("resize", send)
   }
-})();
+})()

--- a/scripts/build-favicons.ts
+++ b/scripts/build-favicons.ts
@@ -34,7 +34,7 @@ async function main() {
   fs.mkdirSync(OUTPUT_DIR, { recursive: true })
 
   console.log(
-    `[favicons] Generating ${jobs.length} asset(s) → ${path.relative(cwd, OUTPUT_DIR)}/`,
+    `[favicons] Generating ${jobs.length} asset(s) → ${path.relative(cwd, OUTPUT_DIR)}/`
   )
   for (const job of jobs) {
     const start = Date.now()
@@ -42,7 +42,7 @@ async function main() {
     fs.writeFileSync(path.join(OUTPUT_DIR, job.outputName), buf)
     const ms = Date.now() - start
     console.log(
-      `  ✓ ${job.outputName.padEnd(28)} ${(buf.length / 1024).toFixed(1).padStart(7)} KB  (${ms}ms)`,
+      `  ✓ ${job.outputName.padEnd(28)} ${(buf.length / 1024).toFixed(1).padStart(7)} KB  (${ms}ms)`
     )
   }
   console.log(`[favicons] Done.`)

--- a/scripts/build-og.ts
+++ b/scripts/build-og.ts
@@ -6,10 +6,7 @@ import { ogLede } from "../src/lib/og-lede"
 import { loadOgLogo } from "../src/og/load-logo"
 import { renderOgPng } from "../src/og/render"
 import type { ServiceDoc } from "../src/lib/content-types"
-import type {
-  BreadcrumbSegment,
-  TitleSegment,
-} from "../src/og/template"
+import type { BreadcrumbSegment, TitleSegment } from "../src/og/template"
 
 const cwd = process.cwd()
 const SERVICES_DIR = path.resolve(cwd, "services")
@@ -80,7 +77,7 @@ function collectJobs(): Array<OgJob> {
       const raw = fs.readFileSync(fullPath, "utf-8")
       // Mirror Vite's import.meta.glob path style so deriveSlug() stays consistent.
       return buildDoc(`/services/${fileName}`, raw)
-    }),
+    })
   )
 
   for (const doc of docs) jobs.push(buildServiceJob(doc))
@@ -92,7 +89,9 @@ async function main() {
   const jobs = collectJobs()
   fs.mkdirSync(OUTPUT_DIR, { recursive: true })
 
-  console.log(`[og] Generating ${jobs.length} OG image(s) → ${path.relative(cwd, OUTPUT_DIR)}/`)
+  console.log(
+    `[og] Generating ${jobs.length} OG image(s) → ${path.relative(cwd, OUTPUT_DIR)}/`
+  )
   for (const job of jobs) {
     const start = Date.now()
     const png = await renderOgPng({
@@ -105,7 +104,7 @@ async function main() {
     fs.writeFileSync(path.join(OUTPUT_DIR, job.outputName), png)
     const ms = Date.now() - start
     console.log(
-      `  ✓ ${job.outputName.padEnd(28)} ${(png.length / 1024).toFixed(1).padStart(7)} KB  (${ms}ms)`,
+      `  ✓ ${job.outputName.padEnd(28)} ${(png.length / 1024).toFixed(1).padStart(7)} KB  (${ms}ms)`
     )
   }
   console.log(`[og] Done.`)

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -60,11 +60,16 @@ function main() {
     console.log(
       `  ✓ ${`${slug}.tokens.json`.padEnd(26)} ` +
         `${tokens.colors.length}c ${tokens.typography.length}t ` +
-        `${tokens.spacing.length}s ${tokens.radius.length}r`,
+        `${tokens.spacing.length}s ${tokens.radius.length}r`
     )
   }
-  const tail = skipped > 0 ? ` (${skipped} existing skipped — use --all to regenerate)` : ""
-  console.log(`[tokens] Wrote ${written}${tail}. Review drafts before committing.`)
+  const tail =
+    skipped > 0
+      ? ` (${skipped} existing skipped — use --all to regenerate)`
+      : ""
+  console.log(
+    `[tokens] Wrote ${written}${tail}. Review drafts before committing.`
+  )
 }
 
 main()

--- a/scripts/validate-sources.ts
+++ b/scripts/validate-sources.ts
@@ -42,7 +42,7 @@ function main(): void {
     const issues = auditSourceCitations(
       doc.frontmatter.slug,
       doc.frontmatter.sources,
-      doc.body,
+      doc.body
     )
     const blocks = issues.filter((i) => i.severity === "block")
     const warns = issues.filter((i) => i.severity === "warn")
@@ -50,7 +50,9 @@ function main(): void {
     warnCount += warns.length
 
     if (blocks.length) {
-      console.log(`FAIL ${file}  (${blocks.length} block, ${warns.length} warn)`)
+      console.log(
+        `FAIL ${file}  (${blocks.length} block, ${warns.length} warn)`
+      )
     } else if (warns.length) {
       console.log(`warn ${file}  (${warns.length} warn)`)
     } else {
@@ -61,12 +63,12 @@ function main(): void {
   }
 
   console.log(
-    `\n${files.length} files — ${blockCount} blocking, ${warnCount} warning issue(s).`,
+    `\n${files.length} files — ${blockCount} blocking, ${warnCount} warning issue(s).`
   )
 
   if (blockCount > 0) {
     console.error(
-      `\nFAILED: ${blockCount} blocking source-citation issue(s) above must be fixed.`,
+      `\nFAILED: ${blockCount} blocking source-citation issue(s) above must be fixed.`
     )
     process.exit(1)
   }

--- a/src/components/site/contribute-dialog.test.tsx
+++ b/src/components/site/contribute-dialog.test.tsx
@@ -23,7 +23,7 @@ describe("ContributeDialog", () => {
     openDialog()
 
     expect(
-      screen.getByRole("heading", { name: /새 항목 추가하기/ }),
+      screen.getByRole("heading", { name: /새 항목 추가하기/ })
     ).toBeDefined()
     expect(screen.getByRole("link", { name: /제안만 할게요/ })).toBeDefined()
     expect(screen.getByRole("link", { name: /직접 추가할래요/ })).toBeDefined()
@@ -35,7 +35,7 @@ describe("ContributeDialog", () => {
 
     const link = screen.getByRole("link", { name: /제안만 할게요/ })
     expect(link.getAttribute("href")).toContain(
-      "/issues/new?template=new-catalog-entry.yml",
+      "/issues/new?template=new-catalog-entry.yml"
     )
     expect(link.getAttribute("target")).toBe("_blank")
     expect(link.getAttribute("rel")).toBe("noopener noreferrer")
@@ -46,9 +46,7 @@ describe("ContributeDialog", () => {
     openDialog()
 
     const link = screen.getByRole("link", { name: /직접 추가할래요/ })
-    expect(link.getAttribute("href")).toContain(
-      "/blob/main/CONTRIBUTING.md#1-",
-    )
+    expect(link.getAttribute("href")).toContain("/blob/main/CONTRIBUTING.md#1-")
     expect(link.getAttribute("target")).toBe("_blank")
     expect(link.getAttribute("rel")).toBe("noopener noreferrer")
   })

--- a/src/components/site/contribute-dialog.tsx
+++ b/src/components/site/contribute-dialog.tsx
@@ -42,25 +42,25 @@ export function ContributeDialog() {
   return (
     <Dialog.Root>
       <Dialog.Trigger
-        className="hover:text-brand focus-visible:text-brand inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors focus-visible:outline-none"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-brand focus-visible:text-brand focus-visible:outline-none"
         aria-label="새 항목 제안하기"
       >
         <PlusIcon className="size-4" />
         <span className="hidden sm:inline">새 항목 제안</span>
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Backdrop className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm" />
+        <Dialog.Backdrop className="fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
         <Dialog.Popup
           className={cn(
-            "fixed top-1/2 left-4 right-4 z-50 -translate-y-1/2 sm:left-1/2 sm:right-auto sm:w-full sm:max-w-xl sm:-translate-x-1/2",
+            "fixed top-1/2 right-4 left-4 z-50 -translate-y-1/2 sm:right-auto sm:left-1/2 sm:w-full sm:max-w-xl sm:-translate-x-1/2",
             "rounded-2xl border bg-background p-6 shadow-2xl outline-none",
             "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95"
           )}
           style={{ borderColor: "var(--rule-strong)" }}
         >
           <Dialog.Close
-            className="hover:bg-muted hover:text-foreground focus-visible:text-foreground absolute top-4 right-4 inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors focus-visible:outline-none"
+            className="absolute top-4 right-4 inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
             aria-label="닫기"
           >
             <CloseIcon className="size-4" />
@@ -109,14 +109,14 @@ function ChoiceCard({
       rel="noopener noreferrer"
       className={cn(
         "group flex flex-col gap-2 rounded-xl border p-4 transition-colors",
-        "hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+        "hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
       )}
       style={{ borderColor: "var(--rule-strong)" }}
     >
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold">{title}</span>
         <span
-          className="group-hover:text-brand text-xs text-muted-foreground transition-colors"
+          className="text-xs text-muted-foreground transition-colors group-hover:text-brand"
           aria-hidden
         >
           →

--- a/src/components/site/footer.tsx
+++ b/src/components/site/footer.tsx
@@ -6,10 +6,11 @@ export function SiteFooter() {
     >
       <div className="mx-auto max-w-[1400px] px-8 text-center">
         <p className="leading-relaxed text-muted-foreground">
-          코드 MIT (잠정) · 콘텐츠 CC-BY 4.0 (잠정) · 각 서비스명·로고는 해당 권리자 소유, 분석 목적 fair use에 한함.
+          코드 MIT (잠정) · 콘텐츠 CC-BY 4.0 (잠정) · 각 서비스명·로고는 해당
+          권리자 소유, 분석 목적 fair use에 한함.
         </p>
         <p className="text-meta-caps mt-4 tabular-nums">
-          — Issue <span className="text-brand font-bold">001</span> / May 2026 —
+          — Issue <span className="font-bold text-brand">001</span> / May 2026 —
         </p>
       </div>
     </footer>

--- a/src/components/site/header.tsx
+++ b/src/components/site/header.tsx
@@ -5,7 +5,12 @@ import { GITHUB_REPO_URL } from "@/lib/site-config"
 
 function GithubMark({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden>
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden
+    >
       <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.57.1.78-.25.78-.55 0-.27-.01-1-.02-1.96-3.2.69-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18.92-.26 1.9-.39 2.88-.39.98 0 1.96.13 2.88.39 2.18-1.49 3.14-1.18 3.14-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.13 0 1.54-.01 2.78-.01 3.16 0 .31.21.66.79.55C20.71 21.39 24 17.08 24 12 24 5.65 18.85.5 12.5.5h-.5z" />
     </svg>
   )
@@ -34,7 +39,7 @@ export function SiteHeader() {
             href={GITHUB_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-brand inline-flex items-center gap-1.5 text-muted-foreground transition-colors"
+            className="inline-flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-brand"
             aria-label="GitHub repository"
           >
             <GithubMark className="size-4" />

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
-import {  cva } from "class-variance-authority"
-import type {VariantProps} from "class-variance-authority";
+import { cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import {  cva } from "class-variance-authority"
-import type {VariantProps} from "class-variance-authority";
+import { cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 

--- a/src/lib/content-collection.test.ts
+++ b/src/lib/content-collection.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
-import { getAllServices, getServiceBySlug, truncateForMeta } from "./content-collection"
+import {
+  getAllServices,
+  getServiceBySlug,
+  truncateForMeta,
+} from "./content-collection"
 import { deriveTagline } from "./content-parser"
 
 describe("content-collection", () => {
@@ -46,7 +50,7 @@ describe("content-collection", () => {
   it("does not import preview HTML through public-directory URLs", () => {
     const source = readFileSync(
       new URL("./content-collection.ts", import.meta.url),
-      "utf8",
+      "utf8"
     )
     expect(source).not.toContain("/public/preview")
   })
@@ -56,14 +60,12 @@ describe("deriveTagline", () => {
   it("strips bold markers and `[src:N]` citation markup so the tagline isn't bibliographic noise", () => {
     const body =
       "\n\n## Brand\n\n본문이다 [src:1][src:6]. 다음 문장도 **굵게** [src:2] 들어간다.\n"
-    expect(deriveTagline(body)).toBe(
-      "본문이다. 다음 문장도 굵게 들어간다.",
-    )
+    expect(deriveTagline(body)).toBe("본문이다. 다음 문장도 굵게 들어간다.")
   })
 
   it("keeps prose unaffected when no citation markers are present", () => {
     expect(deriveTagline("\n## H\n\n그냥 평범한 본문 한 줄.\n")).toBe(
-      "그냥 평범한 본문 한 줄.",
+      "그냥 평범한 본문 한 줄."
     )
   })
 })
@@ -75,7 +77,8 @@ describe("truncateForMeta", () => {
   })
 
   it("breaks on a sentence terminator that lies in the upper 40 percent of the slice", () => {
-    const text = "First sentence ends with a period right here. Then a much longer sentence follows."
+    const text =
+      "First sentence ends with a period right here. Then a much longer sentence follows."
     const result = truncateForMeta(text, 60)
     expect(result).toBe("First sentence ends with a period right here.…")
   })
@@ -94,7 +97,8 @@ describe("truncateForMeta", () => {
   })
 
   it("breaks on a Korean sentence terminator (.) at the end of a clause", () => {
-    const text = "한국어 종결 마침표가 자연스럽게 끊깁니다. 그 다음 문장은 잘려나갑니다."
+    const text =
+      "한국어 종결 마침표가 자연스럽게 끊깁니다. 그 다음 문장은 잘려나갑니다."
     const result = truncateForMeta(text, 30)
     expect(result).toBe("한국어 종결 마침표가 자연스럽게 끊깁니다.…")
   })

--- a/src/lib/content-collection.ts
+++ b/src/lib/content-collection.ts
@@ -15,20 +15,20 @@ const RAW_MODULES: Record<string, string> = import.meta.glob("/services/*.md", {
 // page renders no token-card section for it (graceful during rollout).
 const TOKEN_MODULES: Record<string, unknown> = import.meta.glob(
   "/services/*.tokens.json",
-  { import: "default", eager: true },
+  { import: "default", eager: true }
 )
 
 function coerceServiceTokens(data: unknown, filePath: string): ServiceTokens {
   if (typeof data !== "object" || data === null) {
     throw new Error(
-      `[content-collection] token sidecar ${filePath} must be a JSON object`,
+      `[content-collection] token sidecar ${filePath} must be a JSON object`
     )
   }
   const d = data as Record<string, unknown>
   for (const key of ["colors", "typography", "spacing", "radius"] as const) {
     if (d[key] !== undefined && !Array.isArray(d[key])) {
       throw new Error(
-        `[content-collection] ${filePath}: tokens.${key} must be an array`,
+        `[content-collection] ${filePath}: tokens.${key} must be an array`
       )
     }
   }
@@ -47,7 +47,7 @@ function coerceServiceTokens(data: unknown, filePath: string): ServiceTokens {
       typeof (color as { value?: unknown }).value !== "string"
     ) {
       throw new Error(
-        `[content-collection] ${filePath}: every color needs a string name and value`,
+        `[content-collection] ${filePath}: every color needs a string name and value`
       )
     }
   }
@@ -63,7 +63,7 @@ const TOKENS_BY_SLUG = new Map<string, ServiceTokens>(
   Object.entries(TOKEN_MODULES).map(([filePath, data]) => [
     filePath.replace(/^.*\/(.+)\.tokens\.json$/, "$1"),
     coerceServiceTokens(data, filePath),
-  ]),
+  ])
 )
 
 const DOCS: Array<ServiceDoc> = sortDocs(
@@ -71,7 +71,7 @@ const DOCS: Array<ServiceDoc> = sortDocs(
     const doc = buildDoc(filePath, raw)
     const tokens = TOKENS_BY_SLUG.get(doc.frontmatter.slug)
     return tokens ? { ...doc, tokens } : doc
-  }),
+  })
 )
 
 const BY_SLUG = new Map(DOCS.map((d) => [d.frontmatter.slug, d]))

--- a/src/lib/content-parser.test.ts
+++ b/src/lib/content-parser.test.ts
@@ -21,7 +21,10 @@ function frontmatter(body: string): string {
 
 describe("matter / frontmatter parsing", () => {
   it("parses a canonical frontmatter block", () => {
-    const doc = buildDoc(FILE, frontmatter("sources:\n  - https://example.com/a"))
+    const doc = buildDoc(
+      FILE,
+      frontmatter("sources:\n  - https://example.com/a")
+    )
     expect(doc.frontmatter.name).toBe("Demo")
     expect(doc.frontmatter.sources).toEqual(["https://example.com/a"])
     expect(doc.frontmatter.last_updated).toBe("2026-05-07")
@@ -61,7 +64,7 @@ describe("inline arrays", () => {
   it("splits on commas only outside quotes", () => {
     const doc = buildDoc(
       FILE,
-      frontmatter('sources: ["https://a.com/?q=1,2", "https://b.com"]'),
+      frontmatter('sources: ["https://a.com/?q=1,2", "https://b.com"]')
     )
     expect(doc.frontmatter.sources).toEqual([
       "https://a.com/?q=1,2",
@@ -79,36 +82,27 @@ describe("block arrays", () => {
   it("accepts indented items", () => {
     const doc = buildDoc(
       FILE,
-      frontmatter("sources:\n  - https://a.com\n  - https://b.com"),
+      frontmatter("sources:\n  - https://a.com\n  - https://b.com")
     )
-    expect(doc.frontmatter.sources).toEqual([
-      "https://a.com",
-      "https://b.com",
-    ])
+    expect(doc.frontmatter.sources).toEqual(["https://a.com", "https://b.com"])
   })
 
   it("also accepts zero-indent items (`- foo` at column 0)", () => {
     const doc = buildDoc(
       FILE,
-      frontmatter("sources:\n- https://a.com\n- https://b.com"),
+      frontmatter("sources:\n- https://a.com\n- https://b.com")
     )
-    expect(doc.frontmatter.sources).toEqual([
-      "https://a.com",
-      "https://b.com",
-    ])
+    expect(doc.frontmatter.sources).toEqual(["https://a.com", "https://b.com"])
   })
 
   it("ignores inline `# comment` lines mid-list", () => {
     const doc = buildDoc(
       FILE,
       frontmatter(
-        "sources:\n  - https://a.com\n  # legacy mirror, keeping for reference\n  - https://b.com",
-      ),
+        "sources:\n  - https://a.com\n  # legacy mirror, keeping for reference\n  - https://b.com"
+      )
     )
-    expect(doc.frontmatter.sources).toEqual([
-      "https://a.com",
-      "https://b.com",
-    ])
+    expect(doc.frontmatter.sources).toEqual(["https://a.com", "https://b.com"])
   })
 })
 
@@ -121,7 +115,7 @@ describe("scalar comment stripping", () => {
   it("preserves URL fragments (no leading whitespace before #)", () => {
     const doc = buildDoc(
       FILE,
-      frontmatter("sources:\n  - https://example.com/page#section"),
+      frontmatter("sources:\n  - https://example.com/page#section")
     )
     expect(doc.frontmatter.sources).toEqual([
       "https://example.com/page#section",
@@ -171,7 +165,7 @@ describe("type validation", () => {
 
   it("throws if estimated_tokens is not numeric", () => {
     expect(() =>
-      buildDoc(FILE, frontmatter("estimated_tokens: not-a-number")),
+      buildDoc(FILE, frontmatter("estimated_tokens: not-a-number"))
     ).toThrow(/estimated_tokens/i)
   })
 

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -113,9 +113,7 @@ function parseYamlSubset(text: string): Record<string, unknown> {
     } else if (rest.startsWith("[") && rest.endsWith("]")) {
       const inner = rest.slice(1, -1).trim()
       out[key] =
-        inner === ""
-          ? []
-          : splitOutsideQuotes(inner).map((s) => stripQuotes(s))
+        inner === "" ? [] : splitOutsideQuotes(inner).map((s) => stripQuotes(s))
       i++
     } else {
       out[key] = stripQuotes(stripInlineComment(rest))
@@ -139,13 +137,16 @@ function matter(raw: string): MatterResult {
   if (source.trimStart().startsWith("---")) {
     throw new Error(
       "Frontmatter block is malformed: expected a closing '---' line. Got: " +
-        JSON.stringify(source.slice(0, 80)),
+        JSON.stringify(source.slice(0, 80))
     )
   }
   return { data: {}, content: source }
 }
 
-export function deriveSlug(filePath: string, frontmatterSlug: string | undefined): string {
+export function deriveSlug(
+  filePath: string,
+  frontmatterSlug: string | undefined
+): string {
   if (frontmatterSlug && frontmatterSlug.length > 0) return frontmatterSlug
   const fileName = filePath.split("/").pop() ?? ""
   return fileName.replace(/^_+/, "").replace(/\.md$/, "")
@@ -163,7 +164,7 @@ export function normalizeDateField(value: unknown, context = ""): string {
     if (value === "") return ""
     if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
       throw new Error(
-        `last_updated must be ISO YYYY-MM-DD${context ? ` (${context})` : ""}, got "${value}"`,
+        `last_updated must be ISO YYYY-MM-DD${context ? ` (${context})` : ""}, got "${value}"`
       )
     }
     return value
@@ -199,7 +200,9 @@ export function truncateForMeta(text: string, max = 155): string {
   const slice = text.slice(0, max)
   const minBreak = max * 0.6
   const terminators = [".", "!", "?", "。", "！", "？"]
-  const lastTerminator = Math.max(...terminators.map((c) => slice.lastIndexOf(c)))
+  const lastTerminator = Math.max(
+    ...terminators.map((c) => slice.lastIndexOf(c))
+  )
   if (lastTerminator > minBreak) {
     return slice.slice(0, lastTerminator + 1).trimEnd() + "…"
   }
@@ -212,55 +215,60 @@ export function truncateForMeta(text: string, max = 155): string {
 
 function estimateTokens(raw: string): number {
   const cjkChars =
-    raw.match(/[\u1100-\u11ff\u3040-\u30ff\u3130-\u318f\u3400-\u9fff\uac00-\ud7af]/g)
-      ?.length ?? 0
+    raw.match(
+      /[\u1100-\u11ff\u3040-\u30ff\u3130-\u318f\u3400-\u9fff\uac00-\ud7af]/g
+    )?.length ?? 0
   const latinWords =
     raw.match(/[A-Za-z0-9_]+(?:[./_-][A-Za-z0-9_]+)*/g)?.length ?? 0
   const symbols =
     raw.match(
-      /[^\sA-Za-z0-9_\u1100-\u11ff\u3040-\u30ff\u3130-\u318f\u3400-\u9fff\uac00-\ud7af]/g,
+      /[^\sA-Za-z0-9_\u1100-\u11ff\u3040-\u30ff\u3130-\u318f\u3400-\u9fff\uac00-\ud7af]/g
     )?.length ?? 0
 
-  return Math.max(1, Math.ceil(cjkChars * 0.75 + latinWords * 1.25 + symbols * 0.25))
+  return Math.max(
+    1,
+    Math.ceil(cjkChars * 0.75 + latinWords * 1.25 + symbols * 0.25)
+  )
 }
 
 function coerceNumberField(
   value: unknown,
   field: string,
-  context: string,
+  context: string
 ): number | undefined {
   if (value === undefined || value === null) return undefined
-  if (typeof value === "number") return Number.isFinite(value) ? value : undefined
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : undefined
   if (typeof value === "string") {
     if (value === "") return undefined
     const n = Number(value)
     if (!Number.isFinite(n)) {
       throw new Error(
-        `${field} must be a number${context ? ` (${context})` : ""}, got "${value}"`,
+        `${field} must be a number${context ? ` (${context})` : ""}, got "${value}"`
       )
     }
     return n
   }
   throw new Error(
-    `${field} must be a number${context ? ` (${context})` : ""}, got ${typeof value}`,
+    `${field} must be a number${context ? ` (${context})` : ""}, got ${typeof value}`
   )
 }
 
 function ensureStringArray(
   value: unknown,
   field: string,
-  context: string,
+  context: string
 ): Array<string> {
   if (value === undefined || value === null) return []
   if (!Array.isArray(value)) {
     throw new Error(
-      `${field} must be an array${context ? ` (${context})` : ""}, got ${typeof value}`,
+      `${field} must be an array${context ? ` (${context})` : ""}, got ${typeof value}`
     )
   }
   return value.map((item) => {
     if (typeof item !== "string") {
       throw new Error(
-        `${field} items must be strings${context ? ` (${context})` : ""}, got ${typeof item}`,
+        `${field} items must be strings${context ? ` (${context})` : ""}, got ${typeof item}`
       )
     }
     return item
@@ -277,7 +285,7 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
   for (const key of Object.keys(data)) {
     if (!(KNOWN_FRONTMATTER_KEYS as ReadonlyArray<string>).includes(key)) {
       console.warn(
-        `[content-parser] Unknown frontmatter key "${key}" in ${context} (ignored)`,
+        `[content-parser] Unknown frontmatter key "${key}" in ${context} (ignored)`
       )
     }
   }
@@ -300,13 +308,13 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
     related_services: ensureStringArray(
       fm.related_services,
       "related_services",
-      context,
+      context
     ),
     lang: fm.lang ?? "ko",
     estimated_tokens: coerceNumberField(
       fm.estimated_tokens,
       "estimated_tokens",
-      context,
+      context
     ),
     logo: fm.logo,
   }

--- a/src/lib/design-md-skill-logo-policy.test.ts
+++ b/src/lib/design-md-skill-logo-policy.test.ts
@@ -20,10 +20,10 @@ describe("/design-md logo policy", () => {
     const author = readRepoFile(".claude/agents/design-md-author.md")
     const previewAuthor = readRepoFile(".claude/agents/preview-html-author.md")
     const designRubric = readRepoFile(
-      ".claude/skills/design-md/references/rubric-design.md",
+      ".claude/skills/design-md/references/rubric-design.md"
     )
     const previewRubric = readRepoFile(
-      ".claude/skills/design-md/references/rubric-preview.md",
+      ".claude/skills/design-md/references/rubric-preview.md"
     )
 
     expect(skill).toContain("public/logos/{slug}.{svg,png,webp,avif}")
@@ -58,19 +58,19 @@ describe("/design-md logo policy", () => {
       expect(slug, `${servicePath} slug`).toBeTruthy()
       expect(logo, `${servicePath} logo frontmatter`).toBeTruthy()
       expect(logo, `${servicePath} logo must be absolute URL`).toMatch(
-        /^https:\/\/getdesign\.kr\/logos\//,
+        /^https:\/\/getdesign\.kr\/logos\//
       )
       const logoSrcPath = logo!.replace(/^https:\/\/getdesign\.kr/, "")
       expect(
         existsSync(join(ROOT, "public", logoSrcPath.replace(/^\//, ""))),
-        `${servicePath} logo asset must exist at public${logoSrcPath}`,
+        `${servicePath} logo asset must exist at public${logoSrcPath}`
       ).toBe(true)
 
       for (const theme of ["light", "dark"]) {
         const previewPath = `public/preview/${slug}/${theme}.html`
         expect(
           readRepoFile(previewPath),
-          `${previewPath} must embed site-relative <img src> (not the absolute URL form)`,
+          `${previewPath} must embed site-relative <img src> (not the absolute URL form)`
         ).toContain(`src="${logoSrcPath}"`)
       }
     }

--- a/src/lib/hits-badge.test.ts
+++ b/src/lib/hits-badge.test.ts
@@ -4,16 +4,16 @@ import { hitsBadgeUrl, hitsNamespaceFromSiteUrl } from "./hits-badge"
 describe("hitsNamespaceFromSiteUrl", () => {
   it("extracts the host from VITE_SITE_URL (hits.sh wants a domain)", () => {
     expect(hitsNamespaceFromSiteUrl("https://getdesign.kr")).toBe(
-      "getdesign.kr",
+      "getdesign.kr"
     )
   })
 
   it("returns the hostname only, ignoring trailing path/slash and port", () => {
     expect(hitsNamespaceFromSiteUrl("https://getdesign.kr/")).toBe(
-      "getdesign.kr",
+      "getdesign.kr"
     )
     expect(hitsNamespaceFromSiteUrl("https://getdesign.kr:8080/")).toBe(
-      "getdesign.kr",
+      "getdesign.kr"
     )
   })
 
@@ -30,19 +30,19 @@ describe("hitsNamespaceFromSiteUrl", () => {
 describe("hitsBadgeUrl", () => {
   it("builds a hits.sh .svg URL with our flat-square muted styling params", () => {
     expect(hitsBadgeUrl("getdesign.kr", "gmarket")).toBe(
-      "https://hits.sh/getdesign.kr/gmarket.svg?style=flat-square&label=VIEWS&color=595959&labelColor=eeeeee",
+      "https://hits.sh/getdesign.kr/gmarket.svg?style=flat-square&label=VIEWS&color=595959&labelColor=eeeeee"
     )
   })
 
   it("keeps the namespace verbatim — hits.sh needs a valid URI (domain or owner/repo path), so slashes must survive", () => {
     expect(hitsBadgeUrl("github.com/CaesiumY/ko-design-md", "toss")).toBe(
-      "https://hits.sh/github.com/CaesiumY/ko-design-md/toss.svg?style=flat-square&label=VIEWS&color=595959&labelColor=eeeeee",
+      "https://hits.sh/github.com/CaesiumY/ko-design-md/toss.svg?style=flat-square&label=VIEWS&color=595959&labelColor=eeeeee"
     )
   })
 
   it("URL-encodes the slug so odd characters cannot break the path", () => {
     expect(hitsBadgeUrl("example.com", "a b")).toContain(
-      "/example.com/a%20b.svg?",
+      "/example.com/a%20b.svg?"
     )
   })
 })

--- a/src/lib/hits-badge.ts
+++ b/src/lib/hits-badge.ts
@@ -23,7 +23,7 @@ export function hitsBadgeUrl(namespace: string, slug: string): string {
 // null when the URL is unset (the pre-deploy default) or unparseable, which
 // makes the badge hide itself instead of pointing at a bogus counter.
 export function hitsNamespaceFromSiteUrl(
-  siteUrl: string | undefined,
+  siteUrl: string | undefined
 ): string | null {
   if (!siteUrl) return null
   try {

--- a/src/lib/og-lede.test.ts
+++ b/src/lib/og-lede.test.ts
@@ -11,7 +11,7 @@ describe("ogLede", () => {
     const text =
       "Demo Pay는 결제는 무조건 짧고 단호하게라는 원칙을 본다. 한 손으로 잡은 화면 안에서, 사용자의 시선은"
     expect(ogLede(text)).toBe(
-      "Demo Pay는 결제는 무조건 짧고 단호하게라는 원칙을 본다.",
+      "Demo Pay는 결제는 무조건 짧고 단호하게라는 원칙을 본다."
     )
   })
 
@@ -40,10 +40,11 @@ describe("ogLede", () => {
   })
 
   it("does not match a Korean-ending shorter than 8 chars (avoids capturing a one-word fragment)", () => {
-    const text = "본다. 그리고 그 안에서 사용자의 시선은 금액과 다음 행동 사이를 두 번 오간다."
+    const text =
+      "본다. 그리고 그 안에서 사용자의 시선은 금액과 다음 행동 사이를 두 번 오간다."
     // "본다." is only 4 chars, regex requires ≥8 — should fall through to next match.
     expect(ogLede(text)).toBe(
-      "본다. 그리고 그 안에서 사용자의 시선은 금액과 다음 행동 사이를 두 번 오간다.",
+      "본다. 그리고 그 안에서 사용자의 시선은 금액과 다음 행동 사이를 두 번 오간다."
     )
   })
 })

--- a/src/lib/renumber-citations.ts
+++ b/src/lib/renumber-citations.ts
@@ -27,7 +27,7 @@ export type RenumberResult = {
 export function renumberReferences(
   body: string,
   removeRefs: ReadonlyArray<number>,
-  opts: { unlink?: boolean } = {},
+  opts: { unlink?: boolean } = {}
 ): RenumberResult {
   const removeSet = new Set(removeRefs)
   const refs = parseReferences(body)
@@ -58,7 +58,7 @@ export function renumberReferences(
   const unlinkCites = (text: string): string =>
     text.replace(/(\s*)((?:\[src:\d+\])+)/g, (_m, ws: string, grp: string) => {
       const kept = (grp.match(/\[src:\d+\]/g) ?? []).filter(
-        (c) => !removeSet.has(citeNum(c)),
+        (c) => !removeSet.has(citeNum(c))
       )
       if (kept.length === 0) return ""
       return ws + kept.map((c) => `[src:${shift(citeNum(c))}]`).join("")

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -77,11 +77,13 @@ describe("buildRssXml", () => {
 
     expect(xml).toContain('<rss version="2.0"')
     expect(xml).toContain(
-      '<atom:link href="https://ko-design.example/rss.xml" rel="self" type="application/rss+xml" />',
+      '<atom:link href="https://ko-design.example/rss.xml" rel="self" type="application/rss+xml" />'
     )
-    expect(xml).toContain("<link>https://ko-design.example/services/toss</link>")
     expect(xml).toContain(
-      '<guid isPermaLink="true">https://ko-design.example/services/toss</guid>',
+      "<link>https://ko-design.example/services/toss</link>"
+    )
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://ko-design.example/services/toss</guid>'
     )
     expect(xml).toContain("<pubDate>Sun, 10 May 2026 00:00:00 GMT</pubDate>")
   })
@@ -114,7 +116,7 @@ describe("buildRssXml", () => {
             body: "본문입니다.",
           }),
         ],
-      }),
+      })
     ).toThrow(/Invalid date format/)
   })
 
@@ -123,7 +125,7 @@ describe("buildRssXml", () => {
 
     expect(xml).toContain("<title>A&amp;B &lt;Design&gt;</title>")
     expect(xml).toContain(
-      "<description>요약에도 &amp; 문자가 들어갑니다.</description>",
+      "<description>요약에도 &amp; 문자가 들어갑니다.</description>"
     )
     // Raw markdown body must NOT leak into <description>
     expect(xml).not.toContain("본문에 &lt;tag&gt; &amp; 특수문자가 들어갑니다.")
@@ -200,7 +202,7 @@ describe("buildRssXml with real /services/*.md content", () => {
     // siblings (e.g. <image><description>...</description></image>).
     const doc = new DOMParser().parseFromString(xml, "application/xml")
     return Array.from(doc.getElementsByTagName("item")).map(
-      (item) => item.getElementsByTagName("description")[0].textContent,
+      (item) => item.getElementsByTagName("description")[0].textContent
     )
   }
 
@@ -242,10 +244,10 @@ describe("buildLlmsTxt", () => {
     const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: docs })
 
     expect(txt).toContain(
-      "- [토스](https://ko-design.example/services/toss/llms.txt): etc — 토스 디자인 원칙 전체 본문입니다.",
+      "- [토스](https://ko-design.example/services/toss/llms.txt): etc — 토스 디자인 원칙 전체 본문입니다."
     )
     expect(txt).toContain(
-      "- [A&B <Design>](https://ko-design.example/services/a-b/llms.txt): etc — 요약에도 & 문자가 들어갑니다.",
+      "- [A&B <Design>](https://ko-design.example/services/a-b/llms.txt): etc — 요약에도 & 문자가 들어갑니다."
     )
     // links point at the raw endpoint, not the human detail page
     expect(txt).not.toContain("/services/toss):")
@@ -273,7 +275,7 @@ describe("buildLlmsTxt", () => {
     })
 
     expect(txt).toContain(
-      "- [Heading Only](https://ko-design.example/services/heading-only/llms.txt): etc — Heading Only",
+      "- [Heading Only](https://ko-design.example/services/heading-only/llms.txt): etc — Heading Only"
     )
   })
 
@@ -292,7 +294,7 @@ describe("buildLlmsTxt", () => {
     })
 
     expect(txt).toContain(
-      "- [Whitespace Tagline](https://ko-design.example/services/whitespace-tagline/llms.txt): etc — Whitespace Tagline",
+      "- [Whitespace Tagline](https://ko-design.example/services/whitespace-tagline/llms.txt): etc — Whitespace Tagline"
     )
     // a whitespace-only tagline must not leave a dangling "— " at the line end
     expect(txt).not.toMatch(/— *$/m)
@@ -314,7 +316,7 @@ describe("buildLlmsTxt", () => {
 
     // the `]` is escaped so the link text doesn't terminate early
     expect(txt).toContain(
-      "- [서비스\\]X](https://ko-design.example/services/bracket-name/llms.txt): etc — 괄호 포함 이름",
+      "- [서비스\\]X](https://ko-design.example/services/bracket-name/llms.txt): etc — 괄호 포함 이름"
     )
   })
 
@@ -343,9 +345,9 @@ describe("buildLlmsTxt", () => {
 
     expect(txt).toContain("# ko/design.md")
     expect(txt).toContain("## Catalog")
-    expect(txt.split("\n").filter((line) => line.startsWith("- ["))).toHaveLength(
-      0,
-    )
+    expect(
+      txt.split("\n").filter((line) => line.startsWith("- ["))
+    ).toHaveLength(0)
   })
 })
 
@@ -362,7 +364,7 @@ describe("buildLlmsTxt with real /services/*.md content", () => {
     const entryLines = txt.split("\n").filter((line) => line.startsWith("- ["))
     for (const line of entryLines) {
       expect(line).toMatch(
-        /\]\(https:\/\/ko-design\.example\/services\/[^/]+\/llms\.txt\): /,
+        /\]\(https:\/\/ko-design\.example\/services\/[^/]+\/llms\.txt\): /
       )
     }
   })
@@ -377,7 +379,7 @@ describe("buildRobotsTxt", () => {
         "Disallow:",
         "Sitemap: https://ko-design.example/sitemap.xml",
         "",
-      ].join("\n"),
+      ].join("\n")
     )
   })
 })

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -14,7 +14,7 @@ function normalizeSiteUrl(siteUrl: string): string {
   const normalized = siteUrl.trim().replace(/\/+$/, "")
   if (!/^https?:\/\/[^/]+/.test(normalized)) {
     throw new Error(
-      `siteUrl must be an absolute URL, got "${siteUrl || "(empty)"}"`,
+      `siteUrl must be an absolute URL, got "${siteUrl || "(empty)"}"`
     )
   }
   return normalized
@@ -72,7 +72,7 @@ export function buildSitemapXml({ siteUrl, services }: FeedInput): string {
         "  </url>",
       ]
         .filter(Boolean)
-        .join("\n"),
+        .join("\n")
     ),
   ]
 
@@ -93,7 +93,7 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
     const updated = doc.frontmatter.last_updated
     const description = truncateForMeta(
       doc.tagline || doc.frontmatter.name,
-      500,
+      500
     )
 
     return [

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -18,13 +18,13 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("absoluteUrl preserves an already-absolute http URL", () => {
     expect(absoluteUrl("http://example.com/og.png")).toBe(
-      "http://example.com/og.png",
+      "http://example.com/og.png"
     )
   })
 
   it("absoluteUrl preserves an already-absolute https URL", () => {
     expect(absoluteUrl("https://example.com/og.png")).toBe(
-      "https://example.com/og.png",
+      "https://example.com/og.png"
     )
   })
 
@@ -46,7 +46,7 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("siteRelativeIfSelf returns absolute URL unchanged when SITE_URL is empty", () => {
     expect(siteRelativeIfSelf("https://getdesign.kr/logos/toss.png")).toBe(
-      "https://getdesign.kr/logos/toss.png",
+      "https://getdesign.kr/logos/toss.png"
     )
   })
 
@@ -56,7 +56,7 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("siteRelativeIfSelf returns a foreign-origin URL unchanged", () => {
     expect(siteRelativeIfSelf("https://other-site.example/foo.png")).toBe(
-      "https://other-site.example/foo.png",
+      "https://other-site.example/foo.png"
     )
   })
 
@@ -69,13 +69,13 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("localLogoPath strips the origin from a frontmatter absolute URL", () => {
     expect(localLogoPath("https://getdesign.kr/logos/toss.png")).toBe(
-      "/logos/toss.png",
+      "/logos/toss.png"
     )
   })
 
   it("localLogoPath is origin-agnostic", () => {
     expect(localLogoPath("https://other-origin.example/logos/x.png")).toBe(
-      "/logos/x.png",
+      "/logos/x.png"
     )
   })
 
@@ -89,7 +89,7 @@ describe("site-config (test env, VITE_SITE_URL unset)", () => {
 
   it("localLogoPath preserves query strings and hashes", () => {
     expect(localLogoPath("https://getdesign.kr/logos/toss.png?v=1#top")).toBe(
-      "/logos/toss.png?v=1#top",
+      "/logos/toss.png?v=1#top"
     )
   })
 

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -16,7 +16,7 @@ const RAW = import.meta.env.VITE_SITE_URL ?? ""
 
 if (import.meta.env.PROD && !RAW) {
   throw new Error(
-    "VITE_SITE_URL must be set for production builds. See .env.example for the expected shape.",
+    "VITE_SITE_URL must be set for production builds. See .env.example for the expected shape."
   )
 }
 
@@ -42,7 +42,7 @@ export function absoluteUrl(path: string): string {
 // When VITE_SITE_URL is unset (test/SSR/dev-without-env), the input is
 // returned unchanged — the browser will resolve it as-is.
 export function siteRelativeIfSelf(
-  url: string | undefined,
+  url: string | undefined
 ): string | undefined {
   if (!url || !SITE_URL) return url
   if (url === SITE_URL) return "/"

--- a/src/lib/source-citations.test.ts
+++ b/src/lib/source-citations.test.ts
@@ -30,8 +30,8 @@ describe("auditSourceCitations", () => {
     const issues = auditSourceCitations("demo", sources, body)
     expect(
       issues.some(
-        (i) => i.severity === "block" && i.rule === "non-public-reference",
-      ),
+        (i) => i.severity === "block" && i.rule === "non-public-reference"
+      )
     ).toBe(true)
   })
 
@@ -49,7 +49,7 @@ describe("auditSourceCitations", () => {
     const body = makeBody("[src:1][src:2]", ["1. https://a.example"])
     const issues = auditSourceCitations("demo", sources, body)
     expect(
-      issues.some((i) => i.severity === "block" && i.rule === "citation-range"),
+      issues.some((i) => i.severity === "block" && i.rule === "citation-range")
     ).toBe(true)
   })
 
@@ -62,8 +62,8 @@ describe("auditSourceCitations", () => {
     const issues = auditSourceCitations("demo", sources, body)
     expect(
       issues.some(
-        (i) => i.severity === "block" && i.rule === "references-numbering",
-      ),
+        (i) => i.severity === "block" && i.rule === "references-numbering"
+      )
     ).toBe(true)
   })
 
@@ -77,8 +77,8 @@ describe("auditSourceCitations", () => {
     expect(
       issues.some(
         (i) =>
-          i.severity === "block" && i.rule === "sources-references-mismatch",
-      ),
+          i.severity === "block" && i.rule === "sources-references-mismatch"
+      )
     ).toBe(true)
   })
 
@@ -92,8 +92,8 @@ describe("auditSourceCitations", () => {
     expect(
       issues.some(
         (i) =>
-          i.severity === "block" && i.rule === "sources-references-mismatch",
-      ),
+          i.severity === "block" && i.rule === "sources-references-mismatch"
+      )
     ).toBe(true)
   })
 
@@ -108,7 +108,7 @@ describe("auditSourceCitations", () => {
       const body = makeBody("[src:1]", [`1. ${bad}`])
       const issues = auditSourceCitations("demo", sources, body)
       expect(
-        issues.some((i) => i.severity === "block" && i.rule === "forbidden-url"),
+        issues.some((i) => i.severity === "block" && i.rule === "forbidden-url")
       ).toBe(true)
     }
   })
@@ -121,7 +121,7 @@ describe("auditSourceCitations", () => {
     ])
     const issues = auditSourceCitations("demo", sources, body)
     expect(
-      issues.some((i) => i.severity === "warn" && i.rule === "unused-source"),
+      issues.some((i) => i.severity === "warn" && i.rule === "unused-source")
     ).toBe(true)
     expect(blocks(issues)).toEqual([])
   })
@@ -135,8 +135,8 @@ describe("auditSourceCitations", () => {
     const issues = auditSourceCitations("demo", sources, body)
     expect(
       issues.some(
-        (i) => i.severity === "warn" && i.rule === "duplicate-source-url",
-      ),
+        (i) => i.severity === "warn" && i.rule === "duplicate-source-url"
+      )
     ).toBe(true)
   })
 

--- a/src/lib/source-citations.ts
+++ b/src/lib/source-citations.ts
@@ -34,7 +34,10 @@ const FORBIDDEN_PATTERNS: ReadonlyArray<{
     test: (u) => /api\.anthropic\.com\/v1\/design\/h\//.test(u),
     label: "ephemeral Claude Design handoff link",
   },
-  { test: (u) => u.includes(".claude/cache/"), label: "local .claude/cache path" },
+  {
+    test: (u) => u.includes(".claude/cache/"),
+    label: "local .claude/cache path",
+  },
   { test: (u) => u.startsWith("/"), label: "site-relative path" },
   { test: (u) => u.startsWith("file://"), label: "local file URL" },
 ]
@@ -81,7 +84,7 @@ function refUrl(text: string): string {
 export function auditSourceCitations(
   slug: string,
   sources: Array<string>,
-  body: string,
+  body: string
 ): Array<CitationIssue> {
   const issues: Array<CitationIssue> = []
   const refs = parseReferences(body)

--- a/src/lib/token-curation.test.ts
+++ b/src/lib/token-curation.test.ts
@@ -115,7 +115,7 @@ describe("curateColors", () => {
     // 20 grayscale steps, every one below NEUTRAL_CHROMA → zero chromatic
     // signature. The card must still open with something, not an empty headline.
     const colors = Array.from({ length: 20 }, (_, i) =>
-      c(`gray-${(i + 1) * 50}`, `oklch(${0.05 + i * 0.045} 0 0)`),
+      c(`gray-${(i + 1) * 50}`, `oklch(${0.05 + i * 0.045} 0 0)`)
     )
     const { visible, hidden } = curateColors(colors)
     expect(visible.length).toBe(8) // COLORS_FALLBACK
@@ -126,7 +126,7 @@ describe("curateColors", () => {
   it("caps the signature set and collapses the overflow", () => {
     // 30 distinct named (no hyphen-number suffix) chromatic hues
     const colors = Array.from({ length: 30 }, (_, i) =>
-      c(`tone${i}`, `oklch(0.6 0.2 ${i * 12})`),
+      c(`tone${i}`, `oklch(0.6 0.2 ${i * 12})`)
     )
     const { visible, hidden } = curateColors(colors)
     expect(visible.length).toBe(16) // COLORS_CAP

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -21,7 +21,9 @@ export const MIN_COLLAPSE = 6
 export function colorChroma(value: string): number {
   const lch = value.match(/^(?:oklch|lch)\(\s*[\d.]+%?\s+([+-]?[\d.]+)/i)
   if (lch) return Number(lch[1])
-  const lab = value.match(/^oklab\(\s*[\d.]+%?\s+([+-]?[\d.]+)\s+([+-]?[\d.]+)/i)
+  const lab = value.match(
+    /^oklab\(\s*[\d.]+%?\s+([+-]?[\d.]+)\s+([+-]?[\d.]+)/i
+  )
   if (lab) return Math.hypot(Number(lab[1]), Number(lab[2]))
   return 1
 }
@@ -33,7 +35,7 @@ export function isAlphaColor(value: string): boolean {
 
 /** A numbered scale step (`gray-100`, `blue-500`, `gray-1000`) → {family, step}. */
 export function rampStep(
-  name: string,
+  name: string
 ): { family: string; step: number } | null {
   // \d{1,4} so 4-digit steps (gray-1000, carrot-1000) collapse with their ramp
   // instead of reading as a standalone named token.

--- a/src/lib/token-extractor.test.ts
+++ b/src/lib/token-extractor.test.ts
@@ -8,7 +8,7 @@ import { extractTokensFromMarkdown } from "./token-extractor"
 function loadBody(slug: string): string {
   const raw = readFileSync(
     new URL(`../../services/${slug}.md`, import.meta.url),
-    "utf8",
+    "utf8"
   )
   return buildDoc(`/services/${slug}.md`, raw).body
 }
@@ -38,7 +38,7 @@ describe("extractTokensFromMarkdown — structure", () => {
       "```yaml",
       "grey-900: oklch(0.2 0 0)",
       "```",
-      "## Spacing",
+      "## Spacing"
     )
     const { colors } = extractTokensFromMarkdown(body)
     expect(colors.map((c) => c.name)).toEqual(["blue-500", "grey-900"])
@@ -55,7 +55,7 @@ describe("extractTokensFromMarkdown — structure", () => {
       "```",
       "```yaml",
       "primary: oklch(0.5 0.1 30)",
-      "```",
+      "```"
     )
     expect(extractTokensFromMarkdown(body).colors).toHaveLength(1)
   })
@@ -71,7 +71,7 @@ describe("colors", () => {
       "fill: primary",
       "op: 0.30",
       "dark-bg: oklch(0.1 0 0)",
-      "```",
+      "```"
     )
     const { colors } = extractTokensFromMarkdown(body)
     expect(colors.find((c) => c.name === "primary")).toMatchObject({
@@ -96,7 +96,7 @@ describe("colors", () => {
   it("preserves the alpha slash inside oklch values (toss fg-tertiary)", () => {
     const { colors } = extractTokensFromMarkdown(loadBody("toss"))
     expect(colors.find((c) => c.name === "fg-tertiary")?.value).toBe(
-      "oklch(0.155 0.060 261 / 0.58)",
+      "oklch(0.155 0.060 261 / 0.58)"
     )
   })
 
@@ -124,31 +124,54 @@ describe("spacing & radius", () => {
       "```yaml",
       "full: 9999",
       "circle: 50%",
-      "```",
+      "```"
     )
     const { spacing, radius } = extractTokensFromMarkdown(body)
-    expect(spacing.find((s) => s.name === "a")).toMatchObject({ value: "4px", px: 4 })
-    expect(spacing.find((s) => s.name === "b")).toMatchObject({ value: "16px", px: 16 })
-    expect(spacing.find((s) => s.name === "c")).toMatchObject({ value: "1.5rem", px: 24 })
-    expect(radius.find((r) => r.name === "full")).toMatchObject({ value: "9999px", px: 9999 })
-    expect(radius.find((r) => r.name === "circle")).toMatchObject({ value: "50%", px: null })
+    expect(spacing.find((s) => s.name === "a")).toMatchObject({
+      value: "4px",
+      px: 4,
+    })
+    expect(spacing.find((s) => s.name === "b")).toMatchObject({
+      value: "16px",
+      px: 16,
+    })
+    expect(spacing.find((s) => s.name === "c")).toMatchObject({
+      value: "1.5rem",
+      px: 24,
+    })
+    expect(radius.find((r) => r.name === "full")).toMatchObject({
+      value: "9999px",
+      px: 9999,
+    })
+    expect(radius.find((r) => r.name === "circle")).toMatchObject({
+      value: "50%",
+      px: null,
+    })
   })
 
   it("reads toss spacing (bare) and baemin spacing (px-suffixed)", () => {
     expect(
-      extractTokensFromMarkdown(loadBody("toss")).spacing.find((s) => s.name === "space-1"),
+      extractTokensFromMarkdown(loadBody("toss")).spacing.find(
+        (s) => s.name === "space-1"
+      )
     ).toMatchObject({ value: "4px", px: 4 })
     expect(
-      extractTokensFromMarkdown(loadBody("baemin")).spacing.find((s) => s.name === "space-4"),
+      extractTokensFromMarkdown(loadBody("baemin")).spacing.find(
+        (s) => s.name === "space-4"
+      )
     ).toMatchObject({ value: "16px", px: 16 })
   })
 
   it("reads radius variants: toss full-pill and baemin circle:50%", () => {
     expect(
-      extractTokensFromMarkdown(loadBody("toss")).radius.find((r) => r.name === "radius-full")?.px,
+      extractTokensFromMarkdown(loadBody("toss")).radius.find(
+        (r) => r.name === "radius-full"
+      )?.px
     ).toBe(999)
     expect(
-      extractTokensFromMarkdown(loadBody("baemin")).radius.find((r) => r.name === "circle"),
+      extractTokensFromMarkdown(loadBody("baemin")).radius.find(
+        (r) => r.name === "circle"
+      )
     ).toMatchObject({ value: "50%", px: null })
   })
 })
@@ -196,14 +219,17 @@ describe("typography — format variants (P2 backfill)", () => {
       "weight-700: 700",
       "line-height-16: 1.6rem",
       "letter-spacing-1: -0.01rem",
-      "```",
+      "```"
     )
     const { typography } = extractTokensFromMarkdown(body)
     expect(typography.find((t) => t.name === "font-size-11")).toMatchObject({
       size: "1.1rem",
     })
     // weight / line-height / letter-spacing constants are not size tokens
-    expect(typography.map((t) => t.name)).toEqual(["font-size-11", "font-size-36"])
+    expect(typography.map((t) => t.name)).toEqual([
+      "font-size-11",
+      "font-size-36",
+    ])
   })
 
   it("reads size from platform keys and named weights (11st android/ios object)", () => {
@@ -212,7 +238,7 @@ describe("typography — format variants (P2 backfill)", () => {
       "```yaml",
       "headline-1: { weight: Bold, android: 24, ios: 25 }",
       "body-1: { weight: Regular, android: 14, ios: 15 }",
-      "```",
+      "```"
     )
     const { typography } = extractTokensFromMarkdown(body)
     expect(typography.find((t) => t.name === "headline-1")).toMatchObject({
@@ -231,7 +257,7 @@ describe("typography — format variants (P2 backfill)", () => {
       "| Token | Size / Line height | 용도 |",
       "| --- | --- | --- |",
       "| display-l | 64px / 1.3, -0.02em | 배너 |",
-      "| **body-m** | 17px / 1.55 | 본문 |",
+      "| **body-m** | 17px / 1.55 | 본문 |"
     )
     const { typography } = extractTokensFromMarkdown(body)
     expect(typography.find((t) => t.name === "display-l")).toMatchObject({
@@ -252,7 +278,7 @@ describe("typography — format variants (P2 backfill)", () => {
       "display-1: { size: 56, weight: 700, line-height: 1.3 }",
       "font-display-src: https://fonts.example.com/v2/400/WantedSansVariable.css",
       "font-sans-src: //cdn.example.com/v9/800/body.css",
-      "```",
+      "```"
     )
     const { typography } = extractTokensFromMarkdown(body)
     // The `/400/` and `/800/` URL path segments would otherwise parse as size
@@ -269,7 +295,7 @@ describe("spacing — format variants (P2 backfill)", () => {
       "```yaml",
       "spacing-scale: [2, 4, 8, 16]",
       "spacing-base: 8",
-      "```",
+      "```"
     )
     const pxs = extractTokensFromMarkdown(body).spacing.map((s) => s.px)
     expect(pxs).toEqual(expect.arrayContaining([2, 4, 8, 16]))
@@ -279,13 +305,13 @@ describe("spacing — format variants (P2 backfill)", () => {
 describe("real entries recover a ramp after variant support", () => {
   it("krds (table), bezier (font-size-*), and 11st (platform obj) all extract typography", () => {
     expect(
-      extractTokensFromMarkdown(loadBody("krds")).typography.length,
+      extractTokensFromMarkdown(loadBody("krds")).typography.length
     ).toBeGreaterThan(8)
     expect(
-      extractTokensFromMarkdown(loadBody("bezier")).typography.length,
+      extractTokensFromMarkdown(loadBody("bezier")).typography.length
     ).toBeGreaterThan(8)
     expect(
-      extractTokensFromMarkdown(loadBody("11st")).typography.length,
+      extractTokensFromMarkdown(loadBody("11st")).typography.length
     ).toBeGreaterThan(8)
   })
 })

--- a/src/lib/token-extractor.ts
+++ b/src/lib/token-extractor.ts
@@ -92,7 +92,8 @@ function rawLines(sectionLines: Array<string>): Array<RawLine> {
 
 // ── Colors ────────────────────────────────────────────────────────────────
 
-const COLOR_VALUE = /^(?:oklch|oklab|rgba?|hsla?|hwb|lab|lch|color)\(|^#[0-9a-fA-F]{3,8}$/
+const COLOR_VALUE =
+  /^(?:oklch|oklab|rgba?|hsla?|hwb|lab|lch|color)\(|^#[0-9a-fA-F]{3,8}$/
 
 function parseColors(rows: Array<RawLine>): Array<ColorToken> {
   const out: Array<ColorToken> = []
@@ -171,9 +172,20 @@ function isWeight(n: number): boolean {
 }
 
 const NAMED_WEIGHTS: Record<string, number> = {
-  thin: 100, extralight: 200, ultralight: 200, light: 300, regular: 400,
-  normal: 400, book: 400, medium: 500, semibold: 600, demibold: 600,
-  bold: 700, extrabold: 800, heavy: 800, black: 900,
+  thin: 100,
+  extralight: 200,
+  ultralight: 200,
+  light: 300,
+  regular: 400,
+  normal: 400,
+  book: 400,
+  medium: 500,
+  semibold: 600,
+  demibold: 600,
+  bold: 700,
+  extrabold: 800,
+  heavy: 800,
+  black: 900,
 }
 
 function parseWeight(v: string): number | undefined {
@@ -184,7 +196,15 @@ function parseWeight(v: string): number | undefined {
 
 // Some systems author size under a platform key instead of `size`
 // (11st: `{ weight, android, ios }`). Probe these in priority order.
-const PLATFORM_SIZE_KEYS = ["android", "pc", "web", "desktop", "default", "ios", "mobile"]
+const PLATFORM_SIZE_KEYS = [
+  "android",
+  "pc",
+  "web",
+  "desktop",
+  "default",
+  "ios",
+  "mobile",
+]
 
 function parseTypeObject(value: string): Partial<TypeToken> {
   const out: Partial<TypeToken> = {}
@@ -201,7 +221,9 @@ function parseTypeObject(value: string): Partial<TypeToken> {
     else platform[k] = v
   }
   if (out.size === undefined) {
-    const key = PLATFORM_SIZE_KEYS.find((k) => platform[k] && /^\d/.test(platform[k]))
+    const key = PLATFORM_SIZE_KEYS.find(
+      (k) => platform[k] && /^\d/.test(platform[k])
+    )
     if (key) out.size = normalizeSize(platform[key])
   }
   return out
@@ -210,7 +232,10 @@ function parseTypeObject(value: string): Partial<TypeToken> {
 function parseTypeSlash(value: string): Partial<TypeToken> {
   const out: Partial<TypeToken> = {}
   const notes: Array<string> = []
-  for (const part of value.split("/").map((p) => p.trim()).filter(Boolean)) {
+  for (const part of value
+    .split("/")
+    .map((p) => p.trim())
+    .filter(Boolean)) {
     const lh = part.match(/^line-height\s+(\S+)$/i)
     if (lh) {
       out.lineHeight = normalizeLineHeight(lh[1])
@@ -226,7 +251,8 @@ function parseTypeSlash(value: string): Partial<TypeToken> {
       const n = Number(num[1])
       if (out.size === undefined) out.size = num[2] ? part : `${n}px`
       else if (isWeight(n) && out.weight === undefined) out.weight = n
-      else if (out.lineHeight === undefined) out.lineHeight = normalizeLineHeight(part)
+      else if (out.lineHeight === undefined)
+        out.lineHeight = normalizeLineHeight(part)
       else notes.push(part)
       continue
     }
@@ -249,7 +275,8 @@ function parseType(row: RawLine): TypeToken | null {
   const parenNote = row.key.match(/\(([^)]*)\)/)?.[1]
   const value = row.value
   let parsed: Partial<TypeToken> | null = null
-  if (value.startsWith("{") && value.endsWith("}")) parsed = parseTypeObject(value)
+  if (value.startsWith("{") && value.endsWith("}"))
+    parsed = parseTypeObject(value)
   else if (value.includes("/")) parsed = parseTypeSlash(value)
   if (!parsed || !parsed.size) return null // a ramp token must carry a size
 
@@ -272,7 +299,7 @@ function stripName(raw: string): string {
 // instead of a yaml fence). Header and `---` separator rows fall out downstream
 // because they carry no size-bearing cell.
 function tableRows(
-  sectionLines: Array<string>,
+  sectionLines: Array<string>
 ): Array<{ name: string; cells: Array<string> }> {
   const out: Array<{ name: string; cells: Array<string> }> = []
   for (const line of sectionLines) {
@@ -299,7 +326,7 @@ function parseSizeOnly(row: RawLine): TypeToken | null {
 
 function parseTypography(
   rows: Array<RawLine>,
-  tables: Array<{ name: string; cells: Array<string> }>,
+  tables: Array<{ name: string; cells: Array<string> }>
 ): Array<TypeToken> {
   // Primary: object/slash ramps — the authored type styles.
   const primary: Array<TypeToken> = []
@@ -329,7 +356,9 @@ function parseTypography(
     if (!cell) continue
     // Strip markdown emphasis (`**bold**`, `` `code` ``), then treat commas like
     // extra slash segments (`64px / 1.3, -0.02em` → size / line-height / tracking).
-    const parsed = parseTypeSlash(cell.replace(/[`*]/g, "").replace(/,/g, " / "))
+    const parsed = parseTypeSlash(
+      cell.replace(/[`*]/g, "").replace(/,/g, " / ")
+    )
     if (!parsed.size) continue
     out.push(
       clean({
@@ -339,7 +368,7 @@ function parseTypography(
         lineHeight: parsed.lineHeight,
         tracking: parsed.tracking,
         note: parsed.note || undefined,
-      }),
+      })
     )
     seen.add(row.name)
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import {  clsx } from "clsx"
+import { clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
-import type {ClassValue} from "clsx";
+import type { ClassValue } from "clsx"
 
 export function cn(...inputs: Array<ClassValue>) {
   return twMerge(clsx(inputs))

--- a/src/og/load-fonts.ts
+++ b/src/og/load-fonts.ts
@@ -8,7 +8,10 @@ function readOtf(filename: string): ArrayBuffer {
   const fullPath = path.join(FONTS_DIR, filename)
   const buffer = fs.readFileSync(fullPath)
   // Slice into a fresh ArrayBuffer — satori rejects Node Buffers directly.
-  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  )
 }
 
 let cachedFonts: SatoriOptions["fonts"] | undefined

--- a/src/og/load-logo.test.ts
+++ b/src/og/load-logo.test.ts
@@ -37,7 +37,7 @@ describe("loadOgLogo", () => {
     const result = loadOgLogo("/../etc/passwd")
     expect(result).toBeUndefined()
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("escapes public/"),
+      expect.stringContaining("escapes public/")
     )
   })
 
@@ -47,22 +47,18 @@ describe("loadOgLogo", () => {
     // before the guard runs. Result is undefined because the normalized
     // path ("/etc/passwd") doesn't exist under `public/`, not because
     // the traversal guard fired.
-    const result = loadOgLogo(
-      "https://getdesign.kr/logos/../../etc/passwd",
-    )
+    const result = loadOgLogo("https://getdesign.kr/logos/../../etc/passwd")
     expect(result).toBeUndefined()
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("logo missing"),
+      expect.stringContaining("logo missing")
     )
   })
 
   it("returns undefined for a logo file that does not exist", () => {
-    const result = loadOgLogo(
-      "https://getdesign.kr/logos/__no_such_logo__.png",
-    )
+    const result = loadOgLogo("https://getdesign.kr/logos/__no_such_logo__.png")
     expect(result).toBeUndefined()
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("logo missing"),
+      expect.stringContaining("logo missing")
     )
   })
 
@@ -76,7 +72,7 @@ describe("loadOgLogo", () => {
       const result = loadOgLogo("https://getdesign.kr/logos/krds.gif")
       expect(result).toBeUndefined()
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("logo unsupported extension"),
+        expect.stringContaining("logo unsupported extension")
       )
     } finally {
       existsSpy.mockRestore()

--- a/src/og/load-logo.ts
+++ b/src/og/load-logo.ts
@@ -50,10 +50,7 @@ export function loadOgLogo(logoUrl: string | undefined): string | undefined {
   // runs in CI with read access to `.env` and deploy keys, so an arbitrary
   // file read here is a real supply-chain surface even though only base64
   // ends up in the PNG. Reject anything that doesn't land inside PUBLIC_DIR.
-  if (
-    !absPath.startsWith(PUBLIC_DIR + path.sep) &&
-    absPath !== PUBLIC_DIR
-  ) {
+  if (!absPath.startsWith(PUBLIC_DIR + path.sep) && absPath !== PUBLIC_DIR) {
     console.warn(`[og] logo path escapes public/: ${relPath}`)
     return undefined
   }

--- a/src/og/render.ts
+++ b/src/og/render.ts
@@ -1,9 +1,9 @@
 import satori from "satori"
 import sharp from "sharp"
 import { loadOgFonts } from "./load-fonts"
-import { OgTemplate  } from "./template"
+import { OgTemplate } from "./template"
 import { CANVAS } from "./tokens"
-import type {OgTemplateProps} from "./template";
+import type { OgTemplateProps } from "./template"
 
 export type RenderOgOptions = OgTemplateProps
 

--- a/src/og/tokens.ts
+++ b/src/og/tokens.ts
@@ -79,10 +79,6 @@ function titleWidthScore(rendered: string): number {
 // `hasLogo: true` when the brand mark is rendered on the same row as the
 // title so the budget accounts for the reduced usable width.
 export function pickTitleStyle(rendered: string, hasLogo = false) {
-  const budget = hasLogo
-    ? TITLE_WIDTH_BUDGET_WITH_LOGO
-    : TITLE_WIDTH_BUDGET
-  return titleWidthScore(rendered) > budget
-    ? TYPE.titleCompact
-    : TYPE.title
+  const budget = hasLogo ? TITLE_WIDTH_BUDGET_WITH_LOGO : TITLE_WIDTH_BUDGET
+  return titleWidthScore(rendered) > budget ? TYPE.titleCompact : TYPE.title
 }

--- a/src/routes/-home/components/category-sidebar.tsx
+++ b/src/routes/-home/components/category-sidebar.tsx
@@ -26,18 +26,18 @@ function SidebarItem({ label, count, active, onClick }: ItemProps) {
       className={cn(
         "group relative flex w-full items-baseline gap-3 px-3 py-2 text-left text-sm transition-colors",
         active
-          ? "bg-secondary text-foreground font-semibold"
-          : "text-muted-foreground hover:text-foreground hover:bg-secondary/50",
+          ? "bg-secondary font-semibold text-foreground"
+          : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
       )}
     >
       {active && (
         <span
           aria-hidden
-          className="bg-brand absolute top-1.5 bottom-1.5 left-0 w-[3px]"
+          className="absolute top-1.5 bottom-1.5 left-0 w-[3px] bg-brand"
         />
       )}
       <span className="truncate">{label}</span>
-      <span className="text-muted-foreground ml-auto text-xs tabular-nums">
+      <span className="ml-auto text-xs text-muted-foreground tabular-nums">
         {count}
       </span>
     </button>
@@ -60,8 +60,8 @@ function CategoryChip({ label, count, active, onClick }: ChipProps) {
       className={cn(
         "inline-flex shrink-0 items-baseline gap-1.5 border px-3 py-1.5 text-xs whitespace-nowrap transition-colors",
         active
-          ? "border-foreground bg-foreground text-background font-semibold"
-          : "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
+          ? "border-foreground bg-foreground font-semibold text-background"
+          : "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground"
       )}
     >
       <span>{label}</span>
@@ -85,10 +85,7 @@ export function CategorySidebar({
   return (
     <>
       {/* Desktop: vertical sidebar */}
-      <nav
-        aria-label="Categories"
-        className="hidden lg:block"
-      >
+      <nav aria-label="Categories" className="hidden lg:block">
         <h2 className="text-meta-caps mb-3 px-3">Find Designs</h2>
         <ul>
           <li>

--- a/src/routes/-home/components/design-search.tsx
+++ b/src/routes/-home/components/design-search.tsx
@@ -35,7 +35,7 @@ export function DesignSearch({ value, onChange, className }: Props) {
     <div className={cn("relative", className)}>
       <Search
         aria-hidden
-        className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2"
+        className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
       />
       <input
         type="search"
@@ -43,7 +43,7 @@ export function DesignSearch({ value, onChange, className }: Props) {
         onChange={(e) => setLocal(e.target.value)}
         placeholder="Search all designs"
         aria-label="Search designs"
-        className="border-border placeholder:text-muted-foreground/70 focus:border-foreground/50 focus:ring-brand/30 block w-full border bg-transparent py-2.5 pr-3 pl-10 text-sm transition-colors focus:ring-2 focus:outline-none"
+        className="block w-full border border-border bg-transparent py-2.5 pr-3 pl-10 text-sm transition-colors placeholder:text-muted-foreground/70 focus:border-foreground/50 focus:ring-2 focus:ring-brand/30 focus:outline-none"
       />
     </div>
   )

--- a/src/routes/-home/components/hero.tsx
+++ b/src/routes/-home/components/hero.tsx
@@ -1,6 +1,6 @@
 export function HomeHero() {
   return (
-    <section className="mx-auto max-w-[1400px] break-keep px-8 [container-type:inline-size]">
+    <section className="[container-type:inline-size] mx-auto max-w-[1400px] px-8 break-keep">
       {/* Issue mark — top divider */}
       <div
         className="text-meta-caps animate-fade-in-up flex flex-wrap items-baseline gap-x-5 gap-y-2 border-b pt-12 pb-3.5 sm:gap-x-6 sm:pt-20"
@@ -8,7 +8,7 @@ export function HomeHero() {
       >
         <span>CATALOG</span>
         <span>KOREAN DESIGN</span>
-        <span className="text-brand font-bold">— LLM CONTEXT</span>
+        <span className="font-bold text-brand">— LLM CONTEXT</span>
         <span className="tabular-nums sm:ml-auto">№ 001 / 2026.05</span>
       </div>
 
@@ -30,7 +30,7 @@ export function HomeHero() {
       >
         한국 서비스의 시그니처 디자인을 LLM 컨텍스트로.
         <br />
-        <strong className="text-brand font-bold">
+        <strong className="font-bold text-brand">
           한 번의 클릭으로 design.md 전체를 복사
         </strong>
         해 그대로 붙여넣으세요.

--- a/src/routes/-home/components/service-list-row.tsx
+++ b/src/routes/-home/components/service-list-row.tsx
@@ -38,7 +38,7 @@ function formatShortDate(iso: string): string {
 export function isRecentServiceUpdate(
   iso: string,
   nowMs: number | null,
-  windowDays = NEW_WINDOW_DAYS,
+  windowDays = NEW_WINDOW_DAYS
 ): boolean {
   if (!iso || nowMs === null) return false
   const updated = new Date(iso)
@@ -49,7 +49,7 @@ export function isRecentServiceUpdate(
 
 export function formatServiceListNumber(
   index: number,
-  totalCount: number,
+  totalCount: number
 ): string {
   const targetLength = Math.max(2, String(totalCount).length)
   return String(totalCount - index + 1).padStart(targetLength, "0")
@@ -59,8 +59,8 @@ function UpdatedBadge({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "bg-brand text-primary-foreground inline-flex items-center px-1.5 py-0.5 text-[10px] leading-none font-bold tracking-[0.12em] uppercase",
-        className,
+        "inline-flex items-center bg-brand px-1.5 py-0.5 text-[10px] leading-none font-bold tracking-[0.12em] text-primary-foreground uppercase",
+        className
       )}
     >
       Updated
@@ -80,17 +80,17 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
       to="/services/$slug"
       params={{ slug }}
       search={{ tab: "preview" }}
-      className="group hover:bg-secondary/60 block border-b transition-colors"
+      className="group block border-b transition-colors hover:bg-secondary/60"
       style={{ borderColor: "var(--rule-strong)" }}
     >
       {/* Desktop: single-row 6-col grid */}
       <div
         className={cn(
           "hidden items-center gap-4 px-6 py-3 lg:grid",
-          "lg:grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px]",
+          "lg:grid-cols-[40px_minmax(180px,220px)_1fr_56px_72px_72px]"
         )}
       >
-        <span className="text-muted-foreground text-xs tabular-nums">
+        <span className="text-xs text-muted-foreground tabular-nums">
           {pageNo}
         </span>
         <span className="flex min-w-0 items-center gap-2.5">
@@ -99,12 +99,14 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
             {name}
           </span>
         </span>
-        <span className="text-muted-foreground min-w-0 truncate text-sm">
+        <span className="min-w-0 truncate text-sm text-muted-foreground">
           {doc.tagline}
         </span>
-        <span className="flex items-center">{isUpdated && <UpdatedBadge />}</span>
+        <span className="flex items-center">
+          {isUpdated && <UpdatedBadge />}
+        </span>
         <span className="text-right text-sm tabular-nums">{tokens}</span>
-        <span className="text-muted-foreground text-right text-xs tabular-nums">
+        <span className="text-right text-xs text-muted-foreground tabular-nums">
           {date}
         </span>
       </div>
@@ -117,7 +119,7 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
             {name}
           </span>
           {isUpdated && <UpdatedBadge />}
-          <span className="text-muted-foreground ml-auto flex shrink-0 items-baseline gap-1.5 text-xs tabular-nums">
+          <span className="ml-auto flex shrink-0 items-baseline gap-1.5 text-xs text-muted-foreground tabular-nums">
             <span>{tokens}</span>
             {date && (
               <>
@@ -128,7 +130,7 @@ export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
           </span>
         </div>
         {doc.tagline && (
-          <p className="text-muted-foreground mt-1 truncate pl-[34px] text-xs">
+          <p className="mt-1 truncate pl-[34px] text-xs text-muted-foreground">
             {doc.tagline}
           </p>
         )}

--- a/src/routes/-home/components/service-logo.tsx
+++ b/src/routes/-home/components/service-logo.tsx
@@ -30,8 +30,8 @@ function FallbackBadge({
     <span
       aria-hidden={ariaHidden ? true : undefined}
       className={cn(
-        "bg-secondary text-secondary-foreground inline-flex shrink-0 select-none items-center justify-center text-[11px] font-bold tracking-tight",
-        className,
+        "inline-flex shrink-0 items-center justify-center bg-secondary text-[11px] font-bold tracking-tight text-secondary-foreground select-none",
+        className
       )}
       style={{ width: size, height: size }}
     >
@@ -62,7 +62,7 @@ export function ServiceLogo({ name, logo, size = 24, className }: Props) {
           }
           setFailed(true)
         }}
-        className={cn("shrink-0 select-none object-contain", className)}
+        className={cn("shrink-0 object-contain select-none", className)}
         style={{ width: size, height: size }}
       />
     )

--- a/src/routes/-home/hooks/use-filtered-services.test.ts
+++ b/src/routes/-home/hooks/use-filtered-services.test.ts
@@ -4,7 +4,7 @@ import type { ServiceDoc } from "@/lib/content-types"
 
 function serviceDoc(
   name: string,
-  designSystemName: string | undefined,
+  designSystemName: string | undefined
 ): ServiceDoc {
   return {
     frontmatter: {
@@ -28,7 +28,7 @@ function serviceDoc(
 describe("buildServiceSearchText", () => {
   it("includes the optional design system name so system-name queries still match", () => {
     const haystack = buildServiceSearchText(
-      serviceDoc("당근", "SEED Design"),
+      serviceDoc("당근", "SEED Design")
     ).toLowerCase()
 
     expect(haystack).toContain("당근")

--- a/src/routes/-home/hooks/use-filtered-services.ts
+++ b/src/routes/-home/hooks/use-filtered-services.ts
@@ -29,7 +29,7 @@ export function buildServiceSearchText(doc: ServiceDoc): string {
 }
 
 export function useFilteredServices(
-  allServices: Array<ServiceDoc>,
+  allServices: Array<ServiceDoc>
 ): UseFilteredServicesResult {
   const search = useSearch({ from: "/" })
   const navigate = useNavigate({ from: "/" })

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,9 @@
-import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router"
+import {
+  HeadContent,
+  Outlet,
+  Scripts,
+  createRootRoute,
+} from "@tanstack/react-router"
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools"
 import { TanStackDevtools } from "@tanstack/react-devtools"
 import { Provider as JotaiProvider } from "jotai"
@@ -13,7 +18,10 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" },
+      {
+        name: "viewport",
+        content: "width=device-width, initial-scale=1, viewport-fit=cover",
+      },
       { title: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그" },
       {
         name: "description",
@@ -72,7 +80,9 @@ export const Route = createRootRoute({
       <h1 className="text-display mt-3 text-5xl font-black tracking-tighter">
         Page not found.
       </h1>
-      <p className="mt-4 text-muted-foreground">요청하신 페이지를 찾을 수 없습니다.</p>
+      <p className="mt-4 text-muted-foreground">
+        요청하신 페이지를 찾을 수 없습니다.
+      </p>
     </main>
   ),
   shellComponent: RootDocument,
@@ -106,7 +116,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <TanStackDevtools
           config={{ position: "bottom-right" }}
           plugins={[
-            { name: "Tanstack Router", render: <TanStackRouterDevtoolsPanel /> },
+            {
+              name: "Tanstack Router",
+              render: <TanStackRouterDevtoolsPanel />,
+            },
           ]}
         />
         <Analytics />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,8 +21,7 @@ export const Route = createFileRoute("/")({
       (CATEGORIES as ReadonlyArray<string>).includes(raw.cat)
         ? (raw.cat as Category)
         : undefined
-    const q =
-      typeof raw.q === "string" && raw.q.length > 0 ? raw.q : undefined
+    const q = typeof raw.q === "string" && raw.q.length > 0 ? raw.q : undefined
     return { cat, q }
   },
   component: HomePage,
@@ -45,16 +44,14 @@ function HomePage() {
       <HomeHero />
       <section className="mx-auto max-w-[1400px] px-4 pb-32 sm:px-8">
         {services.length === 0 ? (
-          <p className="text-muted-foreground py-16 text-sm">
+          <p className="py-16 text-sm text-muted-foreground">
             아직 추가된 design.md가 없습니다.{" "}
-            <code className="bg-muted px-1.5 py-0.5 font-mono">
-              services/
-            </code>
+            <code className="bg-muted px-1.5 py-0.5 font-mono">services/</code>
             에 .md 파일을 추가해 보세요.
           </p>
         ) : (
           <div className="lg:grid lg:grid-cols-[220px_1fr] lg:gap-10">
-            <aside className="mb-4 lg:mb-0 lg:pt-8 lg:sticky lg:top-14 lg:max-h-[calc(100svh-3.5rem)] lg:self-start lg:overflow-y-auto">
+            <aside className="mb-4 lg:sticky lg:top-14 lg:mb-0 lg:max-h-[calc(100svh-3.5rem)] lg:self-start lg:overflow-y-auto lg:pt-8">
               <CategorySidebar
                 totalCount={filter.totalCount}
                 counts={filter.counts}
@@ -74,7 +71,7 @@ function HomePage() {
 
               <div>
                 {filter.filtered.length === 0 ? (
-                  <p className="text-muted-foreground py-12 text-sm">
+                  <p className="py-12 text-sm text-muted-foreground">
                     일치하는 design.md가 없습니다.
                   </p>
                 ) : (

--- a/src/routes/llms[.]txt.ts
+++ b/src/routes/llms[.]txt.ts
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/llms.txt")({
             siteUrl: siteUrlFromRequest(SITE_URL, request),
             services: getAllServices(),
           }),
-          { headers: TEXT_HEADERS },
+          { headers: TEXT_HEADERS }
         )
       },
     },

--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/robots.txt")({
       GET: ({ request }) => {
         return new Response(
           buildRobotsTxt(siteUrlFromRequest(SITE_URL, request)),
-          { headers: TEXT_HEADERS },
+          { headers: TEXT_HEADERS }
         )
       },
     },

--- a/src/routes/rss[.]xml.ts
+++ b/src/routes/rss[.]xml.ts
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/rss.xml")({
             siteUrl: siteUrlFromRequest(SITE_URL, request),
             services: getAllServices(),
           }),
-          { headers: RSS_HEADERS },
+          { headers: RSS_HEADERS }
         )
       },
     },

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -10,10 +10,7 @@ import {
 } from "./-components/detail-tabs"
 import { InlineCopyButton } from "./-components/inline-copy-button"
 import { OpenRawButton } from "./-components/open-raw-button"
-import {
-  PreviewFrame,
-  PreviewUnavailable,
-} from "./-components/preview-frame"
+import { PreviewFrame, PreviewUnavailable } from "./-components/preview-frame"
 import { PreviewThemeToggle } from "./-components/preview-theme-toggle"
 import { RawDesignMd } from "./-components/raw-design-md"
 import { ServiceMeta } from "./-components/service-meta"
@@ -163,7 +160,8 @@ export function ServiceDetailLayout({
   const t = doc.tokens
   const hasTokens =
     !!t &&
-    t.colors.length + t.typography.length + t.spacing.length + t.radius.length > 0
+    t.colors.length + t.typography.length + t.spacing.length + t.radius.length >
+      0
   // Serialize the FULL sidecar (not just the signature cards) so a copy hands AI
   // prompts / Tailwind themes every token. Memoized on the stable doc.tokens ref
   // so it stringifies once, not on every tab switch or preview theme toggle.
@@ -175,10 +173,10 @@ export function ServiceDetailLayout({
         <ServiceMeta frontmatter={doc.frontmatter} tagline={doc.tagline} />
       </div>
 
-      <aside className="md:sticky md:top-24 md:col-start-2 md:row-start-1 md:row-span-2 md:max-h-[calc(100svh-6rem)] md:self-start md:overflow-y-auto">
+      <aside className="md:sticky md:top-24 md:col-start-2 md:row-span-2 md:row-start-1 md:max-h-[calc(100svh-6rem)] md:self-start md:overflow-y-auto">
         <p className="text-meta-caps mb-4">
           {primaryAction.mark}{" "}
-          <span className="text-brand font-extrabold">
+          <span className="font-extrabold text-brand">
             {primaryAction.emphasis}
           </span>{" "}
           {primaryAction.suffix}
@@ -251,10 +249,7 @@ export function ServiceDetailLayout({
 
           <DetailTabsPanel value="preview">
             {previewAvailable ? (
-              <PreviewFrame
-                slug={doc.frontmatter.slug}
-                theme={previewTheme}
-              />
+              <PreviewFrame slug={doc.frontmatter.slug} theme={previewTheme} />
             ) : (
               <PreviewUnavailable />
             )}

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -67,19 +67,21 @@ export function CopyButton({ raw }: Props) {
           <CopyIcon
             className={cn(
               "absolute size-4 transition-all duration-200",
-              copied ? "scale-0 opacity-0" : "scale-100 opacity-100",
+              copied ? "scale-0 opacity-0" : "scale-100 opacity-100"
             )}
           />
           <CheckIcon
             className={cn(
               "absolute size-4 transition-all duration-200",
-              copied ? "scale-100 opacity-100" : "scale-0 opacity-0",
+              copied ? "scale-100 opacity-100" : "scale-0 opacity-0"
             )}
           />
         </span>
         <span>{copied ? "Copied" : "design.md 전체 복사"}</span>
       </span>
-      <span aria-hidden className="text-base">→</span>
+      <span aria-hidden className="text-base">
+        →
+      </span>
     </Button>
   )
 }

--- a/src/routes/services/-components/detail-tabs.tsx
+++ b/src/routes/services/-components/detail-tabs.tsx
@@ -16,8 +16,8 @@ export function DetailTabsList({
     <TabsPrimitive.List
       data-slot="detail-tabs-list"
       className={cn(
-        "border-rule-strong inline-flex items-stretch border",
-        className,
+        "inline-flex items-stretch border border-rule-strong",
+        className
       )}
       {...props}
     />
@@ -34,14 +34,14 @@ export function DetailTabsTab({
       className={cn(
         "cursor-pointer px-5 py-2.5 text-xs font-semibold tracking-[0.14em] uppercase",
         "text-muted-foreground transition-colors",
-        "border-rule-strong border-l first:border-l-0",
+        "border-l border-rule-strong first:border-l-0",
         "hover:text-foreground",
         // base-ui Tabs marks the active tab with aria-selected="true" and a
         // data-active attribute. We match aria-selected since it's the W3C
         // standard and Tailwind has a first-class `aria-selected:` variant.
         "aria-selected:bg-foreground aria-selected:text-background",
-        "focus-visible:relative focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        className,
+        "focus-visible:relative focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+        className
       )}
       {...props}
     />
@@ -59,7 +59,7 @@ export function DetailTabsPanel({
       keepMounted={keepMounted}
       className={cn(
         "mt-8 focus-visible:outline-none data-[hidden]:hidden",
-        className,
+        className
       )}
       {...props}
     />

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -70,10 +70,10 @@ export function InlineCopyButton({
       onClick={onCopy}
       aria-label={`Copy ${filename}`}
       className={cn(
-        "border-border bg-background/80 inline-flex h-8 items-center gap-2 border px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors",
+        "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors",
         "hover:bg-foreground hover:text-background",
         copied && "bg-foreground text-background",
-        className,
+        className
       )}
     >
       {copied ? (

--- a/src/routes/services/-components/open-raw-button.tsx
+++ b/src/routes/services/-components/open-raw-button.tsx
@@ -32,14 +32,16 @@ export function OpenRawButton({ slug }: Props) {
       rel="noopener noreferrer"
       className={cn(
         buttonVariants({ variant: "outline", size: "lg" }),
-        "mt-3 w-full justify-between tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]",
+        "mt-3 w-full justify-between tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]"
       )}
     >
       <span className="inline-flex items-center gap-2.5">
         <ExternalLinkIcon className="size-4" />
         <span>llms.txt 열기</span>
       </span>
-      <span aria-hidden className="text-base">↗</span>
+      <span aria-hidden className="text-base">
+        ↗
+      </span>
     </a>
   )
 }

--- a/src/routes/services/-components/preview-theme-toggle.tsx
+++ b/src/routes/services/-components/preview-theme-toggle.tsx
@@ -50,7 +50,7 @@ export function PreviewThemeToggle({ theme, onChange, className }: Props) {
       aria-label="Preview theme"
       className={cn(
         "inline-flex items-center border border-border bg-background/80 backdrop-blur",
-        className,
+        className
       )}
     >
       <button
@@ -62,7 +62,7 @@ export function PreviewThemeToggle({ theme, onChange, className }: Props) {
           "flex size-8 items-center justify-center transition-colors",
           theme === "light"
             ? "bg-foreground text-background"
-            : "text-muted-foreground hover:text-foreground",
+            : "text-muted-foreground hover:text-foreground"
         )}
       >
         <SunIcon className="size-4" />
@@ -76,7 +76,7 @@ export function PreviewThemeToggle({ theme, onChange, className }: Props) {
           "flex size-8 items-center justify-center transition-colors",
           theme === "dark"
             ? "bg-foreground text-background"
-            : "text-muted-foreground hover:text-foreground",
+            : "text-muted-foreground hover:text-foreground"
         )}
       >
         <MoonIcon className="size-4" />

--- a/src/routes/services/-components/raw-design-md.tsx
+++ b/src/routes/services/-components/raw-design-md.tsx
@@ -8,21 +8,18 @@ export function RawDesignMd({ shikiHtml, filename, raw }: Props) {
   const lineCount = raw.split("\n").length
 
   return (
-    <figure
-      className="border"
-      style={{ borderColor: "var(--rule-strong)" }}
-    >
+    <figure className="border" style={{ borderColor: "var(--rule-strong)" }}>
       <header
         className="flex items-center justify-between gap-3 border-b px-4 py-3"
         style={{ borderColor: "var(--rule-strong)" }}
       >
         <div className="flex min-w-0 items-center gap-3">
           <span className="text-meta-caps">Source</span>
-          <span className="text-foreground truncate font-mono text-xs">
+          <span className="truncate font-mono text-xs text-foreground">
             {filename}
           </span>
         </div>
-        <span className="text-meta-caps tabular-nums shrink-0">
+        <span className="text-meta-caps shrink-0 tabular-nums">
           {lineCount} lines
         </span>
       </header>

--- a/src/routes/services/-components/service-meta-bar.test.tsx
+++ b/src/routes/services/-components/service-meta-bar.test.tsx
@@ -10,7 +10,7 @@ afterEach(() => {
 })
 
 function frontmatter(
-  overrides: Partial<ServiceFrontmatter> = {},
+  overrides: Partial<ServiceFrontmatter> = {}
 ): ServiceFrontmatter {
   return {
     name: "지마켓",
@@ -40,7 +40,7 @@ describe("ServiceMetaBar", () => {
     render(<ServiceMetaBar frontmatter={frontmatter()} />)
 
     expect(screen.getByRole("img").getAttribute("src")).toContain(
-      "hits.sh/getdesign.kr/gmarket.svg",
+      "hits.sh/getdesign.kr/gmarket.svg"
     )
     expect(screen.getByText(/UPDATED · 2026-05-14/)).toBeTruthy()
   })

--- a/src/routes/services/-components/service-meta-bar.tsx
+++ b/src/routes/services/-components/service-meta-bar.tsx
@@ -15,11 +15,13 @@ export function ServiceMetaBar({
     <div className="text-meta-caps flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
       <span>CATALOG</span>
       <span aria-hidden>/</span>
-      <span className="text-brand font-bold">{meta.koIndex}.</span>
+      <span className="font-bold text-brand">{meta.koIndex}.</span>
       <span>{meta.label.toUpperCase()}</span>
       <span className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums">
         <ViewCountBadge slug={frontmatter.slug} />
-        {frontmatter.created_at && <span>ADDED · {frontmatter.created_at}</span>}
+        {frontmatter.created_at && (
+          <span>ADDED · {frontmatter.created_at}</span>
+        )}
         {frontmatter.last_updated && (
           <span>UPDATED · {frontmatter.last_updated}</span>
         )}

--- a/src/routes/services/-components/service-meta.test.tsx
+++ b/src/routes/services/-components/service-meta.test.tsx
@@ -23,7 +23,7 @@ describe("ServiceMeta", () => {
       <ServiceMeta
         frontmatter={{ ...baseFm, created_at: "2026-05-11" }}
         tagline="…"
-      />,
+      />
     )
     expect(screen.getByText(/ADDED · 2026-05-11/)).toBeTruthy()
     expect(screen.getByText(/UPDATED · 2026-05-28/)).toBeTruthy()
@@ -38,7 +38,7 @@ describe("ServiceMeta", () => {
           created_at: "2026-05-15",
         }}
         tagline="…"
-      />,
+      />
     )
     expect(screen.getByText(/ADDED · 2026-05-15/)).toBeTruthy()
     expect(screen.getByText(/UPDATED · 2026-05-15/)).toBeTruthy()

--- a/src/routes/services/-components/service-meta.tsx
+++ b/src/routes/services/-components/service-meta.tsx
@@ -34,7 +34,7 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
           className="text-3xl"
         />
         <h1
-          className="text-display text-5xl font-black leading-[1.0] tracking-tighter sm:text-6xl lg:text-7xl"
+          className="text-display text-5xl leading-[1.0] font-black tracking-tighter sm:text-6xl lg:text-7xl"
           style={{ letterSpacing: "-0.06em" }}
         >
           {frontmatter.name}
@@ -42,9 +42,9 @@ export function ServiceMeta({ frontmatter, tagline }: Props) {
       </div>
 
       {frontmatter.design_system_name && (
-        <p className="text-meta-caps text-muted-foreground mt-4">
+        <p className="text-meta-caps mt-4 text-muted-foreground">
           Design system ·{" "}
-          <span className="text-foreground font-bold">
+          <span className="font-bold text-foreground">
             {frontmatter.design_system_name}
           </span>
         </p>

--- a/src/routes/services/-components/token-badge.tsx
+++ b/src/routes/services/-components/token-badge.tsx
@@ -16,9 +16,7 @@ export function TokenBadge({ tokens }: Props) {
       >
         {formatTokens(tokens)}
       </span>
-      <span className="text-meta-caps mt-1 inline-block">
-        TOKENS
-      </span>
+      <span className="text-meta-caps mt-1 inline-block">TOKENS</span>
     </div>
   )
 }

--- a/src/routes/services/-components/token-card-section.tsx
+++ b/src/routes/services/-components/token-card-section.tsx
@@ -46,14 +46,16 @@ export function TokenCardSection({ tokens }: { tokens?: ServiceTokens }) {
   return (
     <section aria-label="Design tokens">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-        <h2 className="text-meta-caps text-foreground font-bold">Design Tokens</h2>
+        <h2 className="text-meta-caps font-bold text-foreground">
+          Design Tokens
+        </h2>
         <p className="text-meta-caps text-muted-foreground">
           {counts
             .filter(([n]) => n > 0)
             .map(([n, label], i) => (
               <span key={label}>
                 {i > 0 && <span className="opacity-40"> · </span>}
-                <span className="text-foreground font-bold">{n}</span> {label}
+                <span className="font-bold text-foreground">{n}</span> {label}
               </span>
             ))}
         </p>
@@ -88,7 +90,7 @@ function MoreDetails({
   return (
     <details className="group/disc mt-5">
       <summary
-        className="text-meta-caps text-foreground hover:bg-ghost flex w-fit cursor-pointer list-none items-center gap-2 border px-3.5 py-2.5 transition-colors [&::-webkit-details-marker]:hidden"
+        className="text-meta-caps flex w-fit cursor-pointer list-none items-center gap-2 border px-3.5 py-2.5 text-foreground transition-colors hover:bg-ghost [&::-webkit-details-marker]:hidden"
         style={{ borderColor: "var(--rule-strong)" }}
       >
         <svg
@@ -154,7 +156,9 @@ function ColorBlock({ colors }: { colors: Array<ColorToken> }) {
   return (
     <div className="mt-8">
       <SubLabel>Colors</SubLabel>
-      <div className="mt-4 space-y-6">{visibleGroups.map(renderColorGroup)}</div>
+      <div className="mt-4 space-y-6">
+        {visibleGroups.map(renderColorGroup)}
+      </div>
       {hidden.length > 0 && (
         <MoreDetails count={hidden.length} label="colors">
           <div className="space-y-6">{hiddenGroups.map(renderColorGroup)}</div>
@@ -164,11 +168,16 @@ function ColorBlock({ colors }: { colors: Array<ColorToken> }) {
   )
 }
 
-function renderColorGroup([group, items]: [string, Array<ColorToken>]): ReactNode {
+function renderColorGroup([group, items]: [
+  string,
+  Array<ColorToken>,
+]): ReactNode {
   return (
     <div key={group || "_"}>
       {group && (
-        <p className="text-muted-foreground mb-2 text-xs font-medium">{group}</p>
+        <p className="mb-2 text-xs font-medium text-muted-foreground">
+          {group}
+        </p>
       )}
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
         {items.map((c) => (
@@ -188,14 +197,14 @@ function SwatchCard({ token }: { token: ColorToken }) {
         aria-hidden
       />
       <div className="px-2.5 py-2">
-        <p className="text-foreground text-[13px] leading-tight font-bold">
+        <p className="text-[13px] leading-tight font-bold text-foreground">
           {token.name}
         </p>
-        <p className="text-muted-foreground mt-1 font-mono text-[10px] break-all">
+        <p className="mt-1 font-mono text-[10px] break-all text-muted-foreground">
           {token.value}
         </p>
         {token.note && (
-          <p className="text-muted-foreground mt-1.5 text-[11px] leading-snug">
+          <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
             {token.note}
           </p>
         )}
@@ -237,13 +246,15 @@ function TypeRow({ token }: { token: TypeToken }) {
       className="grid grid-cols-[minmax(0,9rem)_1fr] items-baseline gap-4 border-b py-3 last:border-b-0 sm:gap-8"
       style={{ borderColor: "var(--rule-strong)" }}
     >
-      <div className="text-muted-foreground font-mono text-[11px] leading-tight">
-        <span className="text-foreground block font-bold">{token.name}</span>
+      <div className="font-mono text-[11px] leading-tight text-muted-foreground">
+        <span className="block font-bold text-foreground">{token.name}</span>
         {meta}
-        {token.note && <span className="mt-0.5 block opacity-70">{token.note}</span>}
+        {token.note && (
+          <span className="mt-0.5 block opacity-70">{token.note}</span>
+        )}
       </div>
       <p
-        className="text-foreground m-0 truncate"
+        className="m-0 truncate text-foreground"
         style={{
           fontSize: token.size,
           fontWeight: token.weight,
@@ -302,15 +313,15 @@ function ScaleBlock({
 function SpacingRow({ token, max }: { token: SpacingToken; max: number }) {
   return (
     <div className="flex items-center gap-3">
-      <span className="text-muted-foreground w-16 shrink-0 font-mono text-[11px]">
+      <span className="w-16 shrink-0 font-mono text-[11px] text-muted-foreground">
         {token.name}
       </span>
       <span
-        className="bg-foreground/80 h-2.5 shrink-0"
+        className="h-2.5 shrink-0 bg-foreground/80"
         style={{ width: barWidth(token.px, max) }}
         aria-hidden
       />
-      <span className="text-muted-foreground font-mono text-[11px]">
+      <span className="font-mono text-[11px] text-muted-foreground">
         {token.value}
       </span>
     </div>
@@ -321,7 +332,7 @@ function RadiusChip({ token }: { token: RadiusToken }) {
   return (
     <div className="flex flex-col items-center gap-2">
       <div
-        className="bg-ghost h-14 w-14 border"
+        className="h-14 w-14 border bg-ghost"
         style={{
           borderRadius: token.px != null ? `${token.px}px` : token.value,
           borderColor: "var(--rule-strong)",
@@ -329,8 +340,10 @@ function RadiusChip({ token }: { token: RadiusToken }) {
         aria-hidden
       />
       <div className="text-center leading-tight">
-        <p className="text-foreground font-mono text-[11px]">{token.name}</p>
-        <p className="text-muted-foreground font-mono text-[10px]">{token.value}</p>
+        <p className="font-mono text-[11px] text-foreground">{token.name}</p>
+        <p className="font-mono text-[10px] text-muted-foreground">
+          {token.value}
+        </p>
       </div>
     </div>
   )
@@ -347,7 +360,7 @@ function barWidth(px: number | null, max: number): string {
 // order matches the document order of the source YAML.
 function groupByOrder<T>(
   items: Array<T>,
-  key: (t: T) => string,
+  key: (t: T) => string
 ): Array<[string, Array<T>]> {
   const map = new Map<string, Array<T>>()
   for (const item of items) {

--- a/src/routes/services/-components/view-count-badge.test.tsx
+++ b/src/routes/services/-components/view-count-badge.test.tsx
@@ -20,7 +20,7 @@ describe("ViewCountBadge", () => {
     render(<ViewCountBadge slug="gmarket" />)
     const img = screen.getByRole("img")
     expect(img.getAttribute("src")).toContain(
-      "https://hits.sh/getdesign.kr/gmarket.svg",
+      "https://hits.sh/getdesign.kr/gmarket.svg"
     )
   })
 

--- a/src/routes/services/-service-detail-layout.test.tsx
+++ b/src/routes/services/-service-detail-layout.test.tsx
@@ -80,7 +80,7 @@ describe("ServiceDetailLayout", () => {
         previewTheme="dark"
         searchTab="preview"
         shikiHtml="<pre><code># Toss</code></pre>"
-      />,
+      />
     )
 
     const copyAction = screen.getByRole("button", {
@@ -90,7 +90,7 @@ describe("ServiceDetailLayout", () => {
 
     expect(
       copyAction.compareDocumentPosition(previewTab) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
   })
 })

--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/sitemap.xml")({
             siteUrl: siteUrlFromRequest(SITE_URL, request),
             services: getAllServices(),
           }),
-          { headers: XML_HEADERS },
+          { headers: XML_HEADERS }
         )
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,7 +101,8 @@ function previewSlugsPlugin(): Plugin {
       root = config.root
     },
     resolveId(id) {
-      if (id === PREVIEW_SLUGS_MODULE_ID) return RESOLVED_PREVIEW_SLUGS_MODULE_ID
+      if (id === PREVIEW_SLUGS_MODULE_ID)
+        return RESOLVED_PREVIEW_SLUGS_MODULE_ID
       return null
     },
     load(id) {


### PR DESCRIPTION
## 변경 요약

CI가 prettier 포맷을 강제하지 않아 누적된 **포맷 드리프트(78개 파일)를 일괄 정리**하고, 재발 방지 게이트와 line-ending 정책을 추가. (dependabot 배치 #148 작업 중 `prettier --check` 96개 실패를 발견 → CRLF 노이즈 제외 시 실제 78개 드리프트로 확인된 건의 후속.)

## 커밋 구성 (리뷰 편의를 위해 분리)

**1. `style:` — 포맷 베이스라인 (자동 생성 diff)**
- `pnpm format`(prettier 3.8.4 + prettier-plugin-tailwindcss 0.8)으로 78개 파일 재포맷
- **기능 변경 0** — prettier 자동 포맷 전용 (Tailwind 클래스 정렬 + 80자 줄바꿈 등)
- 생성 파일 `src/routeTree.gen.ts`는 `.prettierignore`에 추가 (빌드 재생성 시 포맷 깨짐 방지)

**2. `chore(ci):` — 재발 방지 인프라 (핵심 검토 대상)**
- `ci.yml`에 `Format check`(`pnpm format:check`) 스텝 추가 → 향후 포맷 드리프트 차단
- `package.json`에 `format:check` 스크립트
- `.gitattributes`로 전체 텍스트 **LF 통일** — Windows working copy의 CRLF가 `endOfLine: lf` prettier를 오탐시키던 근본 원인 해결

## 변경 종류

- 포맷/툴링 유지보수 — 카탈로그/UI 분류엔 해당 없음

## 일반 체크

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm format:check` 통과
- [x] `pnpm test`(26파일 / 242) · `pnpm build` 통과 — `style:` 커밋이 기능을 깨지 않음 확인
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수
