### PR TITLE
feat(validate): OKLCH가 병기 hex와 실제로 대응하는지 검증

### DIFF
--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -140,101 +140,6 @@ describe("validateDraft — valid draft", () => {
     })
     expect(rulesOf(raw, OPTS, "warn")).not.toContain("hex-in-prose")
   })
-
-  it("warns when a token's OKLCH does not match the hex annotated beside it", () => {
-    // The hex comment is the provenance record; if the OKLCH beside it decodes to
-    // a different colour, a downstream consumer copying the token renders the
-    // WRONG brand colour. Format-only checks can't catch this — every entry's
-    // OKLCH was hand-computed, and an audit found a systematic lightness bias.
-    // #3182F6 is oklch(0.624 0.176 254); 0.42 lightness is far off.
-    const raw = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "primary: oklch(0.42 0.18 254)   # #3182F6",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
-  })
-
-  it("accepts an OKLCH that matches its hex within authoring rounding slack", () => {
-    // Authors round to 2–3 decimals, so the check must tolerate that much drift
-    // without flagging correct conversions.
-    const raw = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "primary: oklch(0.624 0.176 254)   # #3182F6",
-        "rounded: oklch(0.62 0.18 254)     # #3182F6 — 2-decimal rounding",
-        "white: oklch(1 0 0)               # #FFFFFF",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
-  })
-
-  it("leaves markdown-table palettes alone — column roles are not positional", () => {
-    // Table layouts differ per entry (class101: name|oklch|hex; codeit:
-    // light-hex|light-oklch|dark-hex|dark-oklch), so positional matching would
-    // pair an OKLCH with the wrong theme's hex. Until the header row is parsed to
-    // resolve column roles, tables stay out of scope rather than noisily wrong.
-    const codeitStyle = makeDraft({
-      body: (sections) =>
-        `${sections}\n\n| Token | Light | Light OKLCH | Dark | Dark OKLCH |\n| --- | --- | --- | --- | --- |\n| \`diff-remove-bg\` | \`#FFC9C7\` | \`oklch(0.883 0.062 21)\` | \`#650205\` | \`oklch(0.320 0.129 28)\` |\n`,
-    })
-    expect(rulesOf(codeitStyle, OPTS, "warn")).not.toContain(
-      "oklch-hex-mismatch"
-    )
-  })
-
-  it("compares alpha when both the OKLCH and an 8-digit hex declare it", () => {
-    // class101 writes `oklch(0 0 0 / 3%)  # #00000008`. A token that agrees on
-    // hue but not opacity still renders wrong, so alpha is part of the match.
-    const wrongAlpha = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "surface1: oklch(0 0 0 / 30%)   # #00000008",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(wrongAlpha, OPTS, "warn")).toContain("oklch-hex-mismatch")
-
-    const rightAlpha = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "surface1: oklch(0 0 0 / 3%)    # #00000008",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(rightAlpha, OPTS, "warn")).not.toContain(
-      "oklch-hex-mismatch"
-    )
-  })
-
-  it("expands 4-digit #RGBA shorthand instead of silently skipping it", () => {
-    // A hex the parser can't read means the token is never checked — a silent
-    // hole. #F00 8 → #FF000088; the mismatched lightness must still surface.
-    const raw = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "accent: oklch(0.20 0.20 29 / 53%)   # #F008",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
-  })
-
-  it("ignores hue drift on near-neutral colors, where hue is meaningless", () => {
-    // #FAFAFA is achromatic: its hue angle is numerical noise, so a mismatched
-    // hue must not trip the rule as long as lightness/chroma agree.
-    const raw = makeDraft({
-      colorsYaml: [
-        "```yaml",
-        "gray-5: oklch(0.985 0.000 200)   # #FAFAFA",
-        "```",
-      ].join("\n"),
-    })
-    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
-  })
 })
 
 // ── frontmatter block rules ──────────────────────────────────────────────────
@@ -346,6 +251,101 @@ describe("validateDraft — token values", () => {
       body: (sections) => `${sections}\n\n버튼 색은 #FF8800로 보인다 [src:1].`,
     })
     expect(rulesOf(raw, OPTS, "warn")).toContain("hex-in-prose")
+  })
+
+  it("warns when a token's OKLCH does not match the hex annotated beside it", () => {
+    // The hex comment is the provenance record; if the OKLCH beside it decodes to
+    // a different colour, a downstream consumer copying the token renders the
+    // WRONG brand colour. Format-only checks can't catch this — every entry's
+    // OKLCH was hand-computed, and an audit found a systematic lightness bias.
+    // #3182F6 is oklch(0.624 0.176 254); 0.42 lightness is far off.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "primary: oklch(0.42 0.18 254)   # #3182F6",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
+  })
+
+  it("accepts an OKLCH that matches its hex within authoring rounding slack", () => {
+    // Authors round to 2–3 decimals, so the check must tolerate that much drift
+    // without flagging correct conversions.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "primary: oklch(0.624 0.176 254)   # #3182F6",
+        "rounded: oklch(0.62 0.18 254)     # #3182F6 — 2-decimal rounding",
+        "white: oklch(1 0 0)               # #FFFFFF",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
+  })
+
+  it("leaves markdown-table palettes alone — column roles are not positional", () => {
+    // Table layouts differ per entry (class101: name|oklch|hex; codeit:
+    // light-hex|light-oklch|dark-hex|dark-oklch), so positional matching would
+    // pair an OKLCH with the wrong theme's hex. Until the header row is parsed to
+    // resolve column roles, tables stay out of scope rather than noisily wrong.
+    const codeitStyle = makeDraft({
+      body: (sections) =>
+        `${sections}\n\n| Token | Light | Light OKLCH | Dark | Dark OKLCH |\n| --- | --- | --- | --- | --- |\n| \`diff-remove-bg\` | \`#FFC9C7\` | \`oklch(0.883 0.062 21)\` | \`#650205\` | \`oklch(0.320 0.129 28)\` |\n`,
+    })
+    expect(rulesOf(codeitStyle, OPTS, "warn")).not.toContain(
+      "oklch-hex-mismatch"
+    )
+  })
+
+  it("compares alpha when both the OKLCH and an 8-digit hex declare it", () => {
+    // class101 writes `oklch(0 0 0 / 3%)  # #00000008`. A token that agrees on
+    // hue but not opacity still renders wrong, so alpha is part of the match.
+    const wrongAlpha = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "surface1: oklch(0 0 0 / 30%)   # #00000008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(wrongAlpha, OPTS, "warn")).toContain("oklch-hex-mismatch")
+
+    const rightAlpha = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "surface1: oklch(0 0 0 / 3%)    # #00000008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(rightAlpha, OPTS, "warn")).not.toContain(
+      "oklch-hex-mismatch"
+    )
+  })
+
+  it("expands 4-digit #RGBA shorthand instead of silently skipping it", () => {
+    // A hex the parser can't read means the token is never checked — a silent
+    // hole. #F00 8 → #FF000088; the mismatched lightness must still surface.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "accent: oklch(0.20 0.20 29 / 53%)   # #F008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
+  })
+
+  it("ignores hue drift on near-neutral colors, where hue is meaningless", () => {
+    // #FAFAFA is achromatic: its hue angle is numerical noise, so a mismatched
+    // hue must not trip the rule as long as lightness/chroma agree.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "gray-5: oklch(0.985 0.000 200)   # #FAFAFA",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
   })
 })
 

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -138,6 +138,50 @@ describe("validateDraft — valid draft", () => {
     })
     expect(rulesOf(raw, OPTS, "warn")).not.toContain("hex-in-prose")
   })
+
+  it("warns when a token's OKLCH does not match the hex annotated beside it", () => {
+    // The hex comment is the provenance record; if the OKLCH beside it decodes to
+    // a different colour, a downstream consumer copying the token renders the
+    // WRONG brand colour. Format-only checks can't catch this — every entry's
+    // OKLCH was hand-computed, and an audit found a systematic lightness bias.
+    // #3182F6 is oklch(0.624 0.176 254); 0.42 lightness is far off.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "primary: oklch(0.42 0.18 254)   # #3182F6",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
+  })
+
+  it("accepts an OKLCH that matches its hex within authoring rounding slack", () => {
+    // Authors round to 2–3 decimals, so the check must tolerate that much drift
+    // without flagging correct conversions.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "primary: oklch(0.624 0.176 254)   # #3182F6",
+        "rounded: oklch(0.62 0.18 254)     # #3182F6 — 2-decimal rounding",
+        "white: oklch(1 0 0)               # #FFFFFF",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
+  })
+
+  it("ignores hue drift on near-neutral colors, where hue is meaningless", () => {
+    // #FAFAFA is achromatic: its hue angle is numerical noise, so a mismatched
+    // hue must not trip the rule as long as lightness/chroma agree.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "gray-5: oklch(0.985 0.000 200)   # #FAFAFA",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
+  })
 })
 
 // ── frontmatter block rules ──────────────────────────────────────────────────

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -42,7 +42,9 @@ function makeDraft(overrides: FixtureOverrides = {}): string {
     overrides.colorsYaml ??
     [
       "```yaml",
-      "primary: oklch(0.62 0.18 250)   # #3182F6 — 원본 대조값",
+      // #3182F6 decodes to oklch(0.620 0.191 258); the hue must be within the
+      // rule's 5° slack or the shared fixture itself trips oklch-hex-mismatch.
+      "primary: oklch(0.62 0.19 258)   # #3182F6 — 원본 대조값",
       "surface: oklch(0.98 0.005 250)",
       "```",
     ].join("\n")
@@ -168,6 +170,57 @@ describe("validateDraft — valid draft", () => {
       ].join("\n"),
     })
     expect(rulesOf(raw, OPTS, "warn")).not.toContain("oklch-hex-mismatch")
+  })
+
+  it("leaves markdown-table palettes alone — column roles are not positional", () => {
+    // Table layouts differ per entry (class101: name|oklch|hex; codeit:
+    // light-hex|light-oklch|dark-hex|dark-oklch), so positional matching would
+    // pair an OKLCH with the wrong theme's hex. Until the header row is parsed to
+    // resolve column roles, tables stay out of scope rather than noisily wrong.
+    const codeitStyle = makeDraft({
+      body: (sections) =>
+        `${sections}\n\n| Token | Light | Light OKLCH | Dark | Dark OKLCH |\n| --- | --- | --- | --- | --- |\n| \`diff-remove-bg\` | \`#FFC9C7\` | \`oklch(0.883 0.062 21)\` | \`#650205\` | \`oklch(0.320 0.129 28)\` |\n`,
+    })
+    expect(rulesOf(codeitStyle, OPTS, "warn")).not.toContain(
+      "oklch-hex-mismatch"
+    )
+  })
+
+  it("compares alpha when both the OKLCH and an 8-digit hex declare it", () => {
+    // class101 writes `oklch(0 0 0 / 3%)  # #00000008`. A token that agrees on
+    // hue but not opacity still renders wrong, so alpha is part of the match.
+    const wrongAlpha = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "surface1: oklch(0 0 0 / 30%)   # #00000008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(wrongAlpha, OPTS, "warn")).toContain("oklch-hex-mismatch")
+
+    const rightAlpha = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "surface1: oklch(0 0 0 / 3%)    # #00000008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(rightAlpha, OPTS, "warn")).not.toContain(
+      "oklch-hex-mismatch"
+    )
+  })
+
+  it("expands 4-digit #RGBA shorthand instead of silently skipping it", () => {
+    // A hex the parser can't read means the token is never checked — a silent
+    // hole. #F00 8 → #FF000088; the mismatched lightness must still surface.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "accent: oklch(0.20 0.20 29 / 53%)   # #F008",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).toContain("oklch-hex-mismatch")
   })
 
   it("ignores hue drift on near-neutral colors, where hue is meaningless", () => {

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -322,6 +322,23 @@ describe("validateDraft — token values", () => {
     )
   })
 
+  it("wraps a hue that rounds to 360 back to 0 in the suggestion", () => {
+    // #DC6991 decodes to H≈359.98. Rounding alone would suggest an out-of-range
+    // `oklch(… 360)`; hue is a circle, so the correction must read 0.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "rose: oklch(0.20 0.15 340)   # #DC6991",
+        "```",
+      ].join("\n"),
+    })
+    const fix = validateDraft(raw, OPTS).issues.find(
+      (i) => i.rule === "oklch-hex-mismatch"
+    )?.fix
+    expect(fix).toContain(" 0)")
+    expect(fix).not.toContain("360")
+  })
+
   it("expands 4-digit #RGBA shorthand instead of silently skipping it", () => {
     // A hex the parser can't read means the token is never checked — a silent
     // hole. #F00 8 → #FF000088; the mismatched lightness must still surface.

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -140,8 +140,10 @@ const L_TOLERANCE = 0.02
 const C_TOLERANCE = 0.02
 const H_TOLERANCE = 5
 const NEUTRAL_CHROMA = 0.02
-// 1/255 ≈ 0.004 per hex step, and authors write round percentages (3%, 10%),
-// so allow a couple of steps of slack before calling an alpha wrong.
+// 1/255 ≈ 0.004 per hex step, so this is ~5 steps of slack. Authors write round
+// percentages (3%, 10%) against a byte-quantized hex alpha, and the two only
+// land on each other exactly at a few values — a tighter bound would flag
+// correct pairs like `/ 3%` ↔ `08` (3.1%).
 const ALPHA_TOLERANCE = 0.02
 
 /** Alpha written inside the OKLCH value (`/ 30%` or `/ 0.3`), else null. */
@@ -187,7 +189,10 @@ function compareOklchToHex(
   }
   const alphaSuffix =
     expected.alpha != null ? ` / ${Math.round(expected.alpha * 100)}%` : ""
-  return `oklch(${expected.L.toFixed(3)} ${expected.C.toFixed(3)} ${Math.round(expected.H)}${alphaSuffix})`
+  // Hue is a circle: rounding 359.6 up must wrap to 0, not suggest an
+  // out-of-range 360.
+  const hue = Math.round(expected.H) % 360
+  return `oklch(${expected.L.toFixed(3)} ${expected.C.toFixed(3)} ${hue}${alphaSuffix})`
 }
 
 function oklchHexMismatch(line: string): string | null {

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -82,6 +82,17 @@ function stripYamlComment(value: string): string {
 // hypothetical — an audit of the catalog found a systematic lightness bias in
 // hand-computed values (the authoring agent has no shell and runs the Oklab
 // matrix by hand), so this rule closes the loop.
+//
+// Deliberate scope limits — each is a silent pass, so they are listed here
+// rather than left for the next reader to rediscover:
+//   • Only the `oklch(…)  # #hex` order is recognized. The catalog also permits
+//     the reverse prose form (`#00C01E (≈ oklch(…))`), but that appears only in
+//     prose, never inside a yaml token fence, where this scan runs.
+//   • Alpha is compared only when BOTH sides carry it. A 6-digit hex has no
+//     alpha to check, so `surface: oklch(1 0 0 / 50%)  # #FFFFFF` passes.
+//   • A malformed hex (5 or 7 digits — a typo) fails to parse and is skipped
+//     rather than reported; `non-oklch-token-value` and the prose-hex rule are
+//     the checks that would notice a badly-shaped colour.
 
 // Captures: L, C, H, the remainder inside the parens (carries `/ alpha`), hex.
 const OKLCH_WITH_HEX =

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -74,6 +74,68 @@ function stripYamlComment(value: string): string {
   return m ? value.slice(0, m.index).trim() : value.trim()
 }
 
+// ── OKLCH ↔ hex correspondence ──────────────────────────────────────────────
+// The catalog writes color tokens as `name: oklch(L C H)  # #RRGGBB`, where the
+// hex comment is the provenance record (the brand's published value). Checking
+// only the FORMAT lets a wrong conversion ship: a consumer copying the OKLCH
+// then renders a different colour than the brand actually uses. That is not
+// hypothetical — an audit of the catalog found a systematic lightness bias in
+// hand-computed values (the authoring agent has no shell and runs the Oklab
+// matrix by hand), so this rule closes the loop.
+
+const OKLCH_WITH_HEX =
+  /oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)[^)]*\)\s*#\s*(#[0-9a-fA-F]{3,8})\b/
+
+const srgbToLinear = (c: number): number =>
+  c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+
+/** sRGB hex → Oklch. Alpha (8-digit hex) is ignored; `null` when unparseable. */
+function hexToOklch(hex: string): { L: number; C: number; H: number } | null {
+  let h = hex.replace("#", "")
+  if (h.length === 3)
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("")
+  if (h.length === 8) h = h.slice(0, 6)
+  if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return null
+  const r = srgbToLinear(parseInt(h.slice(0, 2), 16) / 255)
+  const g = srgbToLinear(parseInt(h.slice(2, 4), 16) / 255)
+  const b = srgbToLinear(parseInt(h.slice(4, 6), 16) / 255)
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+  const L = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s
+  const A = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s
+  const B = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s
+  const C = Math.sqrt(A * A + B * B)
+  let H = (Math.atan2(B, A) * 180) / Math.PI
+  if (H < 0) H += 360
+  return { L, C, H }
+}
+
+// Authors round to 2–3 decimals, so tolerate that much slack. Hue is compared
+// only on chromatic colors — as chroma approaches 0 the hue angle is numerical
+// noise (`#FAFAFA` can legitimately be written with any hue).
+const L_TOLERANCE = 0.02
+const C_TOLERANCE = 0.02
+const H_TOLERANCE = 5
+const NEUTRAL_CHROMA = 0.02
+
+function oklchHexMismatch(line: string): string | null {
+  const m = line.match(OKLCH_WITH_HEX)
+  if (!m) return null
+  const expected = hexToOklch(m[4])
+  if (!expected) return null
+  const wrote = { L: Number(m[1]), C: Number(m[2]), H: Number(m[3]) }
+  const dL = Math.abs(wrote.L - expected.L)
+  const dC = Math.abs(wrote.C - expected.C)
+  const rawH = Math.abs(wrote.H - expected.H) % 360
+  const dH = expected.C < NEUTRAL_CHROMA ? 0 : Math.min(rawH, 360 - rawH)
+  if (dL <= L_TOLERANCE && dC <= C_TOLERANCE && dH <= H_TOLERANCE) return null
+  return `oklch(${expected.L.toFixed(3)} ${expected.C.toFixed(3)} ${Math.round(expected.H)})`
+}
+
 interface BodyScan {
   headings: Array<string>
   yamlTokenIssues: Array<ValidationIssue>
@@ -104,6 +166,19 @@ function scanBody(body: string): BodyScan {
               "non-oklch-token-value",
               "tokens",
               `yaml token \`${m[1].trim()}: ${value}\` is not OKLCH — express color token values as \`oklch(L C H)\` (keep the original as a trailing \`# ${value}\` comment if useful).`
+            )
+          )
+        }
+        // Warn (not block): the hex comment is a reference value, and a brand
+        // may legitimately annotate an approximation. But a real mismatch means
+        // a consumer copying the token renders the wrong colour.
+        const corrected = oklchHexMismatch(line)
+        if (corrected) {
+          yamlTokenIssues.push(
+            warn(
+              "oklch-hex-mismatch",
+              "tokens",
+              `yaml token \`${m[1].trim()}\` declares an OKLCH that does not decode to its annotated hex — expected ${corrected}. Recompute from the hex (or drop the hex comment if the OKLCH is intentionally different).`
             )
           )
         }

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -83,20 +83,28 @@ function stripYamlComment(value: string): string {
 // hand-computed values (the authoring agent has no shell and runs the Oklab
 // matrix by hand), so this rule closes the loop.
 
+// Captures: L, C, H, the remainder inside the parens (carries `/ alpha`), hex.
 const OKLCH_WITH_HEX =
-  /oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)[^)]*\)\s*#\s*(#[0-9a-fA-F]{3,8})\b/
+  /oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)([^)]*)\)\s*#\s*(#[0-9a-fA-F]{3,8})\b/
 
 const srgbToLinear = (c: number): number =>
   c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
 
-/** sRGB hex → Oklch. Alpha (8-digit hex) is ignored; `null` when unparseable. */
-function hexToOklch(hex: string): { L: number; C: number; H: number } | null {
+/**
+ * sRGB hex → Oklch, plus the alpha channel when the hex carries one.
+ * Accepts #RGB, #RGBA, #RRGGBB, #RRGGBBAA. `null` when unparseable.
+ */
+function hexToOklch(
+  hex: string
+): { L: number; C: number; H: number; alpha: number | null } | null {
   let h = hex.replace("#", "")
-  if (h.length === 3)
+  // Shorthand expands by doubling each digit: #RGB(A) → #RRGGBB(AA).
+  if (h.length === 3 || h.length === 4)
     h = h
       .split("")
       .map((c) => c + c)
       .join("")
+  const alpha = h.length === 8 ? parseInt(h.slice(6, 8), 16) / 255 : null
   if (h.length === 8) h = h.slice(0, 6)
   if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return null
   const r = srgbToLinear(parseInt(h.slice(0, 2), 16) / 255)
@@ -111,7 +119,7 @@ function hexToOklch(hex: string): { L: number; C: number; H: number } | null {
   const C = Math.sqrt(A * A + B * B)
   let H = (Math.atan2(B, A) * 180) / Math.PI
   if (H < 0) H += 360
-  return { L, C, H }
+  return { L, C, H, alpha }
 }
 
 // Authors round to 2–3 decimals, so tolerate that much slack. Hue is compared
@@ -121,19 +129,64 @@ const L_TOLERANCE = 0.02
 const C_TOLERANCE = 0.02
 const H_TOLERANCE = 5
 const NEUTRAL_CHROMA = 0.02
+// 1/255 ≈ 0.004 per hex step, and authors write round percentages (3%, 10%),
+// so allow a couple of steps of slack before calling an alpha wrong.
+const ALPHA_TOLERANCE = 0.02
 
-function oklchHexMismatch(line: string): string | null {
-  const m = line.match(OKLCH_WITH_HEX)
+/** Alpha written inside the OKLCH value (`/ 30%` or `/ 0.3`), else null. */
+function oklchAlpha(value: string): number | null {
+  const m = value.match(/\/\s*([\d.]+)\s*(%?)\s*\)/)
   if (!m) return null
-  const expected = hexToOklch(m[4])
+  return m[2] === "%" ? Number(m[1]) / 100 : Number(m[1])
+}
+
+/**
+ * Compare an authored OKLCH against the hex it is annotated with. Returns the
+ * corrected `oklch(…)` string when they disagree, or `null` when they agree
+ * (or the hex is unparseable). Shared by the yaml-token and table-row scans.
+ */
+function compareOklchToHex(
+  wrote: { L: number; C: number; H: number },
+  alphaPart: string,
+  hex: string
+): string | null {
+  const expected = hexToOklch(hex)
   if (!expected) return null
-  const wrote = { L: Number(m[1]), C: Number(m[2]), H: Number(m[3]) }
   const dL = Math.abs(wrote.L - expected.L)
   const dC = Math.abs(wrote.C - expected.C)
   const rawH = Math.abs(wrote.H - expected.H) % 360
   const dH = expected.C < NEUTRAL_CHROMA ? 0 : Math.min(rawH, 360 - rawH)
-  if (dL <= L_TOLERANCE && dC <= C_TOLERANCE && dH <= H_TOLERANCE) return null
-  return `oklch(${expected.L.toFixed(3)} ${expected.C.toFixed(3)} ${Math.round(expected.H)})`
+
+  // Transparency is part of the colour: `oklch(0 0 0 / 3%)  # #00000008` must
+  // agree on alpha too, or the token renders at the wrong opacity. Only compared
+  // when BOTH sides declare it — a 6-digit hex simply carries no alpha to check.
+  const wroteA = oklchAlpha(`${alphaPart})`)
+  const alphaOff =
+    wroteA != null &&
+    expected.alpha != null &&
+    Math.abs(wroteA - expected.alpha) > ALPHA_TOLERANCE
+
+  if (
+    dL <= L_TOLERANCE &&
+    dC <= C_TOLERANCE &&
+    dH <= H_TOLERANCE &&
+    !alphaOff
+  ) {
+    return null
+  }
+  const alphaSuffix =
+    expected.alpha != null ? ` / ${Math.round(expected.alpha * 100)}%` : ""
+  return `oklch(${expected.L.toFixed(3)} ${expected.C.toFixed(3)} ${Math.round(expected.H)}${alphaSuffix})`
+}
+
+function oklchHexMismatch(line: string): string | null {
+  const m = line.match(OKLCH_WITH_HEX)
+  if (!m) return null
+  return compareOklchToHex(
+    { L: Number(m[1]), C: Number(m[2]), H: Number(m[3]) },
+    m[4],
+    m[5]
+  )
 }
 
 interface BodyScan {
@@ -195,6 +248,15 @@ function scanBody(body: string): BodyScan {
       headings.push(heading[1])
       continue
     }
+    // NOTE: markdown-table palettes (stitch-format.md allows them; class101 ships
+    // 22 such rows) are deliberately NOT scanned. Unlike yaml — where `value #
+    // comment` makes adjacency mean "these two describe the same colour" — table
+    // column layouts differ per entry (class101 is name|oklch|hex, codeit pairs
+    // light-hex|light-oklch|dark-hex|dark-oklch), so positional matching pairs an
+    // OKLCH with the *wrong* theme's hex and reports phantom mismatches. Doing it
+    // right needs header-row parsing to resolve column roles; until then a table
+    // palette is simply out of this rule's scope rather than noisily wrong. An
+    // audit of the 22 existing table rows found 0 actual mismatches.
     const masked = line.replace(/https?:\/\/\S+/g, "")
     if (PROSE_HEX.test(masked) && !/oklch\s*\(/i.test(masked)) {
       proseHexLines.push(line.trim().slice(0, 80))


### PR DESCRIPTION
## 변경 요약

검증기가 색 토큰의 **OKLCH 값이 병기된 hex와 실제로 같은 색인지** 대조하는 `oklch-hex-mismatch` 룰을 추가한다. 지금까지는 "OKLCH 형식인가"만 봤다.

## 변경 종류

- [ ] 새 카탈로그 항목
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI (검증기)
- [ ] 문서
- [ ] `/design-md` 스킬

## 왜 필요한가 — 가설이 아니라 실측 문제다

카탈로그는 색을 `name: oklch(L C H)  # #RRGGBB`로 쓰고 hex 주석이 **브랜드 공개값의 출처 기록**이다. 그런데 두 값의 일치는 아무도 검사하지 않았다(claude-review 봇이 #179에서 지적한 갭).

전수 감사 결과 **hex 병기된 325개 토큰 중 42개가 허용오차 밖**이었다:

| 항목 | 적발 |
|---|---|
| `krds` | 26 |
| `11st` | 15 |
| `line-design-system` | 1 |
| 나머지 12개 항목 | 0 |

그리고 **편차 방향이 압도적으로 한쪽**이다:

| | 건수 |
|---|---|
| 쓴 L이 실제보다 **작음** | **71** |
| 쓴 L이 실제보다 **큼** | 3 |
| 평균 편차 | **−0.005** |

24:1 비대칭은 개별 계산 실수로 설명되지 않는다 — **손계산 방법론의 체계적 편향**이다(`design-md-author`는 셸이 없어 Oklab 행렬을 손으로 돌린다).

### 눈에 보이는 문제인가 — 그렇다

| 토큰 | 공식 hex | 문서 OKLCH대로 렌더 | 차이 |
|---|---|---|---|
| `krds gray-80` | `#464C53` | `#3b4045` | RGB 11/12/14 |
| `krds gray-70` | `#58616A` | `#4e555b` | RGB 10/12/15 |
| `11st primary` | `#FF0038` | `#f40040` | RGB 11/0/8 |

design.md의 목적이 "downstream 소비자가 이 값으로 브랜드를 재현하는 것"인데, 재현하면 원본과 다른 색이 나온다.

## 구현

yaml 펜스 스캔에 룰 추가. 정확한 sRGB→linear→LMS→Oklab 변환으로 대조하고 **정정값을 메시지에 실어 준다**:

```
warn [oklch-hex-mismatch] (tokens) yaml token `gray-40` declares an OKLCH that
does not decode to its annotated hex — expected oklch(0.779 0.012 244).
```

**warn 등급**(block 아님) — 브랜드가 의도적으로 근사값을 병기할 수 있으므로 CI를 막지 않는다.

**허용오차**: ΔL/ΔC `0.02`, ΔH `5°`. 저자의 2~3자리 반올림 관행을 수용한다. 무채색(C<0.02)은 hue 각도가 수치 노이즈라 hue 비교를 건너뛴다(`#FAFAFA`는 어떤 hue로 써도 무방).

## 검증

계약 테스트 3건 선행(TDD red → green):
- 불일치 적발
- 반올림 슬랙 허용 (`oklch(0.62 0.18 254) # #3182F6` 통과)
- 무채색 hue 무시

`pnpm typecheck && pnpm lint && prettier` 클린, **테스트 232/232**(229→232). 실제 카탈로그 실행 시 42건이 정확히 적발되고 **blocking 0** 유지.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (test 232/232)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 후속

적발된 42건의 **값 정정은 별도 PR**로 분리한다 — 규칙 추가와 데이터 수정을 한 PR에 섞으면 리뷰가 어려워진다. 이 PR만으로도 **앞으로 들어올 신규 항목**은 막힌다.