### PR TITLE
fix: 리뷰봇 non-blocking 3건 하드닝 (스택: #166 위)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,9 +77,12 @@ jobs:
             echo "::warning::claude-code-action did not execute (workflow-validation skip on a PR editing this workflow, or output rename) — skipping comment verification."
             exit 0
           fi
-          n=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
-                --jq "[.[] | select(.created_at >= \"${{ steps.start.outputs.ts }}\")
-                           | select(.body | startswith(\"## Claude Code Review\"))] | length")
+          # --paginate --slurp: 이 엔드포인트는 오래된 순 정렬이라 코멘트가 100개를
+          # 넘는 장수 PR에서는 방금 게시된 리뷰가 1페이지 밖으로 밀려 오경보가 난다.
+          # --slurp는 페이지들을 배열의 배열로 감싸므로 .[][]로 평탄화해 집계한다.
+          n=$(gh api --paginate --slurp "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
+                --jq "[.[][] | select(.created_at >= \"${{ steps.start.outputs.ts }}\")
+                             | select(.body | startswith(\"## Claude Code Review\"))] | length")
           echo "review comments posted since job start: $n"
           if [ "${n:-0}" -eq 0 ]; then
             echo "::error::Claude review ran but did not post its review comment (silent failure — re-trigger with @claude or re-run this job)."

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "validate:draft": "tsx scripts/validate-draft.ts",
     "validate:catalog": "tsx scripts/validate-draft.ts --services",
     "validate:previews": "tsx scripts/validate-preview.ts",
-    "build": "npm run build:og && vite build",
+    "build": "pnpm run build:og && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint",

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -380,6 +380,30 @@ describe("validatePreviewPair — review hardening", () => {
     expect(rulesOf(attrColor, "warn")).toContain("hex-colors-present")
   })
 
+  it("does not let data-* attributes satisfy attribute checks (hyphen boundary)", () => {
+    // `\bsrc=` also matches `data-src=` (a hyphen is a non-word character), so
+    // a lazy-load attribute must not satisfy the hero-logo block…
+    const lazyOnly = makeInput({
+      expectedLogoSrc: "/logos/demo.png",
+      lightRaw: makeHtml({
+        body: '<main><img data-src="/logos/demo.png" alt=""><h1>데모</h1></main>',
+      }),
+      darkRaw: makeHtml({
+        theme: "dark",
+        body: '<main><img data-src="/logos/demo.png" alt=""><h1>데모</h1></main>',
+      }),
+    })
+    expect(rulesOf(lazyOnly, "block")).toContain("hero-logo-missing")
+
+    // …and a data-style attribute is not a CSS surface.
+    const dataStyle = makeInput({
+      lightRaw: makeHtml({
+        body: '<main><img src="/logos/demo.png" alt=""><i data-style="color:#6157ea">x</i></main>',
+      }),
+    })
+    expect(rulesOf(dataStyle, "warn")).not.toContain("hex-colors-present")
+  })
+
   it("flags styles identical after comment/whitespace normalization", () => {
     const base = ":root { --primary: oklch(0.62 0.18 250); }"
     const input = makeInput({

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -172,8 +172,11 @@ const ACHROMATIC_HEX = new Set(["#fff", "#ffffff", "#000", "#000000"])
 // (bezier's hero copy and stat cards show "#6157ea" as content, mirroring the
 // design.md prose-provenance convention), and ids/anchors must never match.
 function cssSurfaces(html: string): string {
+  // The attribute name must follow whitespace or a quote — a bare \b would
+  // also match hyphenated attributes (`data-style=`), since a hyphen is a
+  // non-word character.
   const attrValues = [
-    ...html.matchAll(/\b(?:style|fill|stroke)=["']([^"']*)["']/gi),
+    ...html.matchAll(/[\s"'](?:style|fill|stroke)=["']([^"']*)["']/gi),
   ]
     .map((m) => m[1])
     .join("\n")
@@ -216,7 +219,9 @@ function hasAttrValue(
   attr: "href" | "src",
   value: string
 ): boolean {
-  return new RegExp(`\\b${attr}=["']${escapeRegExp(value)}["']`).test(html)
+  // `[\s"']` (not \b) so `data-src=` / `data-href=` can never satisfy the
+  // check — a hyphen is a non-word character, so \b matches inside them.
+  return new RegExp(`[\\s"']${attr}=["']${escapeRegExp(value)}["']`).test(html)
 }
 
 // ── design.md helpers ────────────────────────────────────────────────────────
@@ -259,7 +264,7 @@ function checkFile(
   heroSrc: string | undefined,
   issues: Array<ValidationIssue>
 ): void {
-  const theme = html.match(/<html\b[^>]*\bdata-theme=["']([^"']*)["']/)?.[1]
+  const theme = html.match(/<html\b[^>]*\sdata-theme=["']([^"']*)["']/)?.[1]
   if (theme !== expectedTheme) {
     issues.push(
       block(
@@ -269,7 +274,8 @@ function checkFile(
       )
     )
   }
-  const lang = html.match(/<html\b[^>]*\blang=["']([^"']*)["']/)?.[1]
+  // \s (not \b) so `xml:lang=` / `data-lang=` never shadow the real lang.
+  const lang = html.match(/<html\b[^>]*\slang=["']([^"']*)["']/)?.[1]
   if (lang !== expectedLang) {
     issues.push(
       block(
@@ -289,7 +295,7 @@ function checkFile(
     )
   }
   const scriptSrcs = [
-    ...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']*)["'][^>]*>/gi),
+    ...html.matchAll(/<script\b[^>]*\ssrc=["']([^"']*)["'][^>]*>/gi),
   ]
   const iframeTag = scriptSrcs.find((m) => m[1] === IFRAME_JS_SRC)
   if (!iframeTag) {
@@ -445,7 +451,7 @@ export function validatePreviewPair(
       ["light.html", input.lightRaw],
       ["dark.html", input.darkRaw],
     ] as const) {
-      if (!/<img\b[^>]*\bsrc=["']\/logos\//.test(html)) {
+      if (!/<img\b[^>]*\ssrc=["']\/logos\//.test(html)) {
         issues.push(
           warn(
             "logo-img-missing",


### PR DESCRIPTION
## 변경 요약

[#166](https://github.com/CaesiumY/ko-design-md/pull/166) 승인 시 클로드 리뷰봇이 남긴 non-blocking 3건을 처리하는 소형 하드닝 PR입니다. **#166 위에 스택**되어 있습니다 — #166 머지 전에는 이 PR의 diff가 3건 수정만 보이도록 base를 feat 브랜치로 두었고, #166 머지 후 main으로 리베이스·재타겟하겠습니다.

1. **게시 검증 페이지네이션**: `gh api`에 `--paginate --slurp` — 코멘트 100+개 장수 PR에서 방금 게시된 리뷰가 1페이지(오래된 순) 밖으로 밀려 무음-미게시 오경보가 나던 엣지 제거.
2. **속성 정규식 하이픈 경계**: `\bsrc=`가 `data-src=`도 매칭하던 허점 — `[\s"']` 선행 앵커로 교체(hasAttrValue·cssSurfaces + script src·img /logos/·data-theme·lang 4곳 일관 적용). `data-src`가 hero-logo 체크를 거짓 통과시키지 않는 회귀 테스트 추가(TDD).
3. **pnpm-only 표기 정합**: package.json `build`의 `npm run` → `pnpm run` (신설 CLAUDE.md 정책 일치). `pnpm build` 실행 확인 완료.

## 변경 종류
- [x] 사이트 코드/UI (검증 스크립트)
- [x] 문서 아님 — 워크플로우/스크립트

## 일반 체크
- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (테스트 224개, validate:catalog/previews 0 block·warn 무변동)
- [x] DCO 서명 (`git commit -s`)
- [x] CONTRIBUTING.md 가이드라인 준수

> 참고: 이 PR도 claude-code-review.yml을 수정하므로 자동 리뷰 액션은 스스로 스킵하고(보안 검증), 게시-검증 스텝은 execution_file 게이트로 통과합니다.