### PR TITLE
feat(tokens): 토큰 사이드카가 다크 팔레트를 포함하도록 — 카드 뷰는 라이트 유지

### DIFF
--- a/services/codeit.tokens.json
+++ b/services/codeit.tokens.json
@@ -527,6 +527,474 @@
       "value": "oklch(0.404 0.123 146)",
       "note": "#025918",
       "group": "프리미티브 스케일 — 라이트 테마"
+    },
+    {
+      "name": "dark-gray-00",
+      "value": "oklch(0.225 0.026 274)",
+      "note": "#181b28",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-05",
+      "value": "oklch(0.250 0.023 274)",
+      "note": "#1e212d",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-10",
+      "value": "oklch(0.276 0.026 275)",
+      "note": "#242735",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-15",
+      "value": "oklch(0.292 0.028 273)",
+      "note": "#272b3a",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-20",
+      "value": "oklch(0.321 0.031 274)",
+      "note": "#2e3243",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-30",
+      "value": "oklch(0.367 0.032 273)",
+      "note": "#393e50",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-40",
+      "value": "oklch(0.415 0.034 272)",
+      "note": "#454b5f",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-50",
+      "value": "oklch(0.526 0.031 271)",
+      "note": "#646a7d",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-60",
+      "value": "oklch(0.695 0.024 277)",
+      "note": "#999cac",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-70",
+      "value": "oklch(0.800 0.017 278)",
+      "note": "#bbbdc9",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-80",
+      "value": "oklch(0.872 0.012 281)",
+      "note": "#d3d4dd",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-90",
+      "value": "oklch(0.950 0.004 286)",
+      "note": "#eeeef1",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-gray-100",
+      "value": "oklch(0.976 0.001 286)",
+      "note": "#f7f7f8",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-00",
+      "value": "oklch(0.978 0.015 312)",
+      "note": "#fbf5ff (라이트와 동일 — 불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-05",
+      "value": "oklch(0.958 0.028 313)",
+      "note": "#f8ecff (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-10",
+      "value": "oklch(0.886 0.075 310)",
+      "note": "#e9ccff (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-15",
+      "value": "oklch(0.793 0.127 310)",
+      "note": "#d4a4f9 (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-20",
+      "value": "oklch(0.762 0.147 309)",
+      "note": "#cd96f8 (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-30",
+      "value": "oklch(0.714 0.191 308)",
+      "note": "#c47cfd (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-40",
+      "value": "oklch(0.661 0.223 305)",
+      "note": "#b363fd (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-50",
+      "value": "oklch(0.622 0.249 302)",
+      "note": "#a64eff (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-60",
+      "value": "oklch(0.582 0.273 300)",
+      "note": "#9933ff (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-70",
+      "value": "oklch(0.548 0.294 299)",
+      "note": "#8f00ff (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-80",
+      "value": "oklch(0.490 0.261 296)",
+      "note": "#760dde (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-90",
+      "value": "oklch(0.438 0.239 296)",
+      "note": "#6500c2 (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-purple-100",
+      "value": "oklch(0.380 0.206 298)",
+      "note": "#54009e (불변)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-00",
+      "value": "oklch(0.332 0.132 260)",
+      "note": "#003078",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-05",
+      "value": "oklch(0.382 0.176 262)",
+      "note": "#00369e",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-10",
+      "value": "oklch(0.453 0.190 261)",
+      "note": "#004bbd",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-15",
+      "value": "oklch(0.499 0.211 261)",
+      "note": "#0056d8",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-20",
+      "value": "oklch(0.583 0.211 258)",
+      "note": "#0674f4",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-30",
+      "value": "oklch(0.650 0.187 252)",
+      "note": "#1a90fc",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-40",
+      "value": "oklch(0.711 0.155 251)",
+      "note": "#4da6fe",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-50",
+      "value": "oklch(0.796 0.108 249)",
+      "note": "#85c2ff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-60",
+      "value": "oklch(0.846 0.079 250)",
+      "note": "#a6d1ff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-70",
+      "value": "oklch(0.885 0.058 250)",
+      "note": "#bdddff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-80",
+      "value": "oklch(0.914 0.042 254)",
+      "note": "#d0e5ff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-90",
+      "value": "oklch(0.944 0.027 253)",
+      "note": "#e0eeff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-blue-100",
+      "value": "oklch(0.962 0.018 258)",
+      "note": "#ebf3ff",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-00",
+      "value": "oklch(0.365 0.153 349)",
+      "note": "#72004b",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-05",
+      "value": "oklch(0.432 0.177 354)",
+      "note": "#920156",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-10",
+      "value": "oklch(0.492 0.199 357)",
+      "note": "#af0462",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-15",
+      "value": "oklch(0.554 0.226 357)",
+      "note": "#ce0075",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-20",
+      "value": "oklch(0.614 0.253 355)",
+      "note": "#eb008d",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-30",
+      "value": "oklch(0.664 0.265 352)",
+      "note": "#ff1ca5",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-40",
+      "value": "oklch(0.705 0.229 349)",
+      "note": "#ff52b7",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-50",
+      "value": "oklch(0.774 0.169 345)",
+      "note": "#ff85ce",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-60",
+      "value": "oklch(0.828 0.123 344)",
+      "note": "#ffa6db",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-70",
+      "value": "oklch(0.870 0.090 343)",
+      "note": "#ffbde4",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-80",
+      "value": "oklch(0.906 0.064 342)",
+      "note": "#ffd0ec",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-90",
+      "value": "oklch(0.938 0.042 341)",
+      "note": "#ffe0f3",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-pink-100",
+      "value": "oklch(0.959 0.027 341)",
+      "note": "#ffebf7",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-00",
+      "value": "oklch(0.513 0.138 49)",
+      "note": "#a34900",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-05",
+      "value": "oklch(0.626 0.170 48)",
+      "note": "#d66000",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-10",
+      "value": "oklch(0.705 0.175 55)",
+      "note": "#f07c00",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-15",
+      "value": "oklch(0.759 0.177 61)",
+      "note": "#ff9100",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-20",
+      "value": "oklch(0.786 0.171 68)",
+      "note": "#ffa10a",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-30",
+      "value": "oklch(0.816 0.170 77)",
+      "note": "#ffb200",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-40",
+      "value": "oklch(0.842 0.172 85)",
+      "note": "#ffc002",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-50",
+      "value": "oklch(0.863 0.176 90)",
+      "note": "#ffcb02",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-60",
+      "value": "oklch(0.884 0.171 93)",
+      "note": "#ffd52e",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-70",
+      "value": "oklch(0.908 0.155 96)",
+      "note": "#ffe057",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-80",
+      "value": "oklch(0.928 0.135 98)",
+      "note": "#ffe878",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-90",
+      "value": "oklch(0.956 0.082 98)",
+      "note": "#fff2b2",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-yellow-100",
+      "value": "oklch(0.978 0.025 87)",
+      "note": "#fff7e5",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-00",
+      "value": "oklch(0.404 0.123 146)",
+      "note": "#025918",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-05",
+      "value": "oklch(0.483 0.149 145)",
+      "note": "#03731f",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-10",
+      "value": "oklch(0.571 0.178 145)",
+      "note": "#039127",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-15",
+      "value": "oklch(0.648 0.202 145)",
+      "note": "#07ac30",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-20",
+      "value": "oklch(0.696 0.222 145)",
+      "note": "#00be2f",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-30",
+      "value": "oklch(0.743 0.209 145)",
+      "note": "#3ccc4b",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-40",
+      "value": "oklch(0.791 0.190 146)",
+      "note": "#59da6b",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-50",
+      "value": "oklch(0.842 0.198 145)",
+      "note": "#68ec75",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-60",
+      "value": "oklch(0.867 0.176 145)",
+      "note": "#80f188",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-70",
+      "value": "oklch(0.892 0.145 145)",
+      "note": "#9bf59f",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-80",
+      "value": "oklch(0.925 0.125 145)",
+      "note": "#b0fdb3",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-90",
+      "value": "oklch(0.951 0.079 147)",
+      "note": "#cdfed0 — ⚠ 반전 공식의 유일한 예외(공식대로면 #d9ffdb 예상, 원시 CSS 재확인으로 실측값 확정)",
+      "group": "프리미티브 스케일 — 다크 테마"
+    },
+    {
+      "name": "dark-green-100",
+      "value": "oklch(0.980 0.034 145)",
+      "note": "#ebffeb",
+      "group": "프리미티브 스케일 — 다크 테마"
     }
   ],
   "typography": [

--- a/services/seed-design.tokens.json
+++ b/services/seed-design.tokens.json
@@ -159,6 +159,34 @@
     {
       "name": "warning",
       "value": "oklch(0.592 0.109 85)"
+    },
+    {
+      "name": "dark-bg-default",
+      "value": "oklch(0.205 0.008 275)"
+    },
+    {
+      "name": "dark-bg-floating",
+      "value": "oklch(0.243 0.011 261)"
+    },
+    {
+      "name": "dark-fg-neutral",
+      "value": "oklch(0.967 0.002 248)"
+    },
+    {
+      "name": "dark-stroke-muted",
+      "value": "oklch(1.000 0.000 0 / 0.09)"
+    },
+    {
+      "name": "dark-bg-brand-solid",
+      "value": "oklch(0.696 0.204 43)"
+    },
+    {
+      "name": "dark-bg-brand-pressed",
+      "value": "oklch(0.787 0.137 50)"
+    },
+    {
+      "name": "dark-bg-brand-weak",
+      "value": "oklch(0.274 0.022 42)"
     }
   ],
   "typography": [

--- a/src/lib/token-curation.test.ts
+++ b/src/lib/token-curation.test.ts
@@ -3,6 +3,7 @@ import {
   colorChroma,
   curateColors,
   isAlphaColor,
+  lightColorsOnly,
   rampAnchors,
   rampStep,
 } from "./token-curation"
@@ -142,5 +143,36 @@ describe("curateColors", () => {
     const { visible, hidden } = curateColors(colors)
     expect(hidden).toHaveLength(0)
     expect(visible).toHaveLength(3)
+  })
+})
+
+describe("lightColorsOnly", () => {
+  it("drops dark-* prefixed tokens so the card view stays light-only", () => {
+    // The sidecar carries the full palette (light + dark) so a token copy can
+    // reproduce dark mode, but the card view shows light only — otherwise every
+    // near-identical dark swatch doubles the palette. This is the render-layer
+    // filter that keeps that split at the component boundary.
+    const colors = [
+      c("gray-00", "oklch(1 0 0)"),
+      c("gray-100", "oklch(0.32 0.007 297)"),
+      c("dark-gray-00", "oklch(0.22 0.026 274)", "다크 테마"),
+      c("dark-gray-100", "oklch(0.97 0.001 286)", "다크 테마"),
+    ]
+    expect(lightColorsOnly(colors).map((x) => x.name)).toEqual([
+      "gray-00",
+      "gray-100",
+    ])
+  })
+
+  it("keeps tokens that merely contain 'dark' but do not start with 'dark-'", () => {
+    // socar ships `pressed-dark-regular` as a LIGHT press-ripple token — it must
+    // survive the filter. Only the `dark-` *prefix* marks a dark-theme primitive.
+    const colors = [
+      c("pressed-dark-regular", "oklch(0.2 0.02 265 / 0.09)"),
+      c("dark-bg-default", "oklch(0.15 0.02 265)", "Dark"),
+    ]
+    expect(lightColorsOnly(colors).map((x) => x.name)).toEqual([
+      "pressed-dark-regular",
+    ])
   })
 })

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -112,3 +112,16 @@ export function curateColors(colors: Array<ColorToken>): {
   if (hidden.length <= MIN_COLLAPSE) visible.push(...hidden.splice(0))
   return { visible, hidden }
 }
+
+/**
+ * The card view is light-only: the sidecar carries the full palette (so a token
+ * copy reproduces dark mode), but rendering every near-identical `dark-*` swatch
+ * would double the palette. This is the render-layer filter that keeps that split
+ * at the component boundary — the extractor stays faithful to the source md.
+ *
+ * Keyed on the `dark-` *prefix*, not a substring: a light token that merely
+ * contains "dark" (e.g. socar's `pressed-dark-regular` press-ripple) is kept.
+ */
+export function lightColorsOnly(colors: Array<ColorToken>): Array<ColorToken> {
+  return colors.filter((c) => !c.name.startsWith("dark-"))
+}

--- a/src/lib/token-extractor.test.ts
+++ b/src/lib/token-extractor.test.ts
@@ -78,9 +78,31 @@ describe("colors", () => {
       value: "oklch(0.5 0.1 30)",
       note: "핵심 CTA",
     })
-    // aliases ({ref} + bare token names), opacity scalars, and dark-* tokens are
-    // all excluded — the card sidecar carries visually-renderable colors only.
-    expect(colors.map((c) => c.name)).toEqual(["primary"])
+    // aliases ({ref} + bare token names) and numeric opacity scalars stay in the
+    // md only. dark-* tokens ARE extracted, though — the sidecar carries the full
+    // palette so a token copy can reproduce dark mode; the card VIEW filters them
+    // to light at render time (see token-curation.lightColorsOnly), not here.
+    expect(colors.map((c) => c.name)).toEqual(["primary", "dark-bg"])
+  })
+
+  it("extracts dark-* tokens with their group preserved (full-palette sidecar)", () => {
+    const body = md(
+      "## Colors",
+      "```yaml",
+      "bg: oklch(0.99 0 0)",
+      "```",
+      "",
+      "### 다크 테마",
+      "",
+      "```yaml",
+      "dark-bg: oklch(0.15 0.02 265)",
+      "```"
+    )
+    const { colors } = extractTokensFromMarkdown(body)
+    expect(colors.find((c) => c.name === "dark-bg")).toMatchObject({
+      value: "oklch(0.15 0.02 265)",
+      group: "다크 테마",
+    })
   })
 
   it("extracts a rich oklch palette from toss with notes preserved", () => {

--- a/src/lib/token-extractor.ts
+++ b/src/lib/token-extractor.ts
@@ -98,10 +98,13 @@ const COLOR_VALUE =
 function parseColors(rows: Array<RawLine>): Array<ColorToken> {
   const out: Array<ColorToken> = []
   for (const r of rows) {
-    if (r.key.startsWith("dark-")) continue // dark-theme tokens — light palette only
-    // Cards show visually-renderable colors only. Aliases (`{colors.x}` or a
-    // bare token name) and numeric scalars (opacity) carry no swatch, so they
-    // are excluded here and remain in the design.md prose.
+    // dark-* primitives ARE extracted so the sidecar holds the full palette and a
+    // token copy can reproduce dark mode. The card VIEW filters them to light at
+    // render time (token-curation.lightColorsOnly) — the light/full split lives at
+    // the component boundary, not in the data.
+    //
+    // Aliases (`{colors.x}` or a bare token name) and numeric scalars (opacity)
+    // carry no swatch, so they are still excluded here and remain in the md prose.
     if (!COLOR_VALUE.test(r.value)) continue
     // Collapse the author's column-alignment spaces (`0.000 0.000 0   / 0.08`)
     // so the machine-readable value is canonical. CSS color functions are

--- a/src/routes/services/-components/token-card-section.tsx
+++ b/src/routes/services/-components/token-card-section.tsx
@@ -6,7 +6,11 @@ import type {
   SpacingToken,
   TypeToken,
 } from "@/lib/content-types"
-import { MIN_COLLAPSE, curateColors } from "@/lib/token-curation"
+import {
+  MIN_COLLAPSE,
+  curateColors,
+  lightColorsOnly,
+} from "@/lib/token-curation"
 
 // A pangram-ish sample that exercises Hangul, Latin, and numerals at every
 // ramp step. It renders in the SITE font (Pretendard), not the brand typeface
@@ -27,8 +31,13 @@ export function TokenCardSection({ tokens }: { tokens?: ServiceTokens }) {
   // No sidecar yet (entry not backfilled) → render nothing.
   if (!tokens) return null
   const { colors, typography, spacing, radius } = tokens
+  // The sidecar carries the full palette (light + dark) so a token copy can
+  // reproduce dark mode, but the card view is light-only — dark-* swatches would
+  // just double the palette with near-identical chips. Filter at the render
+  // boundary so the badge count and the ColorBlock agree.
+  const cardColors = lightColorsOnly(colors)
   if (
-    colors.length === 0 &&
+    cardColors.length === 0 &&
     typography.length === 0 &&
     spacing.length === 0 &&
     radius.length === 0
@@ -37,7 +46,7 @@ export function TokenCardSection({ tokens }: { tokens?: ServiceTokens }) {
   }
 
   const counts: Array<[number, string]> = [
-    [colors.length, "Colors"],
+    [cardColors.length, "Colors"],
     [typography.length, "Type"],
     [spacing.length, "Spacing"],
     [radius.length, "Radii"],
@@ -61,7 +70,7 @@ export function TokenCardSection({ tokens }: { tokens?: ServiceTokens }) {
         </p>
       </div>
 
-      {colors.length > 0 && <ColorBlock colors={colors} />}
+      {cardColors.length > 0 && <ColorBlock colors={cardColors} />}
       {typography.length > 0 && <TypeBlock items={typography} />}
       {(spacing.length > 0 || radius.length > 0) && (
         <ScaleBlock spacing={spacing} radius={radius} />


### PR DESCRIPTION
## 변경 요약

상세 페이지의 "Copy {slug}.tokens.json"이 **전체 토큰을 넘긴다고 안내하면서 `dark-*`를 빠뜨려**, 복사한 사용자가 다크 모드를 재현할 수 없었다. 추출 단계의 dark 제외를 걷어내 사이드카가 소스 md를 충실히 반영하게 하고, "카드는 라이트만"이라는 기존 UX는 **렌더 계층 필터**로 그대로 유지한다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서
- [ ] `/design-md` 스킬

## 왜 이렇게 고치는가

dark 제외가 `token-extractor.ts`(추출 단계)에 박혀 있었다. 그런데 **"거의 같은 색 카드가 두 배"는 카드가 렌더될 때만 성립하는 문제**다 — 데이터에서 지워버리는 바람에 복사 표면까지 함께 희생됐다. 관심사를 제자리로 옮긴다:

| 계층 | 역할 |
|---|---|
| 추출기 | 소스 md를 **충실히** 반영 (light + dark 전량) |
| 카드 컴포넌트 | 자기 큐레이션 책임만 — `lightColorsOnly()`로 라이트만 렌더 |
| 복사 버튼 | 사이드카 파일 그대로 → **커밋된 `{slug}.tokens.json`과 동일성 회복** |

복사 버튼 `aria-label`이 `Copy codeit.tokens.json`이라 사용자는 "그 파일을 복사한다"고 인식한다. 이 변경으로 복사 내용과 리포의 사이드카가 실제로 일치한다.

## 구현

- **`token-extractor.ts`** — `dark-` 스킵 제거. 별칭(`{colors.x}`)·불투명도 스칼라 제외는 그대로.
- **`token-curation.ts`** — `lightColorsOnly()` 신설. **`dark-` 프리픽스** 기준이지 substring이 아니다 — socar의 `pressed-dark-regular`(라이트 press-ripple)는 유지된다.
- **`token-card-section.tsx`** — 배지 카운트·`ColorBlock`·빈 체크가 필터된 배열을 보도록. 분기가 정확히 컴포넌트 경계에서 일어난다.

## 파급 범위

`dark-` 키를 실제로 쓰는 **2개 항목만** 재생성:

| 항목 | colors |
|---|---|
| `codeit` | 88 → **166** (dark 78 추가) |
| `seed-design` | 40 → **47** (dark 7 추가) |

`ServiceTokens` 타입·스키마 **변경 없음** — dark는 `name`/`value`/`group`/`note`를 갖춘 평범한 `ColorToken` 행이다. llms.txt는 raw md라 무영향(복사 JSON만 커짐).

> 참고: `--all` 재생성 시 `teamsparta`·`wanted` 사이드카도 diff가 나는데, **이 변경과 무관한 기존 drift**다(main의 추출기로 재생성해도 동일하게 발생 — stash 후 대조로 확인). 이 PR 범위 밖이라 건드리지 않았고, 별도 정리가 필요하다.

## 검증

**계약 테스트 선행(TDD)** — red 확인 후 구현:
- `token-extractor.test.ts`: dark 제외 검증을 **포함으로 반전** + group 보존 케이스 신설
- `token-curation.test.ts`: `lightColorsOnly` 가드 2건 (dark- 프리픽스 제거 / `pressed-dark-regular` 유지)
- 전체 **229 통과**, typecheck·lint·prettier 클린

**브라우저 실측** — 같은 페이지에서 두 표면을 각각 확인:
- **복사 payload**: 클립보드 write를 가로채 검사 → `colors 166` 중 **dark 78개 포함** ✅
- **카드 뷰**: 배지 `88 Colors`, 렌더된 스와치 88개, **dark 스와치 0개** — 변경 전과 동일 ✅

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (test 229/229)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 관련

코드잇 PR #176의 Codex CI 리뷰 지적. 같은 리뷰에서 나온 태그라인 백틱 건은 #177로 분리.