### PR TITLE
fix(audit): audit:oklch 무음 실패 차단 + 캡처 위치 결합 제거

### DIFF
--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs"
 import path from "node:path"
 import {
+  applyDefinition,
   countDefinitions,
   indexCorrections,
   matchDefinition,
-  rebuildDefinition,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
 import { findPreviewDrift, readDefinitions } from "../src/lib/oklch-drift"
@@ -188,7 +188,7 @@ for (const slug of slugs) {
     if (!fix) return line
     // Preserve the author's spacing so only the numbers move in the diff.
     // Round-tripped by `rebuildDefinition`'s tests — this file has none.
-    return line.replace(d.matched, rebuildDefinition(d, to, alphaTo))
+    return applyDefinition(line, d, to, alphaTo)
   })
 
   if (fix && corrections.length > 0) {

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -2,6 +2,7 @@ import fs from "node:fs"
 import path from "node:path"
 import {
   OKLCH_DEFINITION,
+  countDefinitions,
   indexCorrections,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
@@ -118,9 +119,17 @@ let syncCount = 0
 const unsynced: Array<{ slug: string; conflicts: Array<CorrectionConflict> }> =
   []
 
+// Coverage, not just findings. "No mismatches" and "matched nothing" produce
+// identical output otherwise — the failure mode that let 102 annotated pairs go
+// unjudged while this gate reported a clean catalogue.
+const coverage = { annotated: 0, judged: 0 }
+
 for (const slug of slugs) {
   const mdPath = path.join(SERVICES, `${slug}.md`)
   const lines = fs.readFileSync(mdPath, "utf8").split(/\r?\n/)
+  const c = countDefinitions(lines.join("\n"))
+  coverage.annotated += c.annotated
+  coverage.judged += c.judged
   const corrections: Array<{
     old: [string, string, string]
     neu: [string, string, string]
@@ -252,10 +261,28 @@ for (const [slug, items] of byslug) {
 
 const verb = fix ? "corrected" : "mismatched"
 console.log(
-  `\n${findings.length} token(s) ${verb}` +
+  `\n${coverage.judged}/${coverage.annotated} annotated definition(s) judged` +
+    (coverage.annotated - coverage.judged
+      ? ` (${coverage.annotated - coverage.judged} skipped — comment names more than one hex)`
+      : "")
+)
+console.log(
+  `${findings.length} token(s) ${verb}` +
     (sync ? `, ${syncCount} derived literal(s) synced` : "") +
     (findings.length && !fix ? " — re-run with --fix to rewrite" : "")
 )
+
+// A pattern that matches nothing is the one failure this tool cannot express as
+// a finding, so it has to be its own exit path. Anything above zero is left to
+// the coverage line above and the catalogue canary in oklch-sync.test.ts.
+if (coverage.annotated > 0 && coverage.judged === 0) {
+  console.error(
+    `\nJudged 0 of ${coverage.annotated} annotated definition(s) — ` +
+      `OKLCH_DEFINITION is matching nothing. This is a broken pattern, ` +
+      `not a clean catalogue.`
+  )
+  process.exit(1)
+}
 
 // Reported after the whole catalogue is walked, so the count is the real one —
 // the earlier per-slug abort could only ever name the first conflict it hit.

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -4,6 +4,7 @@ import {
   OKLCH_DEFINITION,
   countDefinitions,
   indexCorrections,
+  rebuildDefinition,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
 import { findPreviewDrift, readDefinitions } from "../src/lib/oklch-drift"
@@ -194,10 +195,8 @@ for (const slug of slugs) {
 
     if (!fix) return line
     // Preserve the author's spacing so only the numbers move in the diff.
-    return line.replace(
-      m[0],
-      `${m[1]}:${m[2]}oklch(${to[0]}${m[4]}${to[1]}${m[6]}${to[2]}${alphaTo})${m[9]}${m[10]}`
-    )
+    // Round-tripped by `rebuildDefinition`'s tests — this file has none.
+    return line.replace(m[0], rebuildDefinition(m, to, alphaTo))
   })
 
   if (fix && corrections.length > 0) {

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -123,8 +123,9 @@ const coverage = { annotated: 0, judged: 0 }
 
 for (const slug of slugs) {
   const mdPath = path.join(SERVICES, `${slug}.md`)
-  const lines = fs.readFileSync(mdPath, "utf8").split(/\r?\n/)
-  const c = countDefinitions(lines.join("\n"))
+  const md = fs.readFileSync(mdPath, "utf8")
+  const lines = md.split(/\r?\n/)
+  const c = countDefinitions(md)
   coverage.annotated += c.annotated
   coverage.judged += c.judged
   const corrections: Array<{
@@ -186,8 +187,10 @@ for (const slug of slugs) {
     if (colourOff) corrections.push({ old: from, neu: to })
 
     if (!fix) return line
-    // Preserve the author's spacing so only the numbers move in the diff.
-    // Round-tripped by `rebuildDefinition`'s tests — this file has none.
+    // Preserve the author's spacing so only the numbers move in the diff, and
+    // splice through `applyDefinition` so a `$` in the comment cannot be read as
+    // a substitution pattern. Both are pinned by tests in `src/lib/` — this file
+    // has none of its own.
     return applyDefinition(line, d, to, alphaTo)
   })
 

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs"
 import path from "node:path"
 import {
-  OKLCH_DEFINITION,
   countDefinitions,
   indexCorrections,
+  matchDefinition,
   rebuildDefinition,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
@@ -83,10 +83,6 @@ function like(sample: string, value: number): string {
   return value.toFixed(decimals)
 }
 
-// The one shape where the pairing is unambiguous, so it is the only shape we
-// JUDGE — shared with the sync pass, which must leave those lines alone.
-const DEFINITION = OKLCH_DEFINITION
-
 interface Finding {
   slug: string
   line: number
@@ -137,14 +133,14 @@ for (const slug of slugs) {
   }> = []
 
   const fixedLines = lines.map((line, i) => {
-    const m = line.match(DEFINITION)
-    if (!m) return line
-    const want = hexToOklab(m[10])
+    const d = matchDefinition(line)
+    if (!d) return line
+    const want = hexToOklab(d.hex)
     if (!want) return line
-    const got = lchToOklab(Number(m[3]), Number(m[5]), Number(m[7]))
+    const got = lchToOklab(Number(d.L), Number(d.C), Number(d.H))
     const dE = deltaE(got, want.lab)
     // Only compared when BOTH sides declare it — a 6-digit hex carries no alpha.
-    const wroteA = oklchAlpha(m[8])
+    const wroteA = oklchAlpha(d.tail)
     const wantA = want.alpha
     const alphaOff =
       wroteA != null &&
@@ -152,9 +148,9 @@ for (const slug of slugs) {
       Math.abs(wroteA - wantA) > ALPHA_TOLERANCE
     if (dE <= DELTA_E && !alphaOff) return line
 
-    const from: [string, string, string] = [m[3], m[5], m[7]]
+    const from: [string, string, string] = [d.L, d.C, d.H]
     const target = labToLch(want.lab)
-    const chroma = like(m[5], target.C)
+    const chroma = like(d.C, target.C)
     // A pure grey carries float residue on a/b (#111111 lands at a≈1e-11), so
     // atan2 reports an arbitrary angle — 90° rather than the author's 0. Once
     // chroma rounds to zero the hue is unobservable, so keep what was written
@@ -164,30 +160,26 @@ for (const slug of slugs) {
     // the authored L/C/H rather than restating them at full precision.
     const colourOff = dE > DELTA_E
     const to: [string, string, string] = colourOff
-      ? [
-          like(m[3], target.L),
-          chroma,
-          hueIsMeaningless ? m[7] : String(target.H),
-        ]
+      ? [like(d.L, target.L), chroma, hueIsMeaningless ? d.H : String(target.H)]
       : from
     // `alphaOff` already narrows wantA to a number — it cannot be true otherwise.
     const alphaTo = alphaOff
-      ? m[8].replace(/\/\s*[\d.]+\s*%?/, (seg) =>
+      ? d.tail.replace(/\/\s*[\d.]+\s*%?/, (seg) =>
           seg.includes("%")
             ? `/ ${Number((wantA * 100).toFixed(1))}%`
             : `/ ${Number(wantA.toFixed(3))}`
         )
-      : m[8]
+      : d.tail
 
     findings.push({
       slug,
       line: i + 1,
-      token: m[1],
+      token: d.token,
       from,
       to,
       deltaE: dE,
       colourOff,
-      alpha: alphaOff ? [m[8].trim(), alphaTo.trim()] : null,
+      alpha: alphaOff ? [d.tail.trim(), alphaTo.trim()] : null,
     })
     // Only a changed triple can be propagated — an alpha-only edit has no
     // old→new pair for --sync to search for.
@@ -196,7 +188,7 @@ for (const slug of slugs) {
     if (!fix) return line
     // Preserve the author's spacing so only the numbers move in the diff.
     // Round-tripped by `rebuildDefinition`'s tests — this file has none.
-    return line.replace(m[0], rebuildDefinition(m, to, alphaTo))
+    return line.replace(d.matched, rebuildDefinition(d, to, alphaTo))
   })
 
   if (fix && corrections.length > 0) {

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -270,6 +270,13 @@ console.log(
 // a finding, so it needs its own signal. Anything above zero is left to the
 // coverage line above and the catalogue canary in oklch-sync.test.ts.
 //
+// Know where that split leaves a gap. A PARTIAL regression — the pattern still
+// matching most lines but losing, say, one brand's — prints a lower coverage
+// line here but does not fail; only the canary's ratio assertion turns it into
+// an error, and that runs under `pnpm test`. CI runs both, so the gate is whole
+// there. A local `pnpm audit:oklch --fix` on its own is not: the drop is on
+// screen for a human to notice, and nothing enforces it.
+//
 // Recorded rather than exited on: the preview drift check below parses md with
 // its OWN regex (`oklch-drift.ts`), so it still produces real diagnostics on a
 // run where this pattern is broken. Exiting here would bury them.

--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -264,15 +264,19 @@ console.log(
 )
 
 // A pattern that matches nothing is the one failure this tool cannot express as
-// a finding, so it has to be its own exit path. Anything above zero is left to
-// the coverage line above and the catalogue canary in oklch-sync.test.ts.
-if (coverage.annotated > 0 && coverage.judged === 0) {
+// a finding, so it needs its own signal. Anything above zero is left to the
+// coverage line above and the catalogue canary in oklch-sync.test.ts.
+//
+// Recorded rather than exited on: the preview drift check below parses md with
+// its OWN regex (`oklch-drift.ts`), so it still produces real diagnostics on a
+// run where this pattern is broken. Exiting here would bury them.
+const patternDead = coverage.annotated > 0 && coverage.judged === 0
+if (patternDead) {
   console.error(
     `\nJudged 0 of ${coverage.annotated} annotated definition(s) — ` +
       `OKLCH_DEFINITION is matching nothing. This is a broken pattern, ` +
       `not a clean catalogue.`
   )
-  process.exit(1)
 }
 
 // Reported after the whole catalogue is walked, so the count is the real one —
@@ -324,5 +328,8 @@ if (drift > 0) {
 
 // Report-only mode is a check: non-zero exit lets CI or a pre-commit hook gate on it.
 // An unsynced slug fails in either mode — it means the tree is now half-updated.
+// A dead pattern fails in either mode too: with nothing judged, a `--fix` run
+// that "corrected" nothing is not a success, it is a no-op on a broken tool.
+if (patternDead) process.exit(1)
 if (unsynced.length > 0) process.exit(1)
 if (!fix && (findings.length > 0 || drift > 0)) process.exit(1)

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -102,8 +102,8 @@ function stripYamlComment(value: string): string {
 // hex to sit immediately after the `#` marker, so the two annotation styles the
 // catalog actually uses (`# ≈ #HEX`, `# prose (#HEX)`) were never checked by
 // the authoring gate even though it advertises an OKLCH↔hex comparison.
-// Capture positions come from that pattern: 3/5/7 = L/C/H, 8 = the in-paren
-// tail (alpha), 10 = hex.
+// `matchDefinition` returns the parts by name, so this file never counts
+// capture positions.
 
 /**
  * sRGB hex → Oklch, plus the alpha channel when the hex carries one.

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -3,7 +3,7 @@ import { CATEGORIES } from "./content-types"
 import { auditSourceCitations } from "./source-citations"
 import { ALPHA_TOLERANCE, DELTA_E_TOLERANCE } from "./oklch-tolerance"
 import { deltaE, hexToOklab, lchToOklab, oklabToLch } from "./oklch-convert"
-import { OKLCH_DEFINITION } from "./oklch-sync"
+import { matchDefinition } from "./oklch-sync"
 import type { ServiceDoc } from "./content-types"
 
 // Deterministic validator for design.md drafts — CODEGEN/CI ONLY, never
@@ -169,12 +169,12 @@ function compareOklchToHex(
 }
 
 function oklchHexMismatch(line: string): string | null {
-  const m = line.match(OKLCH_DEFINITION)
-  if (!m) return null
+  const d = matchDefinition(line)
+  if (!d) return null
   return compareOklchToHex(
-    { L: Number(m[3]), C: Number(m[5]), H: Number(m[7]) },
-    m[8],
-    m[10]
+    { L: Number(d.L), C: Number(d.C), H: Number(d.H) },
+    d.tail,
+    d.hex
   )
 }
 

--- a/src/lib/oklch-sync.test.ts
+++ b/src/lib/oklch-sync.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import {
   OKLCH_DEFINITION,
   countDefinitions,
+  rebuildDefinition,
   indexCorrections,
   syncOklchLiterals,
 } from "./oklch-sync"
@@ -277,5 +278,44 @@ describe("catalog OKLCH coverage", () => {
     expect(annotated).toBeGreaterThan(400)
     expect(judged).toBeGreaterThan(400)
     expect(judged / annotated).toBeGreaterThan(0.95)
+  })
+})
+
+// `--fix` rebuilds a definition line from its capture groups so only the numbers
+// move in the diff. That reconstruction lives in `scripts/`, which has no tests
+// at all — a refactor that renumbers or drops the whitespace-preserving groups
+// silently reformats every corrected line and the whole suite stays green.
+// Round-trip is the invariant: rebuilding with the SAME values must be a no-op.
+describe("rebuildDefinition", () => {
+  // The invariant as the caller actually uses it: the match ends at the hex, so
+  // splice the rebuild back over that span and the whole line must be unchanged.
+  const rebuild = (line: string) => {
+    const m = line.match(OKLCH_DEFINITION)
+    if (!m) throw new Error(`not a definition: ${line}`)
+    return line.replace(m[0], rebuildDefinition(m, [m[3], m[5], m[7]], m[8]))
+  }
+
+  it("is byte-identical when the value does not change", () => {
+    const line =
+      "blue-800:  oklch(0.563 0.241 261)   # core Wanted Blue (#0066FF)"
+    expect(rebuild(line)).toBe(line)
+  })
+
+  it("preserves an alpha tail", () => {
+    const line = "border-subtle: oklch(0.556 0.014 271 / 0.08)  # #70737C14"
+    expect(rebuild(line)).toBe(line)
+  })
+
+  it("preserves leading indentation", () => {
+    const line = "  nested-token:  oklch(0.5 0.1 200)   # ≈ #00A0B0"
+    expect(rebuild(line)).toBe(line)
+  })
+
+  it("moves only the numbers when the value changes", () => {
+    const line = "lime-600:   oklch(0.758 0.213 131)   # ≈ #58CF04"
+    const m = line.match(OKLCH_DEFINITION)!
+    expect(
+      line.replace(m[0], rebuildDefinition(m, ["0.756", "0.232", "138"], m[8]))
+    ).toBe("lime-600:   oklch(0.756 0.232 138)   # ≈ #58CF04")
   })
 })

--- a/src/lib/oklch-sync.test.ts
+++ b/src/lib/oklch-sync.test.ts
@@ -2,10 +2,10 @@ import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
-  OKLCH_DEFINITION,
   countDefinitions,
-  rebuildDefinition,
   indexCorrections,
+  matchDefinition,
+  rebuildDefinition,
   syncOklchLiterals,
 } from "./oklch-sync"
 import type { OklchCorrections } from "./oklch-sync"
@@ -125,7 +125,7 @@ describe("syncOklchLiterals", () => {
 // excluded the two annotation styles the catalog actually uses — `# ≈ #HEX` and
 // `# prose (#HEX)`. 102 annotated pairs were being skipped, 66 of them wrong.
 describe("OKLCH_DEFINITION", () => {
-  const hexOf = (line: string) => line.match(OKLCH_DEFINITION)?.[10]
+  const hexOf = (line: string) => matchDefinition(line)?.hex
 
   it("matches the bare `# #hex` form", () => {
     expect(hexOf("gray-5:    oklch(0.985 0 0)          # #FAFAFA")).toBe(
@@ -171,16 +171,18 @@ describe("OKLCH_DEFINITION", () => {
     ).toBeUndefined()
   })
 
-  // audit-oklch.ts reads these positions by index; renumbering them silently
-  // mis-reads every finding.
-  it("keeps the capture positions audit-oklch indexes", () => {
-    const m = "fg-muted:  oklch(0.521 0.018 273 / 0.08)   # ≈ #70737C14".match(
-      OKLCH_DEFINITION
+  // Was an index-position pin (audit-oklch.ts read this match by number). The
+  // contract still matters, but it is now expressed by name — see the
+  // `matchDefinition` suite below, which asserts the same five fields plus the
+  // whitespace parts that nothing used to pin.
+  it("exposes the judged parts by name", () => {
+    const d = matchDefinition(
+      "fg-muted:  oklch(0.521 0.018 273 / 0.08)   # ≈ #70737C14"
     )
-    expect(m?.[1]).toBe("fg-muted")
-    expect([m?.[3], m?.[5], m?.[7]]).toEqual(["0.521", "0.018", "273"])
-    expect(m?.[8]).toBe(" / 0.08")
-    expect(m?.[10]).toBe("#70737C14")
+    expect(d?.token).toBe("fg-muted")
+    expect([d?.L, d?.C, d?.H]).toEqual(["0.521", "0.018", "273"])
+    expect(d?.tail).toBe(" / 0.08")
+    expect(d?.hex).toBe("#70737C14")
   })
 })
 
@@ -223,7 +225,7 @@ describe("indented definitions", () => {
   const indented = "  blue-800:  oklch(0.563 0.232 257)   # ≈ #0066FF"
 
   it("is judged by the audit predicate", () => {
-    expect(indented.match(OKLCH_DEFINITION)?.[10]).toBe("#0066FF")
+    expect(matchDefinition(indented)?.hex).toBe("#0066FF")
   })
 
   it("is skipped by the sync pass", () => {
@@ -269,8 +271,8 @@ describe("catalog OKLCH coverage", () => {
     const dir = join(process.cwd(), "services")
     let annotated = 0
     let judged = 0
-    for (const f of readdirSync(dir).filter((f) => f.endsWith(".md"))) {
-      const c = countDefinitions(readFileSync(join(dir, f), "utf8"))
+    for (const name of readdirSync(dir).filter((f) => f.endsWith(".md"))) {
+      const c = countDefinitions(readFileSync(join(dir, name), "utf8"))
       annotated += c.annotated
       judged += c.judged
     }
@@ -290,9 +292,12 @@ describe("rebuildDefinition", () => {
   // The invariant as the caller actually uses it: the match ends at the hex, so
   // splice the rebuild back over that span and the whole line must be unchanged.
   const rebuild = (line: string) => {
-    const m = line.match(OKLCH_DEFINITION)
-    if (!m) throw new Error(`not a definition: ${line}`)
-    return line.replace(m[0], rebuildDefinition(m, [m[3], m[5], m[7]], m[8]))
+    const d = matchDefinition(line)
+    if (!d) throw new Error(`not a definition: ${line}`)
+    return line.replace(
+      d.matched,
+      rebuildDefinition(d, [d.L, d.C, d.H], d.tail)
+    )
   }
 
   it("is byte-identical when the value does not change", () => {
@@ -313,9 +318,53 @@ describe("rebuildDefinition", () => {
 
   it("moves only the numbers when the value changes", () => {
     const line = "lime-600:   oklch(0.758 0.213 131)   # ≈ #58CF04"
-    const m = line.match(OKLCH_DEFINITION)!
+    const d = matchDefinition(line)!
     expect(
-      line.replace(m[0], rebuildDefinition(m, ["0.756", "0.232", "138"], m[8]))
+      line.replace(
+        d.matched,
+        rebuildDefinition(d, ["0.756", "0.232", "138"], d.tail)
+      )
     ).toBe("lime-600:   oklch(0.756 0.232 138)   # ≈ #58CF04")
+  })
+})
+
+// Positional capture indices were a contract three files read by number, pinned
+// only by one test asserting five of the eleven. The four whitespace groups the
+// `--fix` reconstruction replays were pinned by nothing at all. `matchDefinition`
+// replaces that contract with a typed object so a regex edit is a compile error,
+// not a silent misread.
+describe("matchDefinition", () => {
+  it("names every part of a definition line", () => {
+    const d = matchDefinition(
+      "  fg-muted:  oklch(0.521 0.018 273 / 0.08)   # ≈ #70737C14"
+    )
+    expect(d).not.toBeNull()
+    expect(d!.indent).toBe("  ")
+    expect(d!.token).toBe("fg-muted")
+    expect(d!.L).toBe("0.521")
+    expect(d!.C).toBe("0.018")
+    expect(d!.H).toBe("273")
+    expect(d!.tail).toBe(" / 0.08")
+    expect(d!.hex).toBe("#70737C14")
+    expect(d!.matched).toBe(
+      "  fg-muted:  oklch(0.521 0.018 273 / 0.08)   # ≈ #70737C14"
+    )
+  })
+
+  it("returns null for a line the audit must not judge", () => {
+    expect(
+      matchDefinition(
+        "pink-600: oklch(0.673 0.279 339)  # ≈ #F553DA (mid는 #FF53C0)"
+      )
+    ).toBeNull()
+    expect(matchDefinition("  --derived: oklch(0.5 0 0);")).toBeNull()
+  })
+
+  it("round-trips through rebuildDefinition", () => {
+    const line = "lime-600:   oklch(0.758 0.213 131)   # ≈ #58CF04"
+    const d = matchDefinition(line)!
+    expect(
+      line.replace(d.matched, rebuildDefinition(d, [d.L, d.C, d.H], d.tail))
+    ).toBe(line)
   })
 })

--- a/src/lib/oklch-sync.test.ts
+++ b/src/lib/oklch-sync.test.ts
@@ -1,5 +1,4 @@
 import { readFileSync, readdirSync } from "node:fs"
-import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   applyDefinition,
@@ -269,11 +268,14 @@ describe("countDefinitions", () => {
 // ordinary catalog edits do not trip them — only a collapse does.
 describe("catalog OKLCH coverage", () => {
   it("keeps judging the overwhelming majority of annotated definitions", () => {
-    const dir = join(process.cwd(), "services")
+    // Resolved from this file, not `process.cwd()`, so the canary measures the
+    // catalog wherever vitest is launched from. `token-extractor.test.ts` reads
+    // the same directory the same way.
+    const dir = new URL("../../services/", import.meta.url)
     let annotated = 0
     let judged = 0
     for (const name of readdirSync(dir).filter((f) => f.endsWith(".md"))) {
-      const c = countDefinitions(readFileSync(join(dir, name), "utf8"))
+      const c = countDefinitions(readFileSync(new URL(name, dir), "utf8"))
       annotated += c.annotated
       judged += c.judged
     }

--- a/src/lib/oklch-sync.test.ts
+++ b/src/lib/oklch-sync.test.ts
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
+  applyDefinition,
   countDefinitions,
   indexCorrections,
   matchDefinition,
@@ -294,10 +295,7 @@ describe("rebuildDefinition", () => {
   const rebuild = (line: string) => {
     const d = matchDefinition(line)
     if (!d) throw new Error(`not a definition: ${line}`)
-    return line.replace(
-      d.matched,
-      rebuildDefinition(d, [d.L, d.C, d.H], d.tail)
-    )
+    return applyDefinition(line, d, [d.L, d.C, d.H], d.tail)
   }
 
   it("is byte-identical when the value does not change", () => {
@@ -319,12 +317,9 @@ describe("rebuildDefinition", () => {
   it("moves only the numbers when the value changes", () => {
     const line = "lime-600:   oklch(0.758 0.213 131)   # ≈ #58CF04"
     const d = matchDefinition(line)!
-    expect(
-      line.replace(
-        d.matched,
-        rebuildDefinition(d, ["0.756", "0.232", "138"], d.tail)
-      )
-    ).toBe("lime-600:   oklch(0.756 0.232 138)   # ≈ #58CF04")
+    expect(applyDefinition(line, d, ["0.756", "0.232", "138"], d.tail)).toBe(
+      "lime-600:   oklch(0.756 0.232 138)   # ≈ #58CF04"
+    )
   })
 })
 
@@ -360,11 +355,33 @@ describe("matchDefinition", () => {
     expect(matchDefinition("  --derived: oklch(0.5 0 0);")).toBeNull()
   })
 
-  it("round-trips through rebuildDefinition", () => {
+  it("round-trips through applyDefinition", () => {
     const line = "lime-600:   oklch(0.758 0.213 131)   # ≈ #58CF04"
     const d = matchDefinition(line)!
-    expect(
-      line.replace(d.matched, rebuildDefinition(d, [d.L, d.C, d.H], d.tail))
-    ).toBe(line)
+    expect(applyDefinition(line, d, [d.L, d.C, d.H], d.tail)).toBe(line)
+  })
+})
+
+// `String.replace` with a STRING replacement interprets `$&`, `$$`, `$1` and
+// `$<name>` as substitution patterns. The rebuilt line carries the author's
+// free-form comment verbatim, so a literal `$` in it would corrupt the rewrite.
+// No catalog comment contains one today; the guard costs nothing and this is
+// exactly the line that just shipped an indentation bug.
+describe("rebuildDefinition — replacement safety", () => {
+  it("survives a dollar sign in the comment", () => {
+    const line = "sale-badge: oklch(0.5 0.1 200)   # 세일 $10 배지 (#0066FF)"
+    const d = matchDefinition(line)!
+    expect(applyDefinition(line, d, [d.L, d.C, d.H], d.tail)).toBe(line)
+  })
+
+  // Demonstrates why `applyDefinition` exists rather than leaving the splice to
+  // the caller: the naive string form mangles the very same input.
+  it("would corrupt the line if the splice used a string replacement", () => {
+    const line = "sale-badge: oklch(0.5 0.1 200)   # 세일 $& 배지 (#0066FF)"
+    const d = matchDefinition(line)!
+    const rebuilt = rebuildDefinition(d, [d.L, d.C, d.H], d.tail)
+
+    expect(line.replace(d.matched, rebuilt)).not.toBe(line)
+    expect(applyDefinition(line, d, [d.L, d.C, d.H], d.tail)).toBe(line)
   })
 })

--- a/src/lib/oklch-sync.test.ts
+++ b/src/lib/oklch-sync.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   OKLCH_DEFINITION,
+  countDefinitions,
   indexCorrections,
   syncOklchLiterals,
 } from "./oklch-sync"
@@ -229,5 +232,50 @@ describe("indented definitions", () => {
     )
     expect(text).toBe(indented)
     expect(count).toBe(0)
+  })
+})
+
+// `audit:oklch` cannot distinguish "clean catalog" from "regex matched nothing"
+// — both print `0 token(s) mismatched` and exit 0. That is exactly how 102
+// annotated pairs went unjudged while the gate stayed green. Coverage has to be
+// reported and floored, not inferred from the absence of findings.
+describe("countDefinitions", () => {
+  it("separates annotated definitions from judgeable ones", () => {
+    const text = [
+      "blue-800: oklch(0.563 0.241 261)   # ≈ #0066FF",
+      "pink-600: oklch(0.673 0.279 339)   # ≈ #F553DA (mid는 #FF53C0)",
+      "neutral:  oklch(0.5 0 0)           # 주석에 hex 없음",
+      "  --derived: oklch(0.5 0 0);",
+    ].join("\n")
+
+    expect(countDefinitions(text)).toEqual({ annotated: 2, judged: 1 })
+  })
+
+  it("counts nothing in text with no definitions", () => {
+    expect(countDefinitions("# 제목\n산문 한 줄.")).toEqual({
+      annotated: 0,
+      judged: 0,
+    })
+  })
+})
+
+// Canary over the real catalog: if a regex edit silently stops matching, this
+// fails loudly instead of letting `audit:oklch` report a clean sweep. Floors are
+// deliberately below the 2026-07-26 measurement (474 annotated / 465 judged) so
+// ordinary catalog edits do not trip them — only a collapse does.
+describe("catalog OKLCH coverage", () => {
+  it("keeps judging the overwhelming majority of annotated definitions", () => {
+    const dir = join(process.cwd(), "services")
+    let annotated = 0
+    let judged = 0
+    for (const f of readdirSync(dir).filter((f) => f.endsWith(".md"))) {
+      const c = countDefinitions(readFileSync(join(dir, f), "utf8"))
+      annotated += c.annotated
+      judged += c.judged
+    }
+
+    expect(annotated).toBeGreaterThan(400)
+    expect(judged).toBeGreaterThan(400)
+    expect(judged / annotated).toBeGreaterThan(0.95)
   })
 })

--- a/src/lib/oklch-sync.ts
+++ b/src/lib/oklch-sync.ts
@@ -58,6 +58,30 @@ export const OKLCH_ANNOTATED_DEFINITION =
 /** Any oklch literal, whatever follows the triple (`)`, ` / 30%)`). */
 const OKLCH_LITERAL = /(oklch\(\s*)([\d.]+)(\s+)([\d.]+)(\s+)([\d.]+)(\s*[/)])/g
 
+/**
+ * How many annotated definitions exist, and how many of them the audit can
+ * actually judge.
+ *
+ * `audit:oklch` reports findings, and "no findings" is indistinguishable from
+ * "matched nothing" — same output, same exit code. That ambiguity is not
+ * hypothetical: `OKLCH_DEFINITION` once skipped 102 annotated pairs across
+ * `services/` (66 of them genuinely wrong) while the gate reported a clean
+ * catalog. Coverage has to be counted and asserted, never inferred from silence.
+ */
+export function countDefinitions(text: string): {
+  annotated: number
+  judged: number
+} {
+  let annotated = 0
+  let judged = 0
+  for (const line of text.split(/\r?\n/)) {
+    if (!OKLCH_ANNOTATED_DEFINITION.test(line)) continue
+    annotated++
+    if (OKLCH_DEFINITION.test(line)) judged++
+  }
+  return { annotated, judged }
+}
+
 /** `"0.65 0 0"` → the replacement triple. */
 export type OklchCorrections = Map<string, [string, string, string]>
 

--- a/src/lib/oklch-sync.ts
+++ b/src/lib/oklch-sync.ts
@@ -82,6 +82,32 @@ export function countDefinitions(text: string): {
   return { annotated, judged }
 }
 
+/**
+ * Rebuild a definition line from its own match, swapping in a new triple.
+ *
+ * Every separator the author wrote — indentation, the gap after the colon, the
+ * spaces between L/C/H, the run before the comment — is replayed from the
+ * capture groups so a correction moves the numbers and nothing else. The
+ * invariant is round-trip: rebuilding with the values already on the line must
+ * return that line byte-for-byte.
+ *
+ * This lives here rather than in `scripts/audit-oklch.ts` because `scripts/`
+ * has no test coverage, and an unverified reconstruction quietly reformats
+ * every line it touches.
+ */
+export function rebuildDefinition(
+  m: RegExpMatchArray,
+  triple: [string, string, string],
+  alphaTail: string
+): string {
+  const [indent] = m[0].match(/^\s*/) ?? [""]
+  return (
+    `${indent}${m[1]}:${m[2]}oklch(` +
+    `${triple[0]}${m[4]}${triple[1]}${m[6]}${triple[2]}${alphaTail})` +
+    `${m[9]}${m[10]}`
+  )
+}
+
 /** `"0.65 0 0"` → the replacement triple. */
 export type OklchCorrections = Map<string, [string, string, string]>
 

--- a/src/lib/oklch-sync.ts
+++ b/src/lib/oklch-sync.ts
@@ -158,6 +158,26 @@ export function rebuildDefinition(
   )
 }
 
+/**
+ * Splice a rebuilt definition back over the span it came from.
+ *
+ * The splice is here, not at the call site, because `String.replace` with a
+ * STRING replacement treats `$&`, `$$`, `$1` and `$<name>` as substitution
+ * patterns — and the rebuilt line carries the author's free-form comment
+ * verbatim. A single literal `$` in a comment would silently corrupt the
+ * rewrite. Passing a callback opts out of that parsing entirely, so the only
+ * way to get it wrong is to not use this function.
+ */
+export function applyDefinition(
+  line: string,
+  d: DefinitionMatch,
+  triple: [string, string, string],
+  alphaTail: string
+): string {
+  const rebuilt = rebuildDefinition(d, triple, alphaTail)
+  return line.replace(d.matched, () => rebuilt)
+}
+
 /** `"0.65 0 0"` → the replacement triple. */
 export type OklchCorrections = Map<string, [string, string, string]>
 

--- a/src/lib/oklch-sync.ts
+++ b/src/lib/oklch-sync.ts
@@ -37,7 +37,56 @@
  * triple at 3/5/7, the in-paren tail (alpha) at 8, and the hex at 10.
  */
 export const OKLCH_DEFINITION =
-  /^\s*([a-z][\w-]*):(\s+)oklch\(\s*([\d.]+)(\s+)([\d.]+)(\s+)([\d.]+)([^)]*)\)(\s*#[^#\n]*)(#[0-9a-fA-F]{3,8})\b(?![^\n]*#[0-9a-fA-F]{3,8}\b)/
+  /^(?<indent>\s*)(?<token>[a-z][\w-]*):(?<afterColon>\s+)oklch\(\s*(?<L>[\d.]+)(?<sepLC>\s+)(?<C>[\d.]+)(?<sepCH>\s+)(?<H>[\d.]+)(?<tail>[^)]*)\)(?<comment>\s*#[^#\n]*)(?<hex>#[0-9a-fA-F]{3,8})\b(?![^\n]*#[0-9a-fA-F]{3,8}\b)/
+
+/**
+ * A judged definition line, with every part named.
+ *
+ * The whole point is that nothing downstream counts capture positions. Three
+ * files used to read this match by index — and only five of the eleven groups
+ * were pinned by a test, while the four whitespace groups that `--fix` replays
+ * were pinned by nothing. Renumbering them was a silent misread waiting to
+ * happen; now it is a compile error.
+ */
+export interface DefinitionMatch {
+  /** The matched span. Ends at the hex, so prose after it is left alone. */
+  matched: string
+  indent: string
+  token: string
+  /** Whitespace between `token:` and `oklch(`. */
+  afterColon: string
+  L: string
+  sepLC: string
+  C: string
+  sepCH: string
+  H: string
+  /** Remainder inside the parens — carries ` / alpha` when present. */
+  tail: string
+  /** From the `#` comment marker up to (not including) the hex. */
+  comment: string
+  hex: string
+}
+
+/** Parse one line as a judgeable definition, or `null` when it is not one. */
+export function matchDefinition(line: string): DefinitionMatch | null {
+  const m = line.match(OKLCH_DEFINITION)
+  const g = m?.groups
+  if (!m || !g) return null
+  return {
+    matched: m[0],
+    indent: g.indent,
+    token: g.token,
+    afterColon: g.afterColon,
+    L: g.L,
+    sepLC: g.sepLC,
+    C: g.C,
+    sepCH: g.sepCH,
+    H: g.H,
+    tail: g.tail,
+    comment: g.comment,
+    hex: g.hex,
+  }
+}
 
 /**
  * Any `token: oklch(…)` line whose trailing comment carries a hex — judgeable
@@ -96,15 +145,14 @@ export function countDefinitions(text: string): {
  * every line it touches.
  */
 export function rebuildDefinition(
-  m: RegExpMatchArray,
+  d: DefinitionMatch,
   triple: [string, string, string],
   alphaTail: string
 ): string {
-  const [indent] = m[0].match(/^\s*/) ?? [""]
   return (
-    `${indent}${m[1]}:${m[2]}oklch(` +
-    `${triple[0]}${m[4]}${triple[1]}${m[6]}${triple[2]}${alphaTail})` +
-    `${m[9]}${m[10]}`
+    `${d.indent}${d.token}:${d.afterColon}oklch(` +
+    `${triple[0]}${d.sepLC}${triple[1]}${d.sepCH}${triple[2]}${alphaTail})` +
+    `${d.comment}${d.hex}`
   )
 }
 

--- a/src/lib/oklch-sync.ts
+++ b/src/lib/oklch-sync.ts
@@ -33,8 +33,10 @@
  * all 9 genuinely name two colours (light/dark pairs in codeit and class101,
  * atomic-vs-gradient in wanted). No false skip today.
  *
- * Capture positions are load-bearing — `scripts/audit-oklch.ts` reads the
- * triple at 3/5/7, the in-paren tail (alpha) at 8, and the hex at 10.
+ * Read it through `matchDefinition` rather than by capture index. Three files
+ * used to count positions, and only five of the eleven groups were pinned by a
+ * test — the whitespace groups `--fix` replays were pinned by nothing, so
+ * renumbering them silently reformatted every corrected line.
  */
 export const OKLCH_DEFINITION =
   /^(?<indent>\s*)(?<token>[a-z][\w-]*):(?<afterColon>\s+)oklch\(\s*(?<L>[\d.]+)(?<sepLC>\s+)(?<C>[\d.]+)(?<sepCH>\s+)(?<H>[\d.]+)(?<tail>[^)]*)\)(?<comment>\s*#[^#\n]*)(?<hex>#[0-9a-fA-F]{3,8})\b(?![^\n]*#[0-9a-fA-F]{3,8}\b)/


### PR DESCRIPTION
## 변경 요약

PR #188이 `audit:oklch`의 정규식 사각지대를 고쳤지만 **게이트 자체는 여전히 무음**이었다. 정규식이 0줄을 매칭해도 정상 통과와 출력이 바이트 단위로 같다. 이 PR은 그 무음을 막고, 그 위에서 캡처 위치 결합을 제거한다. 과정에서 **PR #188이 심은 버그 1건**도 나왔다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI  <!-- 검증 스크립트/라이브러리 -->
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

**카탈로그 파일은 한 줄도 바꾸지 않았다.** `services/`·`public/preview/`·사이드카 전부 무변경.

## 1. 게이트가 "깨끗함"과 "아무것도 검사 안 함"을 구분하게 (`f4f52d2`)

`audit:oklch`는 findings만 보고한다. 그래서 **"발견 없음"과 "매칭 0줄"이 같은 출력·같은 종료코드**다. PR #188 이전에 102쌍이 미판정으로 흘러가는 동안 CI가 계속 초록이었던 이유가 이것이고, 정규식을 고친 지금도 **다음에 누가 깨뜨리면 똑같이 조용히 지나간다**.

- `countDefinitions(text)` 추가 — 병기 정의 수와 판정 가능한 수를 함께 센다.
- 요약 앞에 커버리지를 찍는다:
  ```
  465/474 annotated definition(s) judged (9 skipped — comment names more than one hex)
  0 token(s) mismatched
  ```
  스킵 9건은 전부 주석이 두 색을 호명하는 정상 케이스다.
- 판정 수가 0이면 exit 1. "발견 없음"으로는 표현할 수 없는 유일한 실패라 별도 경로가 필요하다.
- 카탈로그 전수 canary 테스트(annotated>400, judged>400, 비율>0.95). 하한은 실측(474/465)보다 낮게 잡아 통상 편집엔 안 걸리고 붕괴만 잡는다.

**가드가 실제로 발동하는지 확인했다.** 정규식을 일부러 깨뜨리자 `0/474 annotated definition(s) judged` + 명시적 에러 + exit 1이 나왔다 — 종전이라면 `0 token(s) mismatched` / exit 0이었을 상황이다.

## 2. `--fix` 재구성 추출 + 들여쓰기 유실 버그 (`bbdf24f`)

`--fix`가 정정된 줄을 캡처 그룹에서 다시 조립하는데, 그 코드가 `scripts/`에 있어 **테스트가 하나도 없었다**. 실제로 버그가 들어 있었다.

**PR #188에서 `OKLCH_DEFINITION`에 `^\s*`를 추가해 들여쓴 정의도 매칭하게 만들었는데, 재구성은 여전히 `${m[1]}:`로 시작했다.** `m[0]`은 선행 공백을 포함하므로 `line.replace(m[0], …)`가 **들여쓰기를 지우고** 토큰을 컬럼 0으로 당긴다. 카탈로그에 현재 들여쓴 정의가 없어 발현되지 않았을 뿐이다.

`rebuildDefinition`을 `src/lib/`로 추출하고 왕복 테스트 4개를 붙였다 — 값이 그대로면 바이트 동일, 알파 꼬리 보존, **들여쓰기 보존**, 값이 바뀌면 숫자만 이동.

## 3. 캡처 위치 결합 제거 (`50dc2a3`) — 리뷰 중점

세 파일이 이 정규식을 **번호로** 읽고 있었다. 이번 브랜치에서 `indent`를 캡처로 승격하자 인덱스가 하나씩 밀렸고, 그게 정확히 이 결합의 위험을 보여준다.

**결합 규모가 문서보다 컸다.** 주석은 `3/5/7/8/10`만 말하지만 `--fix` 재구성이 공백 보존 그룹을 재생하므로 **0~10 전부가 load-bearing**이다. 그런데 테스트가 핀으로 잡던 건 다섯 개뿐이라, 나머지를 건드려도 전 테스트가 통과한다.

- named capture group으로 전환 + `matchDefinition(line): DefinitionMatch | null` 추가. 소비자는 이제 이름으로만 접근하고, **정규식 편집이 컴파일 에러로 드러난다**.
- `scripts/audit-oklch.ts`(11개 인덱스), `src/lib/draft-validator.ts`(5개) 전환.
- 위치 인덱스 테스트는 지우지 않고 이름 기반으로 의미를 옮겼다. 그동안 아무것도 핀으로 잡지 않던 **공백 파트까지** 이제 검사한다.

**건드리지 않은 것**: `OKLCH_ANNOTATED_DEFINITION`(캡처 0개, 소비자가 `.test()` 하나), 모듈 내부 `OKLCH_LITERAL`(`/g` + 8-arg 위치 replacer라 named group 도입 시 타입 시그니처가 조용히 불완전해진다).

## 리뷰어가 알아두면 좋은 것

- **동작 무변경을 두 축으로 확인했다** — 커버리지가 리팩터링 전후 `465/474`로 동일하고, `--fix --sync`를 실제 카탈로그에 돌려 `0 corrected / 0 synced`에 파일 변화 0이다.
- 순서에 이유가 있다. 리팩터링이 정규식을 직접 건드리는 작업인데, 그게 조용히 깨져도 알 방법이 없는 상태였다. **①무음 차단 → ②왕복 테스트 → ③리팩터링** 순으로 안전망을 먼저 깔았다.
- `scripts/`에는 여전히 테스트가 없다. 이번에 `--fix` 재구성만 `src/lib/`로 끌어와 덮었고, 나머지 경로는 그대로다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`) — 3개 커밋 전부
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

추가 게이트: `pnpm test` **289개 통과**(286 → 신규 10 포함) · `validate:catalog` 0 blocking(경고 21건 전부 기존) · `tokens:check` 16개 동기 · `audit:oklch` 0건 · `validate:previews` 0 blocking

<!-- format:check 위반 14건은 전부 `.claude/skills/docs-crawler/` 의 Windows CRLF 오탐이며 이 PR이 건드린 파일이 아님 -->

## 후속

경고 21건 정리는 다음 PR로 분리했다. 조사해 보니 **9건 중 3건은 고치면 안 되는 경고**다 — gmarket 2건은 *"색상 값을 hex로 다시 적지 않는다"*는 Don't 규칙 본문과 미해결 상류 불일치(`#00C400` vs `#00C01E`) 기록이고, toss 1건은 산문이 아니라 `## References` 항목이라 규칙 쪽을 좁히는 게 맞다.

그 뒤로 인용 의미 감사(미검증 12개 파일)가 이어진다. 편중도 순으로 vapor-ui(한 출처가 인용의 96%)·bezier(70%, 게다가 Chromatic 빌드 해시 URL)부터 본다.
