### PR TITLE
fix(og): deriveTagline이 인라인 코드 백틱을 제거하도록 수정

### DIFF
--- a/src/lib/content-collection.test.ts
+++ b/src/lib/content-collection.test.ts
@@ -68,6 +68,18 @@ describe("deriveTagline", () => {
       "그냥 평범한 본문 한 줄."
     )
   })
+
+  it("strips inline-code backticks so the OG/meta tagline isn't literal markdown", () => {
+    // The tagline is consumed where markdown does NOT render — the OG image
+    // (satori) and the meta description — so `code` must shed its backticks the
+    // same way `**bold**` and `[src:N]` do. Without this, e.g. codeit's OG card
+    // renders the literal text `design.codeit.com` with visible backticks.
+    const body =
+      "\n## Brand\n\n코드잇은 프로그래밍 교육 서비스이며, `design.codeit.com`은 그 공개 디자인 시스템 사이트다.\n"
+    expect(deriveTagline(body)).toBe(
+      "코드잇은 프로그래밍 교육 서비스이며, design.codeit.com은 그 공개 디자인 시스템 사이트다."
+    )
+  })
 })
 
 describe("truncateForMeta", () => {

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -187,6 +187,7 @@ export function deriveTagline(body: string): string {
     return trimmed
       .replace(/\*\*/g, "")
       .replace(/\s*\[src:[^\]]*\]/g, "")
+      .replace(/`/g, "")
       .trim()
   }
   return ""

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -177,6 +177,9 @@ export function normalizeDateField(value: unknown, context = ""): string {
 //   `[src:N]` — Stitch v0.1 citation markers (`삼는다 [src:1][src:6].` →
 //   `삼는다.`). Eats leading whitespace so prose around citations stays
 //   clean; without it, the period would dangle after a stray space.
+//   backticks — inline-code fences. The tagline is consumed where markdown does
+//   NOT render (the OG image via satori, the meta description), so a leftover
+//   backtick shows up as a literal character on the social card.
 export function deriveTagline(body: string): string {
   const lines = body.split(/\r?\n/)
   for (const line of lines) {


### PR DESCRIPTION
## 변경 요약

`deriveTagline`이 인라인 코드 백틱을 벗겨내지 않아 OG 이미지·메타 설명에 마크다운 문법이 리터럴로 노출되던 문제를 수정한다. `**`·`[src:N]`은 이미 제거하면서 백틱만 빠져 있었다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 배경

태그라인은 마크다운이 렌더되지 않는 두 곳에서 소비된다 — OG 이미지(satori 렌더)와 메타 description(평문). 그래서 `` `code` ``의 백틱이 글자 그대로 보인다. 코드잇 PR #176 리뷰에서 Codex/claude-review 봇이 짚었고, 별도 PR로 분리해 처리한다(카탈로그 전역 인프라라 항목 PR에 번들하면 무관한 항목들의 OG가 함께 재생성됨).

**재현 (수정 전):** `public/og/codeit.png`에 "design.codeit.com"이 백틱째 렌더.
**수정 후:** 백틱 없이 깨끗하게 렌더 (아래 검증).

## 영향 범위

첫 본문 문단에 백틱을 쓰는 **5개 항목**의 OG가 다음 `build:og`에서 개선된다: `codeit`, `class101`, `seed-design`, `socar`, `wanted`. (`>` 인용으로 시작하는 항목들은 tagline이 다른 줄이라 무영향.)

`public/og/*.png`는 gitignore된 빌드 산출물이라 이 PR에 PNG diff는 없다 — 배포 시 `pnpm build`(→ `build:og`)가 자동 재생성한다.

## 수정

`content-parser.ts`의 `deriveTagline` replace 체인에 `.replace(/\`/g, "")` 한 줄 추가. 굵게·인용 제거와 동일한 이유이고 동일한 자리다.

## 검증

- **계약 테스트 선행**(TDD): `content-collection.test.ts`에 백틱 제거 케이스 추가 → red 확인 → 구현 → green.
- `pnpm typecheck && pnpm lint` 통과, **테스트 226/226**(225→226), prettier 통과.
- 코드잇 OG 재생성 후 육안 확인 — "design.codeit.com"이 백틱 없이 렌더됨.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (test 226/226)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 관련

코드잇 항목 추가 PR #176의 후속. 같은 리뷰에서 나온 사이드카 다크 팔레트 노출 건은 별도 PR로 진행 예정.