### PR TITLE
feat: 카탈로그 카테고리를 한글 라벨로 표시

### DIFF
--- a/src/lib/category-style.ts
+++ b/src/lib/category-style.ts
@@ -1,7 +1,10 @@
 import type { Category } from "./content-types"
 
 export interface CategoryStyle {
-  /** English label for accessibility / search keywords. */
+  /**
+   * English label. Retained for tests and a future English locale;
+   * not currently rendered in the UI (display uses `koLabel`).
+   */
   label: string
   /** Korean display label, e.g. "결제". */
   koLabel: string

--- a/src/routes/-home/components/category-sidebar.tsx
+++ b/src/routes/-home/components/category-sidebar.tsx
@@ -79,7 +79,7 @@ export function CategorySidebar({
   const items = counts.map(({ category, count }) => ({
     category,
     count,
-    label: getCategoryStyle(category).label,
+    label: getCategoryStyle(category).koLabel,
   }))
 
   return (
@@ -90,7 +90,7 @@ export function CategorySidebar({
         <ul>
           <li>
             <SidebarItem
-              label="All"
+              label="전체"
               count={totalCount}
               active={activeCategory === undefined}
               onClick={() => onSelect(undefined)}
@@ -115,7 +115,7 @@ export function CategorySidebar({
         className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 sm:-mx-8 sm:px-8 lg:hidden"
       >
         <CategoryChip
-          label="All"
+          label="전체"
           count={totalCount}
           active={activeCategory === undefined}
           onClick={() => onSelect(undefined)}

--- a/src/routes/-home/components/category-sidebar.tsx
+++ b/src/routes/-home/components/category-sidebar.tsx
@@ -3,6 +3,8 @@ import type { CategoryCount } from "../hooks/use-filtered-services"
 import { getCategoryStyle } from "@/lib/category-style"
 import { cn } from "@/lib/utils"
 
+const ALL_LABEL = "전체"
+
 interface Props {
   totalCount: number
   counts: Array<CategoryCount>
@@ -85,12 +87,12 @@ export function CategorySidebar({
   return (
     <>
       {/* Desktop: vertical sidebar */}
-      <nav aria-label="Categories" className="hidden lg:block">
+      <nav aria-label="카테고리" className="hidden lg:block">
         <h2 className="text-meta-caps mb-3 px-3">Find Designs</h2>
         <ul>
           <li>
             <SidebarItem
-              label="전체"
+              label={ALL_LABEL}
               count={totalCount}
               active={activeCategory === undefined}
               onClick={() => onSelect(undefined)}
@@ -111,11 +113,11 @@ export function CategorySidebar({
 
       {/* Mobile: horizontal scrollable chip row */}
       <nav
-        aria-label="Categories"
+        aria-label="카테고리"
         className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 sm:-mx-8 sm:px-8 lg:hidden"
       >
         <CategoryChip
-          label="전체"
+          label={ALL_LABEL}
           count={totalCount}
           active={activeCategory === undefined}
           onClick={() => onSelect(undefined)}

--- a/src/routes/services/-components/service-meta-bar.test.tsx
+++ b/src/routes/services/-components/service-meta-bar.test.tsx
@@ -30,7 +30,7 @@ describe("ServiceMetaBar", () => {
     render(<ServiceMetaBar frontmatter={frontmatter()} />)
 
     expect(screen.getByText("CATALOG")).toBeTruthy()
-    expect(screen.getByText("ETC")).toBeTruthy()
+    expect(screen.getByText("기타")).toBeTruthy()
     expect(screen.getByText(/UPDATED · 2026-05-14/)).toBeTruthy()
     expect(screen.queryByRole("img")).toBeNull()
   })

--- a/src/routes/services/-components/service-meta-bar.tsx
+++ b/src/routes/services/-components/service-meta-bar.tsx
@@ -16,7 +16,7 @@ export function ServiceMetaBar({
       <span>CATALOG</span>
       <span aria-hidden>/</span>
       <span className="font-bold text-brand">{meta.koIndex}.</span>
-      <span>{meta.label.toUpperCase()}</span>
+      <span>{meta.koLabel}</span>
       <span className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums">
         <ViewCountBadge slug={frontmatter.slug} />
         {frontmatter.created_at && (

--- a/src/routes/services/-components/service-meta-bar.tsx
+++ b/src/routes/services/-components/service-meta-bar.tsx
@@ -15,8 +15,10 @@ export function ServiceMetaBar({
     <div className="text-meta-caps flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
       <span>CATALOG</span>
       <span aria-hidden>/</span>
-      <span className="font-bold text-brand">{meta.koIndex}.</span>
-      <span>{meta.koLabel}</span>
+      <span className="inline-flex gap-1">
+        <span className="font-bold text-brand">{meta.koIndex}.</span>
+        <span>{meta.koLabel}</span>
+      </span>
       <span className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums">
         <ViewCountBadge slug={frontmatter.slug} />
         {frontmatter.created_at && (


### PR DESCRIPTION
홈 카테고리 필터와 서비스 상세 메타 바에서 영어 label 대신
category-style의 koLabel을 사용하도록 변경. 필터의 "All"은 "전체"로
표기. 내부 slug(finance 등)와 URL 동작은 그대로 유지.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VjEGPTTP2k4KEtwnq8dUg