### PR TITLE
fix(tokens): stale 토큰 사이드카 2건 재생성 — 소스 md와 동기화 회복

### DIFF
--- a/services/teamsparta.tokens.json
+++ b/services/teamsparta.tokens.json
@@ -123,12 +123,12 @@
     {
       "name": "focus-ring",
       "value": "oklch(0.429 0.297 264 / 0.32)",
-      "group": "Overlays"
+      "group": "Semantic alias"
     },
     {
       "name": "modal-backdrop",
       "value": "oklch(0.000 0.000 0 / 0.48)",
-      "group": "Overlays"
+      "group": "Semantic alias"
     },
     {
       "name": "badge-blue-bg",

--- a/services/wanted.md
+++ b/services/wanted.md
@@ -118,7 +118,7 @@ orange-700: oklch(0.625 0.148 56)    # --fg-warning
 orange-600: oklch(0.733 0.179 56)
 orange-100: oklch(0.967 0.030 81)    # --bg-warning-subtle (#FEF4E6)
 coral-600:  oklch(0.665 0.218 38)    # brand gradient end-stop
-pink-600:   oklch(0.673 0.279 339)   # brand gradient mid (atomic value; README magenta는 약간 다름)
+# 그라디언트 mid-stop은 아래 Extended atomic ramps의 `pink-600` — 중복 정의를 피해 그쪽에만 둔다
 ```
 
 ### Extended atomic ramps (lime / cyan / sky / violet / purple / pink — accent 전용)

--- a/services/wanted.tokens.json
+++ b/services/wanted.tokens.json
@@ -294,12 +294,6 @@
       "group": "Semantic signal"
     },
     {
-      "name": "pink-600",
-      "value": "oklch(0.673 0.279 339)",
-      "note": "brand gradient mid (atomic value; README magenta는 약간 다름)",
-      "group": "Semantic signal"
-    },
-    {
       "name": "lime-600",
       "value": "oklch(0.758 0.213 131)",
       "note": "≈ #58CF04",

--- a/services/wanted.tokens.json
+++ b/services/wanted.tokens.json
@@ -328,6 +328,285 @@
       "value": "oklch(0.659 0.265 309)",
       "note": "≈ #CB59FF",
       "group": "Extended atomic ramps"
+    },
+    {
+      "name": "pink-600",
+      "value": "oklch(0.673 0.279 339)",
+      "note": "≈ #F553DA (atomic; gradient mid는 #FF53C0)",
+      "group": "Extended atomic ramps"
+    },
+    {
+      "name": "bg-canvas",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-surface",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-subtle",
+      "value": "oklch(0.972 0.002 286)",
+      "note": "neutral-50, page bg",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-muted",
+      "value": "oklch(0.961 0.002 286)",
+      "note": "neutral-75, hover fill",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-elevated",
+      "value": "oklch(1 0 0)",
+      "note": "dialog/popover",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-inverse",
+      "value": "oklch(0.148 0.004 277)",
+      "note": "neutral-960",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-brand",
+      "value": "oklch(0.563 0.232 257)",
+      "note": "blue-800",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-brand-subtle",
+      "value": "oklch(0.954 0.022 250)",
+      "note": "blue-100",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-danger-subtle",
+      "value": "oklch(0.951 0.018 18)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-success-subtle",
+      "value": "oklch(0.968 0.052 154)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-warning-subtle",
+      "value": "oklch(0.967 0.030 81)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-strong",
+      "value": "oklch(0.148 0.004 277)",
+      "note": "@ alpha 1 (= neutral-960)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-default",
+      "value": "oklch(0.259 0.010 273 / 0.88)",
+      "note": "body",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-secondary",
+      "value": "oklch(0.298 0.010 273 / 0.61)",
+      "note": "labels, captions",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-tertiary",
+      "value": "oklch(0.298 0.010 273 / 0.43)",
+      "note": "placeholder",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-disabled",
+      "value": "oklch(0.298 0.010 273 / 0.28)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-on-brand",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-brand",
+      "value": "oklch(0.563 0.232 257)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-link",
+      "value": "oklch(0.563 0.232 257)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-danger",
+      "value": "oklch(0.546 0.220 27)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-success",
+      "value": "oklch(0.673 0.211 144)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "fg-warning",
+      "value": "oklch(0.625 0.148 56)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "border-subtle",
+      "value": "oklch(0.521 0.018 273 / 0.08)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "border-default",
+      "value": "oklch(0.521 0.018 273 / 0.22)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "border-strong",
+      "value": "oklch(0.521 0.018 273 / 0.35)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "border-inverse",
+      "value": "oklch(1 0 0 / 0.16)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "border-brand",
+      "value": "oklch(0.563 0.232 257)",
+      "group": "Semantic alias — Light"
+    },
+    {
+      "name": "bg-canvas",
+      "value": "oklch(0.148 0.004 277)",
+      "note": "neutral-960",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-surface",
+      "value": "oklch(0.166 0.005 271)",
+      "note": "neutral-950",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-subtle",
+      "value": "oklch(0.135 0.002 286)",
+      "note": "neutral-970",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-muted",
+      "value": "oklch(0.196 0.008 273)",
+      "note": "neutral-925",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-elevated",
+      "value": "oklch(0.237 0.008 273)",
+      "note": "neutral-900",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-inverse",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-brand-subtle",
+      "value": "oklch(0.149 0.069 257)",
+      "note": "blue-975",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-danger-subtle",
+      "value": "oklch(0.298 0.10 22 / 0.32)",
+      "note": "synthesized for dark contrast",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-success-subtle",
+      "value": "oklch(0.298 0.10 144 / 0.28)",
+      "note": "synthesized",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "bg-warning-subtle",
+      "value": "oklch(0.298 0.10 56 / 0.32)",
+      "note": "synthesized",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-strong",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-default",
+      "value": "oklch(1 0 0 / 0.88)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-secondary",
+      "value": "oklch(1 0 0 / 0.61)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-tertiary",
+      "value": "oklch(1 0 0 / 0.43)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-disabled",
+      "value": "oklch(1 0 0 / 0.28)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-on-brand",
+      "value": "oklch(1 0 0)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-brand",
+      "value": "oklch(0.715 0.155 255)",
+      "note": "blue-400 (brightened from blue-800; synthesized)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-danger",
+      "value": "oklch(0.715 0.220 27)",
+      "note": "synthesized (red @ ↑ lightness)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-success",
+      "value": "oklch(0.760 0.180 144)",
+      "note": "synthesized (green @ ↑ lightness)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "fg-warning",
+      "value": "oklch(0.778 0.158 64)",
+      "note": "synthesized (orange @ ↑ lightness)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "border-subtle",
+      "value": "oklch(1 0 0 / 0.08)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "border-default",
+      "value": "oklch(1 0 0 / 0.22)",
+      "group": "Semantic alias — Dark"
+    },
+    {
+      "name": "border-strong",
+      "value": "oklch(1 0 0 / 0.35)",
+      "group": "Semantic alias — Dark"
     }
   ],
   "typography": [

--- a/src/lib/token-curation.test.ts
+++ b/src/lib/token-curation.test.ts
@@ -164,6 +164,34 @@ describe("lightColorsOnly", () => {
     ])
   })
 
+  it("drops dark tokens marked by GROUP when the name is shared across themes", () => {
+    // wanted reuses the same names in both themes (`bg-canvas` exists in Light
+    // and Dark) and distinguishes them only by the group heading. Filtering on
+    // the name alone let 23 dark swatches render in the light card view as
+    // duplicate-named cards.
+    const colors = [
+      c("bg-canvas", "oklch(1 0 0)", "Semantic alias — Light"),
+      c("bg-canvas", "oklch(0.148 0.004 277)", "Semantic alias — Dark"),
+      c("fg-default", "oklch(0.2 0.01 270)", "Semantic alias — Light"),
+      c("fg-default", "oklch(0.95 0.003 280)", "Semantic alias — Dark"),
+    ]
+    const kept = lightColorsOnly(colors)
+    expect(kept).toHaveLength(2)
+    expect(kept.every((x) => x.group === "Semantic alias — Light")).toBe(true)
+  })
+
+  it("recognises a Korean 다크 group label too", () => {
+    const colors = [
+      c("gray-00", "oklch(1 0 0)", "프리미티브 스케일 — 라이트 테마"),
+      c(
+        "dark-gray-00",
+        "oklch(0.225 0.026 274)",
+        "프리미티브 스케일 — 다크 테마"
+      ),
+    ]
+    expect(lightColorsOnly(colors).map((x) => x.name)).toEqual(["gray-00"])
+  })
+
   it("keeps tokens that merely contain 'dark' but do not start with 'dark-'", () => {
     // socar ships `pressed-dark-regular` as a LIGHT press-ripple token — it must
     // survive the filter. Only the `dark-` *prefix* marks a dark-theme primitive.

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -113,15 +113,27 @@ export function curateColors(colors: Array<ColorToken>): {
   return { visible, hidden }
 }
 
+// Entries mark dark-theme tokens two different ways, and the card filter has to
+// understand both:
+//   1. name prefix   — codeit writes `dark-gray-00` (light counterpart is `gray-00`)
+//   2. group heading — wanted writes `### Semantic alias — Dark` and REUSES the
+//      light names (`bg-canvas` exists in both themes), so the name alone can't
+//      tell them apart. Without the group check those 23 dark swatches render in
+//      the light card view as duplicate-named cards.
+const DARK_NAME_PREFIX = /^dark-/
+const DARK_GROUP = /(^|[\s—-])dark($|[\s—-])|다크/i
+
 /**
  * The card view is light-only: the sidecar carries the full palette (so a token
- * copy reproduces dark mode), but rendering every near-identical `dark-*` swatch
+ * copy reproduces dark mode), but rendering every near-identical dark swatch
  * would double the palette. This is the render-layer filter that keeps that split
  * at the component boundary — the extractor stays faithful to the source md.
  *
- * Keyed on the `dark-` *prefix*, not a substring: a light token that merely
- * contains "dark" (e.g. socar's `pressed-dark-regular` press-ripple) is kept.
+ * The name test is a *prefix*, not a substring, so a light token that merely
+ * contains "dark" (socar's `pressed-dark-regular` press-ripple) is kept.
  */
 export function lightColorsOnly(colors: Array<ColorToken>): Array<ColorToken> {
-  return colors.filter((c) => !c.name.startsWith("dark-"))
+  return colors.filter(
+    (c) => !DARK_NAME_PREFIX.test(c.name) && !DARK_GROUP.test(c.group ?? "")
+  )
 }


### PR DESCRIPTION
## 변경 요약

`pnpm tokens:build --all`이 `teamsparta`·`wanted` 사이드카에서 diff를 낸다. 두 파일이 소스 md와 어긋난 stale 상태였고, 재생성으로 동기화를 회복한다.

## 변경 종류

- [ ] 새 카탈로그 항목
- [x] 기존 항목 수정 (사이드카만 — `.md` 무변경)
- [ ] 사이트 코드/UI
- [ ] 문서
- [ ] `/design-md` 스킬

## 배경

PR #179 작업 중 발견했으나 **그 변경과 무관한 기존 drift**다. 제 변경을 stash로 걷어내고 **main의 원본 추출기로 재생성해도 동일하게 발생**함을 확인해 격리했고, #179에는 포함하지 않았다.

## 두 건의 원인이 다르다

### `wanted` — 재생성 누락 (색상 61 → 112)

| | 마지막 커밋 |
|---|---|
| `wanted.md` | 2026-06-16 (#138 font-display-src) |
| `wanted.tokens.json` | 2026-06-09 |

md가 갱신됐는데 사이드카를 재생성하지 않아 **51개 색상이 누락**돼 있었다. 추가되는 토큰이 실제로 md에 있는지 대조했다 — `pink-600`, `bg-canvas`, `bg-surface`, `bg-brand` 모두 실재. diff는 **삭제 1줄 / 추가 280줄**로 순수 보충이며 기존 값을 덮어쓰지 않는다.

### `teamsparta` — 유령 그룹 라벨 정정 (카운트 불변 28)

md(06-05)가 사이드카(06-09)보다 **오래됐으므로** md 변경 탓이 아니라 추출기 로직 변경분 미반영이다.

`focus-ring`·`modal-backdrop`의 `group`이 `"Overlays"`로 박혀 있는데, **md 전체에 `### Overlays` 헤딩은 0개**이고 두 토큰은 실제로 `### Semantic alias`(71줄) 아래 있다. `name`/`value` diff는 **0건** — 존재하지 않는 라벨만 실제 헤딩으로 정정된다.

## 왜 재생성이 안전한가

`build-tokens.ts`는 사이드카를 "DRAFT — 커밋 전 사람이 검토"로 정의한다. 그래서 **사람이 손본 큐레이션을 날리는 게 아닌지** 먼저 확인했다:
- `wanted`는 md에 있는 값을 채우기만 함 (삭제 1줄)
- `teamsparta`의 `"Overlays"`는 **md에 존재하지 않는 그룹명** — 사람의 큐레이션이 아니라 과거 md의 잔재

즉 재생성은 손실이 아니라 **잃어버린 동기화의 회복**이다.

## 검증

- `pnpm test` **229/229**, `pnpm validate:catalog` blocking 0
- **dev 서버 실측**:
  - 원티드 상세: 배지 `112 Colors`, 스와치 112개 렌더, 누락됐던 `pink-600`·`bg-canvas` 표시 확인
  - 팀스파르타 상세: `28 Colors` 유지, 그룹 라벨이 전부 md의 실제 `###` 헤딩과 일치(`Brand & interaction` / `Neutral scale` / `Semantic status` / `Semantic alias` / `Supporting badge surfaces`), **`Overlays` 소멸 확인**

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (test 229/229)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 후속

`tokens:build --all`이 clean인지 CI에서 강제하면 이런 drift가 재발하지 않는다 — 별도 검토 대상.