### PR TITLE
feat(home): 메인 Hero에 use-design-md 스킬 설치 안내 추가

### DIFF
--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -82,3 +82,8 @@ export function localLogoPath(url: string | undefined): string | undefined {
 // and is the single source of truth for header link, contribute dialog,
 // issue template / CONTRIBUTING anchors composed at runtime.
 export const GITHUB_REPO_URL = "https://github.com/caesiumy/ko-design-md"
+
+// `use-design-md` consumer skill — the agent-driven counterpart to the catalog's
+// manual copy flow. Surfaced in the homepage hero. Single source of truth so the
+// hero (and any future surface) stays in sync with the published install command.
+export const SKILL_INSTALL_CMD = "npx skills add CaesiumY/ko-design-md"

--- a/src/routes/-home/components/hero.tsx
+++ b/src/routes/-home/components/hero.tsx
@@ -1,3 +1,5 @@
+import { UseSkillHint } from "./use-skill-hint"
+
 export function HomeHero() {
   return (
     <section className="[container-type:inline-size] mx-auto max-w-[1400px] px-8 break-keep">
@@ -35,6 +37,9 @@ export function HomeHero() {
         </strong>
         해 그대로 붙여넣으세요.
       </p>
+
+      {/* Secondary path — apply via the use-design-md coding-agent skill */}
+      <UseSkillHint />
 
       {/* spacer */}
       <div className="pb-16 sm:pb-20" />

--- a/src/routes/-home/components/use-skill-hint.tsx
+++ b/src/routes/-home/components/use-skill-hint.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react"
+
+import { SKILL_INSTALL_CMD } from "@/lib/site-config"
+
+function CopyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  )
+}
+
+// Secondary, agent-driven path shown under the hero lede. The lede sells the
+// manual "click to copy design.md" flow; this hints the automated counterpart —
+// the `use-design-md` skill that applies a catalogued brand to your own project.
+// Kept muted (no vermillion fill) so it never competes with the catalog's primary
+// copy action. The command sits in an input-like box with a small icon-only copy
+// button tucked inside its right edge.
+export function UseSkillHint() {
+  const [copied, setCopied] = useState(false)
+
+  async function onCopy() {
+    try {
+      await navigator.clipboard.writeText(SKILL_INSTALL_CMD)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // Clipboard rejection is rare (denied permission / non-secure context);
+      // fall through silently and leave the button in its idle state.
+    }
+  }
+
+  return (
+    <div
+      className="animate-fade-in-up mt-7 break-keep sm:mt-8"
+      style={{ animationDelay: "220ms" }}
+    >
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        또는 Claude Code·Cursor·Codex 등에서{" "}
+        <code className="font-mono text-[0.9em] font-semibold whitespace-nowrap text-brand">
+          use-design-md
+        </code>{" "}
+        스킬로 카탈로그 디자인을 현재 프로젝트에 바로 적용하세요.
+      </p>
+      <div className="mt-3 flex h-9 w-full max-w-md items-center gap-1 border border-rule-strong bg-muted pr-1 pl-3 transition-colors focus-within:border-foreground/40">
+        <code className="min-w-0 flex-1 [scrollbar-width:none] overflow-x-auto font-mono text-xs whitespace-nowrap sm:text-sm [&::-webkit-scrollbar]:hidden">
+          {SKILL_INSTALL_CMD}
+        </code>
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label="use-design-md 설치 명령 복사"
+          className="inline-flex size-7 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+        >
+          {copied ? (
+            <CheckIcon className="size-3.5" />
+          ) : (
+            <CopyIcon className="size-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/-home/components/use-skill-hint.tsx
+++ b/src/routes/-home/components/use-skill-hint.tsx
@@ -69,7 +69,7 @@ export function UseSkillHint() {
         </code>{" "}
         스킬로 카탈로그 디자인을 현재 프로젝트에 바로 적용하세요.
       </p>
-      <div className="mt-3 flex h-9 w-full max-w-md items-center gap-1 border border-rule-strong bg-muted pr-1 pl-3 transition-colors focus-within:border-foreground/40">
+      <div className="mt-3 flex h-9 w-full max-w-md items-center gap-1 border border-rule-strong bg-muted pr-1 pl-3">
         <code className="min-w-0 flex-1 [scrollbar-width:none] overflow-x-auto font-mono text-xs whitespace-nowrap sm:text-sm [&::-webkit-scrollbar]:hidden">
           {SKILL_INSTALL_CMD}
         </code>
@@ -77,7 +77,7 @@ export function UseSkillHint() {
           type="button"
           onClick={onCopy}
           aria-label="use-design-md 설치 명령 복사"
-          className="inline-flex size-7 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none"
+          className="inline-flex size-7 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:ring-3 focus-visible:ring-ring/30 focus-visible:outline-none"
         >
           {copied ? (
             <CheckIcon className="size-3.5" />

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -70,7 +70,7 @@ export function InlineCopyButton({
       onClick={onCopy}
       aria-label={`Copy ${filename}`}
       className={cn(
-        "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors",
+        "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",
         "hover:bg-foreground hover:text-background",
         copied && "bg-foreground text-background",
         className


### PR DESCRIPTION
## 변경 요약

메인 페이지 Hero 리드 바로 아래에 **use-design-md 스킬 설치 안내**(한 줄 설명 + 복사 가능한 설치 명령)를 추가합니다. 카탈로그 방문자가 수동 복사(`design.md` 전체 복사) 외에 코딩 에이전트에서 자동 적용하는 경로를 발견하게 하는 것이 목적입니다. 더불어 디자인 리뷰에서 발견된 공유 `InlineCopyButton`의 `focus-visible` 접근성 갭을 함께 수정합니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 상세

**커밋 1 — `feat(home)`: Hero 스킬 안내**
- `use-skill-hint.tsx`(신규): 인풋형 박스 + 아이콘 전용 복사 버튼(자체 `focus-visible`). 외부 링크 없는 미니멀 구성.
- `hero.tsx`: 리드 문단과 카탈로그 사이에 렌더.
- `site-config.ts`: `SKILL_INSTALL_CMD` 단일 출처 상수 추가.
- muted 톤으로 1차 액션(카탈로그 vermillion 복사)과 경쟁하지 않게.

**커밋 2 — `fix(a11y)`: 공유 복사 버튼 focus-visible**
- `inline-copy-button.tsx`: raw `<button>`이 키보드 포커스 시 약한 전역 기본값(`* { outline-ring/50 }`)에만 의존하던 것을, shadcn `Button`과 동일한 ring 패턴(`focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30`)으로 보강. 서비스 상세(Tokens/DESIGN.md 탭)의 Copy 버튼에 적용됨.
- `copy-button.tsx`는 shadcn `Button`을 써 이미 `focus-visible`이 적용돼 있어 미변경.

## 리뷰어 노트

- **사이트는 라이트 전용**입니다(`__root.tsx`가 `data-theme=\"light\"` 고정; 다크 토큰은 프리뷰 iframe 전용 스코프). 라이트 렌더만 검증했습니다.
- 검증: 데스크톱/모바일(390·375px) 렌더 + 가로 오버플로우 없음, `pnpm typecheck && lint && build` 통과, vitest **242 passed**, `focus-visible`은 실제 키보드 Tab으로 `:focus-visible` 매칭 + 3px 링(box-shadow)·ring색 테두리 확인.
- 헤드리스 환경 한계로 복사 버튼의 클립보드 동작은 자동 검증 불가(샌드박스). 기존 검증된 패턴과 동일.
- 커밋 2(a11y)는 Hero 기능과 파일이 겹치지 않아 독립적입니다.