### PR TITLE
fix(catalog): hex와 어긋난 OKLCH 42건 정정 — 11st·krds·line

### DIFF
--- a/public/preview/11st/dark.html
+++ b/public/preview/11st/dark.html
@@ -17,9 +17,9 @@
        ============================================ */
     [data-theme="dark"] {
       /* Brand tokens stay identical for legibility */
-      --brand-orange:    oklch(0.66 0.21 32);
-      --brand-red:       oklch(0.60 0.26 18);
-      --brand-magenta:   oklch(0.65 0.36 332);
+      --brand-orange:    oklch(0.68 0.21 35);
+      --brand-red:       oklch(0.63 0.25 23);
+      --brand-magenta:   oklch(0.69 0.31 332);
       --gradient-brand: linear-gradient(135deg,
         var(--brand-orange) 0%,
         var(--brand-red) 50%,

--- a/public/preview/11st/dark.html
+++ b/public/preview/11st/dark.html
@@ -395,8 +395,8 @@
       align-items: center;
     }
     .badge--out {
-      background: oklch(0.65 0.26 18 / 0.12);
-      border: 1px solid oklch(0.65 0.26 18 / 0.5);
+      background: oklch(0.65 0.25 23 / 0.12);
+      border: 1px solid oklch(0.65 0.25 23 / 0.5);
       color: var(--primary);
     }
     .badge--fill { background: var(--primary); color: oklch(1 0 0); }

--- a/public/preview/11st/dark.html
+++ b/public/preview/11st/dark.html
@@ -25,8 +25,8 @@
         var(--brand-red) 50%,
         var(--brand-magenta) 100%);
 
-      --primary:         oklch(0.65 0.26 18);   /* +5L for dark contrast */
-      --primary-pressed: oklch(0.54 0.22 19);
+      --primary:         oklch(0.65 0.25 23);   /* +5L for dark contrast */
+      --primary-pressed: oklch(0.54 0.22 22);
       --primary-soft:    oklch(0.28 0.10 18);   /* deep-red wash for dark selected */
 
       /* Inverted grayscale — warm-tinted dark surfaces (chroma 0.005~0.007 @ hue 30) */
@@ -45,18 +45,18 @@
       --gray-13: oklch(0.14 0.006 30);    /* subtle bg, warm */
       --gray-14: oklch(0.10 0.005 30);    /* page bg, warm */
 
-      --color-blue:     oklch(0.68 0.18 245);
+      --color-blue:     oklch(0.68 0.18 252);
       --color-yellow:   oklch(0.82 0.16 70);
-      --color-green:    oklch(0.65 0.14 150);
+      --color-green:    oklch(0.65 0.13 154);
       --color-bluegray: oklch(0.70 0.07 246);
-      --color-brown:    oklch(0.62 0.04 25);
+      --color-brown:    oklch(0.62 0.04 18);
 
       /* Service sub-palette (slightly lifted L for dark contrast) */
       --svc-amazon:     oklch(0.70 0.10 224);
-      --svc-tuniverse:  oklch(0.46 0.27 276);
-      --svc-ooah:       oklch(0.48 0.30 269);
-      --svc-freshtable: oklch(0.72 0.13 187);
-      --svc-money:      oklch(0.58 0.28 282);
+      --svc-tuniverse:  oklch(0.46 0.25 275);
+      --svc-ooah:       oklch(0.48 0.27 266);
+      --svc-freshtable: oklch(0.72 0.12 184);
+      --svc-money:      oklch(0.58 0.26 281);
       --svc-seller:     oklch(0.68 0.20 264);
 
       --bg-page:       var(--gray-14);

--- a/public/preview/11st/light.html
+++ b/public/preview/11st/light.html
@@ -12,22 +12,22 @@
        ============================================ */
     :root {
       /* Brand tokens (canonical from design.md) */
-      --brand-orange:    oklch(0.66 0.21 32);
-      --brand-red:       oklch(0.60 0.26 18);
-      --brand-magenta:   oklch(0.65 0.36 332);
+      --brand-orange:    oklch(0.68 0.21 35);
+      --brand-red:       oklch(0.63 0.25 23);
+      --brand-magenta:   oklch(0.69 0.31 332);
       --gradient-brand: linear-gradient(135deg,
         var(--brand-orange) 0%,
         var(--brand-red) 50%,
         var(--brand-magenta) 100%);
 
-      --primary:         oklch(0.60 0.26 18);
-      --primary-pressed: oklch(0.49 0.22 19);
-      --primary-soft:    oklch(0.95 0.02 18);
+      --primary:         oklch(0.63 0.25 23);
+      --primary-pressed: oklch(0.53 0.22 22);
+      --primary-soft:    oklch(0.96 0.02 4);
 
       --gray-01: oklch(0 0 0);
       --gray-02: oklch(0.16 0 0);
-      --gray-03: oklch(0.30 0 0);
-      --gray-04: oklch(0.49 0 0);
+      --gray-03: oklch(0.32 0 0);
+      --gray-04: oklch(0.51 0 0);
       --gray-05: oklch(0.55 0 0);
       --gray-06: oklch(0.65 0 0);
       --gray-07: oklch(0.67 0 0);
@@ -39,18 +39,18 @@
       --gray-13: oklch(0.98 0 0);
       --gray-14: oklch(1 0 0);
 
-      --color-blue:     oklch(0.61 0.18 245);
+      --color-blue:     oklch(0.61 0.18 252);
       --color-yellow:   oklch(0.79 0.16 70);
-      --color-green:    oklch(0.56 0.14 150);
+      --color-green:    oklch(0.59 0.13 154);
       --color-bluegray: oklch(0.64 0.07 246);
-      --color-brown:    oklch(0.56 0.04 25);
+      --color-brown:    oklch(0.59 0.04 18);
 
       /* Service sub-palette */
       --svc-amazon:     oklch(0.66 0.10 224);
-      --svc-tuniverse:  oklch(0.36 0.27 276);
-      --svc-ooah:       oklch(0.38 0.30 269);
-      --svc-freshtable: oklch(0.67 0.13 187);
-      --svc-money:      oklch(0.51 0.28 282);
+      --svc-tuniverse:  oklch(0.42 0.25 275);
+      --svc-ooah:       oklch(0.41 0.27 266);
+      --svc-freshtable: oklch(0.69 0.12 184);
+      --svc-money:      oklch(0.52 0.26 281);
       --svc-seller:     oklch(0.62 0.20 264);
 
       --bg-page:       var(--gray-14);
@@ -1646,7 +1646,7 @@
               </div>
               <div class="order-card-divider"></div>
               <div class="order-item">
-                <div class="order-item-img" style="background: oklch(0.61 0.18 245);"></div>
+                <div class="order-item-img" style="background: oklch(0.61 0.18 252);"></div>
                 <div>
                   <div class="order-item-name">신선식품 · 산지직송</div>
                   <div class="order-item-sub">내일도착 · 새벽배송 가능</div>

--- a/public/preview/11st/light.html
+++ b/public/preview/11st/light.html
@@ -388,8 +388,8 @@
       align-items: center;
     }
     .badge--out {
-      background: oklch(0.60 0.26 18 / 0.04);
-      border: 1px solid oklch(0.60 0.26 18 / 0.4);
+      background: oklch(0.63 0.25 23 / 0.04);
+      border: 1px solid oklch(0.63 0.25 23 / 0.4);
       color: var(--primary);
     }
     .badge--fill { background: var(--primary); color: var(--gray-14); }
@@ -573,7 +573,7 @@
       align-items: center;
     }
     .tooltip {
-      background: oklch(0.30 0 0 / 0.92);
+      background: oklch(0.32 0 0 / 0.92);
       color: var(--gray-14);
       font-size: 12px;
       font-weight: 500;
@@ -592,7 +592,7 @@
       width: 0; height: 0;
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
-      border-top: 6px solid oklch(0.30 0 0 / 0.92);
+      border-top: 6px solid oklch(0.32 0 0 / 0.92);
     }
     .tooltip-target {
       font-size: 18px;

--- a/public/preview/krds/dark.html
+++ b/public/preview/krds/dark.html
@@ -42,7 +42,7 @@
 
     /* Secondary — desaturated cool surfaces */
     --krds-secondary-10: oklch(0.22 0.012 258);
-    --krds-secondary-50: oklch(0.46 0.045 257);
+    --krds-secondary-50: oklch(0.46 0.055 254);
     --krds-secondary-70: oklch(0.65 0.04 254);
 
     /* Accent — warm red, lifted for visibility */

--- a/public/preview/krds/light.html
+++ b/public/preview/krds/light.html
@@ -13,39 +13,39 @@
     --krds-gray-10:   oklch(0.965 0.002 247);
     --krds-gray-20:   oklch(0.92 0.003 247);
     --krds-gray-30:   oklch(0.84 0.005 247);
-    --krds-gray-40:   oklch(0.755 0.008 240);
-    --krds-gray-50:   oklch(0.625 0.013 246);
-    --krds-gray-60:   oklch(0.525 0.014 246);
-    --krds-gray-70:   oklch(0.445 0.013 247);
-    --krds-gray-80:   oklch(0.37 0.011 250);
-    --krds-gray-90:   oklch(0.295 0.011 268);
-    --krds-gray-95:   oklch(0.21 0.005 264);
-    --krds-gray-100:  oklch(0.16 0.003 264);
+    --krds-gray-40:   oklch(0.779 0.012 240);
+    --krds-gray-50:   oklch(0.662 0.019 246);
+    --krds-gray-60:   oklch(0.567 0.020 246);
+    --krds-gray-70:   oklch(0.488 0.018 247);
+    --krds-gray-80:   oklch(0.41 0.014 250);
+    --krds-gray-90:   oklch(0.333 0.013 268);
+    --krds-gray-95:   oklch(0.25 0.007 264);
+    --krds-gray-100:  oklch(0.19 0.004 264);
 
     --krds-primary-5:    oklch(0.98 0.01 256);
     --krds-primary-10:   oklch(0.955 0.018 254);
-    --krds-primary-20:   oklch(0.91 0.035 252);
-    --krds-primary-30:   oklch(0.79 0.085 251);
-    --krds-primary-40:   oklch(0.665 0.155 254);
+    --krds-primary-20:   oklch(0.92 0.036 263);
+    --krds-primary-30:   oklch(0.81 0.084 261);
+    --krds-primary-40:   oklch(0.668 0.157 261);
     --krds-primary-50:   oklch(0.575 0.205 257);
     --krds-primary-60:   oklch(0.475 0.21 261);
     --krds-primary-70:   oklch(0.345 0.115 257);
     --krds-primary-80:   oklch(0.275 0.092 258);
-    --krds-primary-90:   oklch(0.225 0.082 263);
+    --krds-primary-90:   oklch(0.252 0.086 258);
 
     --krds-secondary-10: oklch(0.945 0.011 248);
     --krds-secondary-20: oklch(0.885 0.019 247);
-    --krds-secondary-50: oklch(0.395 0.045 257);
+    --krds-secondary-50: oklch(0.425 0.055 254);
     --krds-secondary-70: oklch(0.275 0.092 258);
 
     --krds-accent-10: oklch(0.945 0.022 17);
-    --krds-accent-50: oklch(0.605 0.205 25);
-    --krds-accent-60: oklch(0.515 0.205 27);
+    --krds-accent-50: oklch(0.633 0.194 25);
+    --krds-accent-60: oklch(0.543 0.192 26);
 
     --krds-info:    oklch(0.555 0.155 245);
-    --krds-success: oklch(0.49 0.11 153);
-    --krds-warning: oklch(0.555 0.135 55);
-    --krds-danger:  oklch(0.555 0.205 28);
+    --krds-success: oklch(0.51 0.12 154);
+    --krds-warning: oklch(0.611 0.146 58);
+    --krds-danger:  oklch(0.576 0.201 27);
 
     /* Mapped onto runtime token names */
     --background: oklch(1 0 0);

--- a/public/preview/line-design-system/dark.html
+++ b/public/preview/line-design-system/dark.html
@@ -41,7 +41,7 @@
       --ldsg-brand-onsurface-alt: oklch(0 0 0);
       --ldsg-brand-primary: oklch(0.73 0.197 152);
       --ldsg-brand-primary-alt: oklch(0.63 0.171 151);
-      --ldsg-brand-secondary: oklch(0.25 0.054 268);
+      --ldsg-brand-secondary: oklch(0.28 0.052 269);
 
       /* LDSG Role Color */
       --ldsg-role-positive: oklch(0.73 0.197 152);

--- a/public/preview/line-design-system/light.html
+++ b/public/preview/line-design-system/light.html
@@ -37,7 +37,7 @@
       --ldsg-brand-onsurface-alt: oklch(0 0 0);
       --ldsg-brand-primary: oklch(0.73 0.197 152);     /* = linegreen */
       --ldsg-brand-primary-alt: oklch(0.63 0.171 151); /* #04A647 = lightgreen-700 */
-      --ldsg-brand-secondary: oklch(0.25 0.054 268);   /* #1E2742 = linenavy */
+      --ldsg-brand-secondary: oklch(0.28 0.052 269);   /* #1E2742 = linenavy */
 
       /* LDSG Role Color (의미 토큰) */
       --ldsg-role-positive: oklch(0.73 0.197 152);  /* = LINE green (정정) */

--- a/services/11st.md
+++ b/services/11st.md
@@ -59,7 +59,7 @@ logo: https://getdesign.kr/logos/11st.png
 brand-gradient-orange:  oklch(0.68 0.21 35)    # #FF5A2E
 brand-gradient-red:     oklch(0.63 0.25 23)    # #FF0038
 brand-gradient-magenta: oklch(0.69 0.31 332)   # #FF00EF
-brand-gradient:         "linear-gradient(135deg, oklch(0.66 0.21 32) 0%, oklch(0.60 0.26 18) 50%, oklch(0.65 0.36 332) 100%)"
+brand-gradient:         "linear-gradient(135deg, oklch(0.68 0.21 35) 0%, oklch(0.63 0.25 23) 50%, oklch(0.69 0.31 332) 100%)"
 ```
 
 **Primary (11STREET_Red)** — 주요 버튼, 라디오/체크박스 선택 상태, 탭 인디케이터, 뱃지 fill, 에러 텍스트, 로딩 스피너 [src:3].

--- a/services/11st.md
+++ b/services/11st.md
@@ -56,18 +56,18 @@ logo: https://getdesign.kr/logos/11st.png
 **Brand gradient (시그니처)** — 메인 서비스 플랫폼, 모바일 앱 아이콘, 광고에 사용 [src:3].
 
 ```yaml
-brand-gradient-orange:  oklch(0.66 0.21 32)    # #FF5A2E
-brand-gradient-red:     oklch(0.60 0.26 18)    # #FF0038
-brand-gradient-magenta: oklch(0.65 0.36 332)   # #FF00EF
+brand-gradient-orange:  oklch(0.68 0.21 35)    # #FF5A2E
+brand-gradient-red:     oklch(0.63 0.25 23)    # #FF0038
+brand-gradient-magenta: oklch(0.69 0.31 332)   # #FF00EF
 brand-gradient:         "linear-gradient(135deg, oklch(0.66 0.21 32) 0%, oklch(0.60 0.26 18) 50%, oklch(0.65 0.36 332) 100%)"
 ```
 
 **Primary (11STREET_Red)** — 주요 버튼, 라디오/체크박스 선택 상태, 탭 인디케이터, 뱃지 fill, 에러 텍스트, 로딩 스피너 [src:3].
 
 ```yaml
-primary:         oklch(0.60 0.26 18)    # #FF0038 11STREET_Red
-primary-pressed: oklch(0.49 0.22 19)    # #CC002D — primary를 어둡게
-primary-soft:    oklch(0.95 0.02 18)    # #FFEBEF — selected chip fill / hover tint
+primary:         oklch(0.63 0.25 23)    # #FF0038 11STREET_Red
+primary-pressed: oklch(0.53 0.22 22)    # #CC002D — primary를 어둡게
+primary-soft:    oklch(0.96 0.02 4)    # #FFEBEF — selected chip fill / hover tint
 ```
 
 **Grayscale (14단계)** — 정확히 14단계로 정의된다 [src:3].
@@ -75,8 +75,8 @@ primary-soft:    oklch(0.95 0.02 18)    # #FFEBEF — selected chip fill / hover
 ```yaml
 gray-01: oklch(0 0 0)        # #000000
 gray-02: oklch(0.16 0 0)     # #111111
-gray-03: oklch(0.30 0 0)     # #333333 — fg-primary (기본 본문)
-gray-04: oklch(0.49 0 0)     # #666666 — fg-secondary
+gray-03: oklch(0.32 0 0)     # #333333 — fg-primary (기본 본문)
+gray-04: oklch(0.51 0 0)     # #666666 — fg-secondary
 gray-05: oklch(0.55 0 0)     # #777777 — fg-tertiary (힌트/비활성)
 gray-06: oklch(0.65 0 0)     # #949494
 gray-07: oklch(0.67 0 0)     # #999999 — fg-disabled
@@ -92,21 +92,21 @@ gray-14: oklch(1 0 0)        # #FFFFFF — page/elevated bg
 **Secondary palette** — 정보 유형 강조용 [src:3].
 
 ```yaml
-secondary-blue:     oklch(0.61 0.18 245)  # #0B83E6 — 배송예정일/배송정보
+secondary-blue:     oklch(0.61 0.18 252)  # #0B83E6 — 배송예정일/배송정보
 secondary-yellow:   oklch(0.79 0.16 70)   # #FFA700 — Review 별점
-secondary-green:    oklch(0.56 0.14 150)  # #249356 — 성공/신선
+secondary-green:    oklch(0.59 0.13 154)  # #249356 — 성공/신선
 secondary-bluegray: oklch(0.64 0.07 246)  # #6D96C0
-secondary-brown:    oklch(0.56 0.04 25)   # #937676
+secondary-brown:    oklch(0.59 0.04 18)   # #937676
 ```
 
 **Service colors** — 서브 서비스 식별용 [src:3].
 
 ```yaml
 service-amazon:     oklch(0.66 0.10 224)  # #49A3C7 Amazon_Bluegreen
-service-tuniverse:  oklch(0.36 0.27 276)  # #3617CE T_Blue
-service-ooah:       oklch(0.38 0.30 269)  # #0F0FD9 OOAH_Blue
-service-freshtable: oklch(0.67 0.13 187)  # #00B4A5 Freshtable_mint
-service-money:      oklch(0.51 0.28 282)  # #5C38F5 Money_purple
+service-tuniverse:  oklch(0.42 0.25 275)  # #3617CE T_Blue
+service-ooah:       oklch(0.41 0.27 266)  # #0F0FD9 OOAH_Blue
+service-freshtable: oklch(0.69 0.12 184)  # #00B4A5 Freshtable_mint
+service-money:      oklch(0.52 0.26 281)  # #5C38F5 Money_purple
 service-seller:     oklch(0.62 0.20 264)  # #5483FD Seller_blue
 ```
 

--- a/services/11st.md
+++ b/services/11st.md
@@ -67,7 +67,7 @@ brand-gradient:         "linear-gradient(135deg, oklch(0.68 0.21 35) 0%, oklch(0
 ```yaml
 primary:         oklch(0.63 0.25 23)    # #FF0038 11STREET_Red
 primary-pressed: oklch(0.53 0.22 22)    # #CC002D — primary를 어둡게
-primary-soft:    oklch(0.96 0.02 4)    # #FFEBEF — selected chip fill / hover tint
+primary-soft:    oklch(0.96 0.02 4)     # #FFEBEF — selected chip fill / hover tint
 ```
 
 **Grayscale (14단계)** — 정확히 14단계로 정의된다 [src:3].

--- a/services/11st.tokens.json
+++ b/services/11st.tokens.json
@@ -2,32 +2,32 @@
   "colors": [
     {
       "name": "brand-gradient-orange",
-      "value": "oklch(0.66 0.21 32)",
+      "value": "oklch(0.68 0.21 35)",
       "note": "#FF5A2E"
     },
     {
       "name": "brand-gradient-red",
-      "value": "oklch(0.60 0.26 18)",
+      "value": "oklch(0.63 0.25 23)",
       "note": "#FF0038"
     },
     {
       "name": "brand-gradient-magenta",
-      "value": "oklch(0.65 0.36 332)",
+      "value": "oklch(0.69 0.31 332)",
       "note": "#FF00EF"
     },
     {
       "name": "primary",
-      "value": "oklch(0.60 0.26 18)",
+      "value": "oklch(0.63 0.25 23)",
       "note": "#FF0038 11STREET_Red"
     },
     {
       "name": "primary-pressed",
-      "value": "oklch(0.49 0.22 19)",
+      "value": "oklch(0.53 0.22 22)",
       "note": "#CC002D — primary를 어둡게"
     },
     {
       "name": "primary-soft",
-      "value": "oklch(0.95 0.02 18)",
+      "value": "oklch(0.96 0.02 4)",
       "note": "#FFEBEF — selected chip fill / hover tint"
     },
     {
@@ -42,12 +42,12 @@
     },
     {
       "name": "gray-03",
-      "value": "oklch(0.30 0 0)",
+      "value": "oklch(0.32 0 0)",
       "note": "#333333 — fg-primary (기본 본문)"
     },
     {
       "name": "gray-04",
-      "value": "oklch(0.49 0 0)",
+      "value": "oklch(0.51 0 0)",
       "note": "#666666 — fg-secondary"
     },
     {
@@ -102,7 +102,7 @@
     },
     {
       "name": "secondary-blue",
-      "value": "oklch(0.61 0.18 245)",
+      "value": "oklch(0.61 0.18 252)",
       "note": "#0B83E6 — 배송예정일/배송정보"
     },
     {
@@ -112,7 +112,7 @@
     },
     {
       "name": "secondary-green",
-      "value": "oklch(0.56 0.14 150)",
+      "value": "oklch(0.59 0.13 154)",
       "note": "#249356 — 성공/신선"
     },
     {
@@ -122,7 +122,7 @@
     },
     {
       "name": "secondary-brown",
-      "value": "oklch(0.56 0.04 25)",
+      "value": "oklch(0.59 0.04 18)",
       "note": "#937676"
     },
     {
@@ -132,22 +132,22 @@
     },
     {
       "name": "service-tuniverse",
-      "value": "oklch(0.36 0.27 276)",
+      "value": "oklch(0.42 0.25 275)",
       "note": "#3617CE T_Blue"
     },
     {
       "name": "service-ooah",
-      "value": "oklch(0.38 0.30 269)",
+      "value": "oklch(0.41 0.27 266)",
       "note": "#0F0FD9 OOAH_Blue"
     },
     {
       "name": "service-freshtable",
-      "value": "oklch(0.67 0.13 187)",
+      "value": "oklch(0.69 0.12 184)",
       "note": "#00B4A5 Freshtable_mint"
     },
     {
       "name": "service-money",
-      "value": "oklch(0.51 0.28 282)",
+      "value": "oklch(0.52 0.26 281)",
       "note": "#5C38F5 Money_purple"
     },
     {

--- a/services/krds.md
+++ b/services/krds.md
@@ -88,18 +88,18 @@ warning:  oklch(0.611 0.146 58)        # #C26900
 danger:   oklch(0.576 0.201 27)        # #D6322F
 
 # Foreground & surface (default mode)
-fg-1:           oklch(0.16 0.003 264)  # gray-100, 본문 1차 텍스트
-fg-2:           oklch(0.37 0.011 250)  # gray-80, 2차 텍스트
-fg-3:           oklch(0.525 0.014 246) # gray-60, 3차/플레이스홀더
-fg-4:           oklch(0.625 0.013 246) # gray-50, disabled/muted
+fg-1:           oklch(0.19 0.004 264)  # gray-100, 본문 1차 텍스트
+fg-2:           oklch(0.41 0.014 250)  # gray-80, 2차 텍스트
+fg-3:           oklch(0.567 0.020 246) # gray-60, 3차/플레이스홀더
+fg-4:           oklch(0.662 0.019 246) # gray-50, disabled/muted
 fg-on-primary:  oklch(1 0 0)           # #FFFFFF
 fg-link:        oklch(0.475 0.21 261)  # primary-60
 bg-canvas:      oklch(1 0 0)           # #FFFFFF
 bg-subtle:      oklch(0.965 0.002 247) # gray-10
 bg-muted:       oklch(0.945 0.011 248) # secondary-10
-bg-inverse:     oklch(0.16 0.003 264)  # gray-100
+bg-inverse:     oklch(0.19 0.004 264)  # gray-100
 border-default: oklch(0.84 0.005 247)  # gray-30, 1px 기본 디바이더
-border-strong:  oklch(0.625 0.013 246) # gray-50
+border-strong:  oklch(0.662 0.019 246) # gray-50
 border-focus:   oklch(0.575 0.205 257) # primary-50
 ```
 

--- a/services/krds.md
+++ b/services/krds.md
@@ -189,10 +189,10 @@ radius-pill:   999px  # chip과 카운터 전용
 4단 그림자 시스템을 사용한다. 그림자는 표면 색 단계와 1px 디바이더(`gray-30`)가 만드는 평면 위계를 보조하는 역할이다.
 
 ```yaml
-shadow-1: 0 1px 2px oklch(0.16 0.003 264 / 0.06), 0 1px 1px oklch(0.16 0.003 264 / 0.04)
-shadow-2: 0 2px 6px oklch(0.16 0.003 264 / 0.08), 0 1px 2px oklch(0.16 0.003 264 / 0.04)
-shadow-3: 0 6px 16px oklch(0.16 0.003 264 / 0.10), 0 2px 4px oklch(0.16 0.003 264 / 0.05)
-shadow-4: 0 12px 28px oklch(0.16 0.003 264 / 0.14), 0 4px 8px oklch(0.16 0.003 264 / 0.06)
+shadow-1: 0 1px 2px oklch(0.19 0.004 264 / 0.06), 0 1px 1px oklch(0.19 0.004 264 / 0.04)
+shadow-2: 0 2px 6px oklch(0.19 0.004 264 / 0.08), 0 1px 2px oklch(0.19 0.004 264 / 0.04)
+shadow-3: 0 6px 16px oklch(0.19 0.004 264 / 0.10), 0 2px 4px oklch(0.19 0.004 264 / 0.05)
+shadow-4: 0 12px 28px oklch(0.19 0.004 264 / 0.14), 0 4px 8px oklch(0.19 0.004 264 / 0.06)
 ```
 
 기본 모드에서 그림자 1–2단은 약 6–14% 검정으로 매우 절제된다. **선명한 화면 모드에서는 그림자가 더 약해지고, 표면 색 단계가 위계를 대신한다**. 인너 섀도우 시스템은 정의되지 않는다.
@@ -207,7 +207,7 @@ shadow-4: 0 12px 28px oklch(0.16 0.003 264 / 0.14), 0 4px 8px oklch(0.16 0.003 2
 - 라인 아이콘 약 120종, 24×24 그리드. 사이즈 변형 12 / 16 / 20 / 32 / 40px.
 - 외곽선·단색, 약 1.5–2px 스트로크, 둥근 라인 캡과 조인.
 - 채움(fill) 변형은 상태 아이콘(`check-circle`, `system-info`, `system-warning`, `system-danger`, `system-success`)에 한정.
-- 기본 fill `oklch(0.295 0.011 268)` (`gray-90`); status info `oklch(0.555 0.155 245)`; success check-circle은 brand blue `oklch(0.575 0.205 257)`로 채워진다.
+- 기본 fill `oklch(0.333 0.013 268)` (`gray-90`); status info `oklch(0.555 0.155 245)`; success check-circle은 brand blue `oklch(0.575 0.205 257)`로 채워진다.
 - Format: SVG. 번들 caveat: 약 120개 중 6개(search, close, home, menu, download, exclamation)만 추출되어 있어, CDN 폴백이 필요하면 **Material Symbols Outlined** (weight 400, grade 0, optical size 24)로 대체한다.
 
 **Focus state.** 항상 보이는 2px 솔리드 아웃라인을 `primary-50`로 그리고 2px 오프셋을 둔다. `outline:none`은 어떤 경우에도 사용하지 않는다.
@@ -321,7 +321,7 @@ KRDS Button은 3 사이즈 × 3 변형(primary / secondary / tertiary)으로 운
 
 ### modal
 
-너비 480px, 흰 표면, `{rounded.radius-xlarge}`, `{spacing.space-8}` (32px) 패딩, `{elevation.shadow-4}`. 240ms 슬라이드업, 뒤에 `oklch(0.16 0.003 264 / 0.5)` 스크림. 헤더는 행동 질문형(예: "민원 신청을 시작하시겠습니까?"), 본문은 절차형 `합니다` 정중체(예: "본인 인증이 필요한 서비스입니다. 간편인증 또는 공동인증서로 본인 확인 후 진행됩니다.").
+너비 480px, 흰 표면, `{rounded.radius-xlarge}`, `{spacing.space-8}` (32px) 패딩, `{elevation.shadow-4}`. 240ms 슬라이드업, 뒤에 `oklch(0.19 0.004 264 / 0.5)` 스크림. 헤더는 행동 질문형(예: "민원 신청을 시작하시겠습니까?"), 본문은 절차형 `합니다` 정중체(예: "본인 인증이 필요한 서비스입니다. 간편인증 또는 공동인증서로 본인 확인 후 진행됩니다.").
 
 ### toast
 
@@ -421,7 +421,7 @@ info / tips / warning 콜아웃. 패딩 18/20, `{rounded.radius-large}` (10px), 
 
 ### bottom-sheet
 
-모바일 하단 시트. 상단 코너는 표준 스케일보다 큰 16px(시트 한정), 36×4 `{colors.gray-30}` grab handle, 항목 패딩 14px. 뒤에 `oklch(0.16 0.003 264 / 0.55)` (gray-100 55%) 스크림, 240ms 슬라이드업.
+모바일 하단 시트. 상단 코너는 표준 스케일보다 큰 16px(시트 한정), 36×4 `{colors.gray-30}` grab handle, 항목 패딩 14px. 뒤에 `oklch(0.19 0.004 264 / 0.55)` (gray-100 55%) 스크림, 240ms 슬라이드업.
 
 ### tooltip · contextual-help
 

--- a/services/krds.md
+++ b/services/krds.md
@@ -40,52 +40,52 @@ gray-5:    oklch(0.985 0 0)          # #FAFAFA
 gray-10:   oklch(0.965 0.002 247)    # #F4F5F6 — bg-subtle
 gray-20:   oklch(0.92 0.003 247)     # #E6E8EA — row divider
 gray-30:   oklch(0.84 0.005 247)     # #CDD1D5 — border-default (1px workhorse)
-gray-40:   oklch(0.755 0.008 240)    # #B1B8BE
-gray-50:   oklch(0.625 0.013 246)    # #8A949E — border-strong, fg-4 (disabled)
-gray-60:   oklch(0.525 0.014 246)    # #6D7882 — fg-3 (tertiary/placeholder)
-gray-70:   oklch(0.445 0.013 247)    # #58616A
-gray-80:   oklch(0.37 0.011 250)     # #464C53 — fg-2 (secondary)
-gray-90:   oklch(0.295 0.011 268)    # #33363D — 아이콘 기본 fill
-gray-95:   oklch(0.21 0.005 264)     # #1E2124
-gray-100:  oklch(0.16 0.003 264)     # #131416 — fg-1 (primary text), bg-inverse, footer/identifier strip
+gray-40:   oklch(0.779 0.012 240)    # #B1B8BE
+gray-50:   oklch(0.662 0.019 246)    # #8A949E — border-strong, fg-4 (disabled)
+gray-60:   oklch(0.567 0.020 246)    # #6D7882 — fg-3 (tertiary/placeholder)
+gray-70:   oklch(0.488 0.018 247)    # #58616A
+gray-80:   oklch(0.41 0.014 250)     # #464C53 — fg-2 (secondary)
+gray-90:   oklch(0.333 0.013 268)    # #33363D — 아이콘 기본 fill
+gray-95:   oklch(0.25 0.007 264)     # #1E2124
+gray-100:  oklch(0.19 0.004 264)     # #131416 — fg-1 (primary text), bg-inverse, footer/identifier strip
 
 # Primary — Government blue (브랜드 앵커)
 primary-5:    oklch(0.98 0.01 256)     # #F7FAFF
 primary-10:   oklch(0.955 0.018 254)   # #ECF2FE — selected bg, 서비스 타일 아이콘 컨테이너
-primary-20:   oklch(0.91 0.035 252)    # #D8E5FD
-primary-30:   oklch(0.79 0.085 251)    # #A3C2F8
-primary-40:   oklch(0.665 0.155 254)   # #5B92F4
+primary-20:   oklch(0.92 0.036 263)    # #D8E5FD
+primary-30:   oklch(0.81 0.084 261)    # #A3C2F8
+primary-40:   oklch(0.668 0.157 261)   # #5B92F4
 primary-50:   oklch(0.575 0.205 257)   # #256EF4 — brand blue, focus outline, primary button
 primary-60:   oklch(0.475 0.21 261)    # #0B50D0 — hover/pressed, fg-link
 primary-70:   oklch(0.345 0.115 257)   # #063A74 — masthead 워드마크, seal 배경
 primary-80:   oklch(0.275 0.092 258)   # #052B57
-primary-90:   oklch(0.225 0.082 263)   # #03204A
-primary-95:   oklch(0.175 0.06 264)    # #021735
-primary-100:  oklch(0.13 0.035 265)    # #010C1F
+primary-90:   oklch(0.252 0.086 258)   # #03204A
+primary-95:   oklch(0.208 0.07 256)    # #021735
+primary-100:  oklch(0.16 0.046 255)    # #010C1F
 
 # Secondary — Deep desaturated navy (헤더 chrome, 절제된 강조)
 secondary-10:  oklch(0.945 0.011 248)  # #EEF2F7 — hero 배경, bg-muted
 secondary-20:  oklch(0.885 0.019 247)  # #D6E0EB
-secondary-30:  oklch(0.715 0.038 252)  # #98ACC5
-secondary-40:  oklch(0.575 0.045 254)  # #6E84A3
-secondary-50:  oklch(0.395 0.045 257)  # #39506C
-secondary-60:  oklch(0.31 0.05 258)    # #223A58
+secondary-30:  oklch(0.737 0.043 254)  # #98ACC5
+secondary-40:  oklch(0.608 0.054 257)  # #6E84A3
+secondary-50:  oklch(0.425 0.055 254)  # #39506C
+secondary-60:  oklch(0.34 0.06 255)    # #223A58
 secondary-70:  oklch(0.275 0.092 258)  # #052B57 — masthead chrome 앵커
-secondary-80:  oklch(0.215 0.07 263)   # #032041
-secondary-90:  oklch(0.155 0.045 264)  # #02132A
+secondary-80:  oklch(0.244 0.07 254)   # #032041
+secondary-90:  oklch(0.187 0.053 254)  # #02132A
 
 # Accent — Warm red (한 화면 5% 미만, 알럿/치명 상태/단일 핵심 강조 전용)
 accent-10:  oklch(0.945 0.022 17)      # #FCE9E9
 accent-30:  oklch(0.755 0.115 17)      # #F19A9A
-accent-50:  oklch(0.605 0.205 25)      # #E84B4B
-accent-60:  oklch(0.515 0.205 27)      # #C72B2B
-accent-70:  oklch(0.395 0.16 28)       # #8E1A1A
+accent-50:  oklch(0.633 0.194 25)      # #E84B4B
+accent-60:  oklch(0.543 0.192 26)      # #C72B2B
+accent-70:  oklch(0.422 0.15 27)       # #8E1A1A
 
 # Semantic / status
 info:     oklch(0.555 0.155 245)       # #0B78CB
-success:  oklch(0.49 0.11 153)         # #1F7A47
-warning:  oklch(0.555 0.135 55)        # #C26900
-danger:   oklch(0.555 0.205 28)        # #D6322F
+success:  oklch(0.51 0.12 154)         # #1F7A47
+warning:  oklch(0.611 0.146 58)        # #C26900
+danger:   oklch(0.576 0.201 27)        # #D6322F
 
 # Foreground & surface (default mode)
 fg-1:           oklch(0.16 0.003 264)  # gray-100, 본문 1차 텍스트

--- a/services/krds.tokens.json
+++ b/services/krds.tokens.json
@@ -212,22 +212,22 @@
     },
     {
       "name": "fg-1",
-      "value": "oklch(0.16 0.003 264)",
+      "value": "oklch(0.19 0.004 264)",
       "note": "gray-100, 본문 1차 텍스트"
     },
     {
       "name": "fg-2",
-      "value": "oklch(0.37 0.011 250)",
+      "value": "oklch(0.41 0.014 250)",
       "note": "gray-80, 2차 텍스트"
     },
     {
       "name": "fg-3",
-      "value": "oklch(0.525 0.014 246)",
+      "value": "oklch(0.567 0.020 246)",
       "note": "gray-60, 3차/플레이스홀더"
     },
     {
       "name": "fg-4",
-      "value": "oklch(0.625 0.013 246)",
+      "value": "oklch(0.662 0.019 246)",
       "note": "gray-50, disabled/muted"
     },
     {
@@ -257,7 +257,7 @@
     },
     {
       "name": "bg-inverse",
-      "value": "oklch(0.16 0.003 264)",
+      "value": "oklch(0.19 0.004 264)",
       "note": "gray-100"
     },
     {
@@ -267,7 +267,7 @@
     },
     {
       "name": "border-strong",
-      "value": "oklch(0.625 0.013 246)",
+      "value": "oklch(0.662 0.019 246)",
       "note": "gray-50"
     },
     {

--- a/services/krds.tokens.json
+++ b/services/krds.tokens.json
@@ -22,42 +22,42 @@
     },
     {
       "name": "gray-40",
-      "value": "oklch(0.755 0.008 240)",
+      "value": "oklch(0.779 0.012 240)",
       "note": "#B1B8BE"
     },
     {
       "name": "gray-50",
-      "value": "oklch(0.625 0.013 246)",
+      "value": "oklch(0.662 0.019 246)",
       "note": "#8A949E — border-strong, fg-4 (disabled)"
     },
     {
       "name": "gray-60",
-      "value": "oklch(0.525 0.014 246)",
+      "value": "oklch(0.567 0.020 246)",
       "note": "#6D7882 — fg-3 (tertiary/placeholder)"
     },
     {
       "name": "gray-70",
-      "value": "oklch(0.445 0.013 247)",
+      "value": "oklch(0.488 0.018 247)",
       "note": "#58616A"
     },
     {
       "name": "gray-80",
-      "value": "oklch(0.37 0.011 250)",
+      "value": "oklch(0.41 0.014 250)",
       "note": "#464C53 — fg-2 (secondary)"
     },
     {
       "name": "gray-90",
-      "value": "oklch(0.295 0.011 268)",
+      "value": "oklch(0.333 0.013 268)",
       "note": "#33363D — 아이콘 기본 fill"
     },
     {
       "name": "gray-95",
-      "value": "oklch(0.21 0.005 264)",
+      "value": "oklch(0.25 0.007 264)",
       "note": "#1E2124"
     },
     {
       "name": "gray-100",
-      "value": "oklch(0.16 0.003 264)",
+      "value": "oklch(0.19 0.004 264)",
       "note": "#131416 — fg-1 (primary text), bg-inverse, footer/identifier strip"
     },
     {
@@ -72,17 +72,17 @@
     },
     {
       "name": "primary-20",
-      "value": "oklch(0.91 0.035 252)",
+      "value": "oklch(0.92 0.036 263)",
       "note": "#D8E5FD"
     },
     {
       "name": "primary-30",
-      "value": "oklch(0.79 0.085 251)",
+      "value": "oklch(0.81 0.084 261)",
       "note": "#A3C2F8"
     },
     {
       "name": "primary-40",
-      "value": "oklch(0.665 0.155 254)",
+      "value": "oklch(0.668 0.157 261)",
       "note": "#5B92F4"
     },
     {
@@ -107,17 +107,17 @@
     },
     {
       "name": "primary-90",
-      "value": "oklch(0.225 0.082 263)",
+      "value": "oklch(0.252 0.086 258)",
       "note": "#03204A"
     },
     {
       "name": "primary-95",
-      "value": "oklch(0.175 0.06 264)",
+      "value": "oklch(0.208 0.07 256)",
       "note": "#021735"
     },
     {
       "name": "primary-100",
-      "value": "oklch(0.13 0.035 265)",
+      "value": "oklch(0.16 0.046 255)",
       "note": "#010C1F"
     },
     {
@@ -132,22 +132,22 @@
     },
     {
       "name": "secondary-30",
-      "value": "oklch(0.715 0.038 252)",
+      "value": "oklch(0.737 0.043 254)",
       "note": "#98ACC5"
     },
     {
       "name": "secondary-40",
-      "value": "oklch(0.575 0.045 254)",
+      "value": "oklch(0.608 0.054 257)",
       "note": "#6E84A3"
     },
     {
       "name": "secondary-50",
-      "value": "oklch(0.395 0.045 257)",
+      "value": "oklch(0.425 0.055 254)",
       "note": "#39506C"
     },
     {
       "name": "secondary-60",
-      "value": "oklch(0.31 0.05 258)",
+      "value": "oklch(0.34 0.06 255)",
       "note": "#223A58"
     },
     {
@@ -157,12 +157,12 @@
     },
     {
       "name": "secondary-80",
-      "value": "oklch(0.215 0.07 263)",
+      "value": "oklch(0.244 0.07 254)",
       "note": "#032041"
     },
     {
       "name": "secondary-90",
-      "value": "oklch(0.155 0.045 264)",
+      "value": "oklch(0.187 0.053 254)",
       "note": "#02132A"
     },
     {
@@ -177,17 +177,17 @@
     },
     {
       "name": "accent-50",
-      "value": "oklch(0.605 0.205 25)",
+      "value": "oklch(0.633 0.194 25)",
       "note": "#E84B4B"
     },
     {
       "name": "accent-60",
-      "value": "oklch(0.515 0.205 27)",
+      "value": "oklch(0.543 0.192 26)",
       "note": "#C72B2B"
     },
     {
       "name": "accent-70",
-      "value": "oklch(0.395 0.16 28)",
+      "value": "oklch(0.422 0.15 27)",
       "note": "#8E1A1A"
     },
     {
@@ -197,17 +197,17 @@
     },
     {
       "name": "success",
-      "value": "oklch(0.49 0.11 153)",
+      "value": "oklch(0.51 0.12 154)",
       "note": "#1F7A47"
     },
     {
       "name": "warning",
-      "value": "oklch(0.555 0.135 55)",
+      "value": "oklch(0.611 0.146 58)",
       "note": "#C26900"
     },
     {
       "name": "danger",
-      "value": "oklch(0.555 0.205 28)",
+      "value": "oklch(0.576 0.201 27)",
       "note": "#D6322F"
     },
     {

--- a/services/line-design-system.md
+++ b/services/line-design-system.md
@@ -88,7 +88,7 @@ ldsg-color-brand-onsurface:      oklch(1 0 0)            # #FFFFFF · 공식 기
 ldsg-color-brand-onsurface-alt:  oklch(0 0 0)            # #000000 · 공식 기본 매핑(= black)
 ldsg-color-brand-primary:        oklch(0.73 0.197 152)  # #06C755 · 공식 매핑(= linegreen)
 ldsg-color-brand-primary-alt:    oklch(0.63 0.171 151)  # #04A647 · = lightgreen-700 (매핑 공식 / hex 재구성)
-ldsg-color-brand-secondary:      oklch(0.25 0.054 268)  # #1E2742 · = linenavy (매핑 공식 / hex 재구성)
+ldsg-color-brand-secondary:      oklch(0.28 0.052 269)  # #1E2742 · = linenavy (매핑 공식 / hex 재구성)
 # ldsg-color-brand-secondary-alt:  TBD                    # 공식 "TBD" 표기 — 다운스트림이 임의 값을 발명하지 않는다
 
 # Theme Color — Role Color (의미 토큰)

--- a/services/line-design-system.tokens.json
+++ b/services/line-design-system.tokens.json
@@ -92,7 +92,7 @@
     },
     {
       "name": "ldsg-color-brand-secondary",
-      "value": "oklch(0.25 0.054 268)",
+      "value": "oklch(0.28 0.052 269)",
       "note": "#1E2742 · = linenavy (매핑 공식 / hex 재구성)"
     },
     {


### PR DESCRIPTION
## 변경 요약

병기된 hex로 재계산하면 **다른 색이 나오는** 토큰 42건을 정정한다. hex 주석이 브랜드 공개값의 출처 기록이므로 그쪽이 정본이고, OKLCH를 맞췄다.

## 변경 종류

- [ ] 새 카탈로그 항목
- [x] 기존 항목 수정
- [ ] 사이트 코드/UI
- [ ] 문서
- [ ] `/design-md` 스킬

## 배경

검증기는 지금까지 "OKLCH 형식인가"만 보고 두 값의 일치는 검사하지 않았다(#181이 그 룰을 추가한다). 전수 감사 결과 hex 병기 **325개 중 42개**가 허용오차 밖:

| 항목 | 정정 |
|---|---|
| `krds` | 26 |
| `11st` | 15 |
| `line-design-system` | 1 |

편차가 한쪽으로 쏠려 있다 — 쓴 L이 실제보다 **작음 71건 vs 큼 3건**, 평균 −0.005. 개별 실수가 아니라 손계산 방법론의 체계적 편향이다.

## 실제로 색이 달랐다 — 그리고 이제 맞는다

정정 후 dev 서버에서 **브라우저가 실제로 칠한 픽셀을 캔버스로 읽어** 공식 hex와 대조했다:

| 토큰 | 공식 hex | 정정 전 렌더 | **정정 후 렌더** | 차이 |
|---|---|---|---|---|
| `krds gray-50` | `#8a949e` | — | **`#8a949e`** | **0** |
| `krds gray-70` | `#58616a` | `#4e555b` | **`#58616a`** | **0** |
| `krds gray-80` | `#464c53` | `#3b4045` | `#454b52` | 1 (반올림 한계) |
| `krds gray-90` | `#33363d` | — | **`#33363d`** | **0** |

정정 전 `gray-80`은 채널당 11~14 어긋났다. design.md의 목적이 "소비자가 이 값으로 브랜드를 재현하는 것"이므로 이 차이는 그대로 두면 안 된다.

## 정정 규칙

- **저자의 소수 자릿수 유지** — `0.755`는 3자리, `0.62`는 2자리로 그대로. 불필요한 diff를 만들지 않는다.
- **무채색(C<0.02)은 hue를 저자 값 그대로 둠** — 그 구간의 hue 각도는 수치 노이즈라 정정 대상이 아니다(#181 검증기 룰과 동일 판단). 그래서 krds gray 램프는 L/C만 바뀐다.
- **hex 주석 전량 보존** (krds 44개) — 출처 기록이 사라지면 재검증이 불가능해진다.

md의 OKLCH가 바뀌었으므로 3개 항목의 **사이드카도 동기화**했다(토큰 카운트 불변, 값만 변경).

## 검증

- **재감사 42 → 0건** (카탈로그 전체가 hex↔OKLCH 정합)
- `pnpm test` **229/229**, `pnpm validate:catalog` blocking 0, typecheck 클린
- 위 캔버스 픽셀 대조

## 일반 체크

- [x] `pnpm typecheck && pnpm lint` 통과 (test 229/229)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 준수

## 관련

#181(검증기 룰 추가)과 **독립적**이다 — 규칙 추가와 데이터 수정을 분리했다. 둘 다 머지되면 이 클래스의 결함이 재발하지 않는다(#181이 앞으로를 막고, 이 PR이 과거를 정리).