### PR TITLE
fix(detail): 상세 탭 컨트롤 좁은 화면 오버플로우 → 콘텐츠 폭 줄바꿈

### DIFF
--- a/src/routes/services/-components/detail-tabs.tsx
+++ b/src/routes/services/-components/detail-tabs.tsx
@@ -16,7 +16,13 @@ export function DetailTabsList({
     <TabsPrimitive.List
       data-slot="detail-tabs-list"
       className={cn(
-        "inline-flex items-stretch border border-rule-strong",
+        // flex-wrap so tabs flow to the next line on narrow widths instead of
+        // overflowing. The outer border is intentionally absent — each tab
+        // carries its own border (see DetailTabsTab) so the group hugs its
+        // content (no full-width stretching box) when wrapped. The tabs'
+        // -ml-px / -mt-px margins collapse adjacent borders in both axes, so a
+        // wrapped group still reads as one connected block with no row gap.
+        "flex flex-wrap items-stretch",
         className
       )}
       {...props}
@@ -33,8 +39,18 @@ export function DetailTabsTab({
       data-slot="detail-tabs-tab"
       className={cn(
         "cursor-pointer px-5 py-2.5 text-xs font-semibold tracking-[0.14em] uppercase",
+        // Taller tap targets in the narrow / stacked (column) mode — i.e.
+        // mobile — to meet the ~44px touch-target guideline. Desktop keeps the
+        // compact py-2.5.
+        "@max-sm:py-3.5",
         "text-muted-foreground transition-colors",
-        "border-l border-rule-strong first:border-l-0",
+        // Each tab carries a full border; -ml-px and -mt-px overlap adjacent
+        // borders (horizontally within a row, vertically across wrapped rows)
+        // into single 1px seams so the group reads as one connected control.
+        // Margins are uniform (no first:ml-0) so every wrapped row's leading
+        // tab lands at the same x — aligned with each other and with the body
+        // text — instead of the first row jutting 1px inward.
+        "-mt-px -ml-px border border-rule-strong",
         "hover:text-foreground",
         // base-ui Tabs marks the active tab with aria-selected="true" and a
         // data-active attribute. We match aria-selected since it's the W3C

--- a/src/routes/services/-components/detail-tabs.tsx
+++ b/src/routes/services/-components/detail-tabs.tsx
@@ -22,7 +22,10 @@ export function DetailTabsList({
         // content (no full-width stretching box) when wrapped. The tabs'
         // -ml-px / -mt-px margins collapse adjacent borders in both axes, so a
         // wrapped group still reads as one connected block with no row gap.
-        "flex flex-wrap items-stretch",
+        // pt-px / pl-px offset those negative margins so the group's outer edge
+        // stays on the column grid (body-text alignment) instead of the whole
+        // control drifting 1px up/left.
+        "flex flex-wrap items-stretch pt-px pl-px",
         className
       )}
       {...props}
@@ -48,8 +51,8 @@ export function DetailTabsTab({
         // borders (horizontally within a row, vertically across wrapped rows)
         // into single 1px seams so the group reads as one connected control.
         // Margins are uniform (no first:ml-0) so every wrapped row's leading
-        // tab lands at the same x — aligned with each other and with the body
-        // text — instead of the first row jutting 1px inward.
+        // tab lands at the same x; DetailTabsList's pt-px/pl-px then offsets
+        // them back onto the column grid so the group aligns with the body text.
         "-mt-px -ml-px border border-rule-strong",
         "hover:text-foreground",
         // base-ui Tabs marks the active tab with aria-selected="true" and a

--- a/src/routes/services/-components/detail-tabs.tsx
+++ b/src/routes/services/-components/detail-tabs.tsx
@@ -16,15 +16,13 @@ export function DetailTabsList({
     <TabsPrimitive.List
       data-slot="detail-tabs-list"
       className={cn(
-        // flex-wrap so tabs flow to the next line on narrow widths instead of
-        // overflowing. The outer border is intentionally absent — each tab
-        // carries its own border (see DetailTabsTab) so the group hugs its
-        // content (no full-width stretching box) when wrapped. The tabs'
-        // -ml-px / -mt-px margins collapse adjacent borders in both axes, so a
-        // wrapped group still reads as one connected block with no row gap.
-        // pt-px / pl-px offset those negative margins so the group's outer edge
-        // stays on the column grid (body-text alignment) instead of the whole
-        // control drifting 1px up/left.
+        // Wraps onto multiple rows on narrow widths (flex-wrap) instead of
+        // overflowing. No outer border — each tab carries its own (see
+        // DetailTabsTab), so the group hugs its content instead of stretching
+        // full-width, and the tabs' uniform -ml-px/-mt-px collapse adjacent
+        // borders into shared 1px seams (one connected block, even wrapped).
+        // pt-px/pl-px offset those negative margins so the group's outer edge
+        // stays aligned to the column grid (body text).
         "flex flex-wrap items-stretch pt-px pl-px",
         className
       )}
@@ -47,12 +45,8 @@ export function DetailTabsTab({
         // compact py-2.5.
         "@max-sm:py-3.5",
         "text-muted-foreground transition-colors",
-        // Each tab carries a full border; -ml-px and -mt-px overlap adjacent
-        // borders (horizontally within a row, vertically across wrapped rows)
-        // into single 1px seams so the group reads as one connected control.
-        // Margins are uniform (no first:ml-0) so every wrapped row's leading
-        // tab lands at the same x; DetailTabsList's pt-px/pl-px then offsets
-        // them back onto the column grid so the group aligns with the body text.
+        // Full border per tab; uniform -ml-px/-mt-px collapses adjacent borders
+        // into 1px seams (see DetailTabsList for the wrap / alignment model).
         "-mt-px -ml-px border border-rule-strong",
         "hover:text-foreground",
         // base-ui Tabs marks the active tab with aria-selected="true" and a


### PR DESCRIPTION
## 변경 요약

서비스 상세 페이지의 탭 컨트롤(Live Preview · Tokens · DESIGN.md)이 모바일·좁은 컬럼 폭에서 가로로 **오버플로우**되던 문제를 수정합니다. 이제 탭이 다음 줄로 **줄바꿈**되며, 그룹은 **콘텐츠 폭만 점유**(레이아웃 전체 폭 미점유)하고, 한 줄일 때는 기존의 단일 연결 컨트롤 외형을 유지합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

해당 없음 — 카탈로그 콘텐츠가 아닌 UI 수정입니다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- 없음 -->

---

## 구현 상세

대상: `src/routes/services/-components/detail-tabs.tsx` (단일 파일, Tailwind className만 변경)

- **`DetailTabsList`**: `inline-flex` + 외곽 `border` → `flex flex-wrap`. 외곽 박스를 제거해, 줄바꿈된 flex 컨테이너가 가용 폭까지 늘어나도 **보이지 않으므로** 시각적으로 콘텐츠를 hug합니다(요구사항: 전체 폭 미점유).
- **`DetailTabsTab`**: 탭별 `border` + `-ml-px`/`-mt-px` 양방향 테두리 겹침 → 한 줄일 땐 이음매 없는 단일 컨트롤, 줄바꿈 시에도 행이 테두리를 공유하는 연결 블록으로 보입니다.
- **`first:ml-0` 제거(균일 음수 마진)**: 줄바꿈된 모든 행의 첫 탭을 동일 x에 정렬(이전엔 둘째 행이 1px 좌측 돌출). 본문 텍스트 정렬선과도 일치.
- **`@max-sm:py-3.5`**: 좁은/스택 모드(모바일)에서만 탭 높이를 ~44px로 키워 터치 타깃 가이드라인 충족. 데스크톱은 컴팩트 `py-2.5` 유지.

## 검증

라이브 dev 서버에서 폭별·테마별 확인:

| 폭 | 결과 |
|---|---|
| 1280px | 단일 연결 행(기존 외형 유지), 높이 37.8px, 콘텐츠 hug, 오버플로우 없음 |
| 768 / 375px | 2행 줄바꿈, 행 정렬(돌출 0), 모바일 높이 45.8px(터치 타깃), 오버플로우 없음 |

- 독립 UI/UX 리뷰 1회 진행 → 지적된 P2 2건(모바일 터치 타깃, 1px 좌측 돌출) 모두 반영.
- `pnpm typecheck` · `pnpm lint` · `pnpm build` · `prettier --check` 통과.
