### PR TITLE
feat(home): 카탈로그 목록을 추가순 정렬로 전환 + 갱신은 뱃지로 분리

### DIFF
--- a/.claude/agents/design-md-author.md
+++ b/.claude/agents/design-md-author.md
@@ -41,6 +41,7 @@ design_system_name: {Design System Name} # optional; include only when the publi
 slug: {slug}
 category: {one of: finance, messenger, commerce, delivery, mobility, content, community, travel, gov, developer, education, career, etc}
 last_updated: {today as YYYY-MM-DD}
+created_at: {today as YYYY-MM-DD} # date this entry first lands in the catalog; for a brand-new entry this equals last_updated. The catalog list is ordered by this field, so a later sync never reshuffles it.
 sources: [https://..., https://...]   # from research.md ## Sources — only publicly reachable 2xx URLs. EXCLUDE ephemeral/private handoff-bundle links (e.g. api.anthropic.com/v1/design/h/...) and local .claude/cache/... paths: they 404 for catalog readers. Such a bundle stays a source in ## References by label only (no URL).
 related_services: []                    # leave empty; user fills at checkpoint
 lang: {ko|en}

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -41,7 +41,7 @@ This skill builds a complete catalog entry through a 5-subagent pipeline with on
 Verify the working environment before doing anything user-visible.
 
 1. `Bash`: `pwd` to capture the absolute repo root. Hold this value as `${repo_root}` in your reasoning and substitute it literally into every later Bash command and dispatch prompt that touches a repo path. The shell preserves cwd across calls, but pinning the absolute path makes Stage 8/10/11 robust to any inadvertent `cd`.
-2. `Bash`: `date +%Y-%m-%d` to capture today's date. Hold this value as `${today}` in your reasoning. Stage 6a passes this to the author for the `last_updated` frontmatter field; the project's date validator at `src/lib/content-parser.ts:158-171` rejects any other format.
+2. `Bash`: `date +%Y-%m-%d` to capture today's date. Hold this value as `${today}` in your reasoning. Stage 6a passes this to the author for **both** the `last_updated` and `created_at` frontmatter fields — a brand-new entry is added and last-updated on the same day. The project's date validator at `src/lib/content-parser.ts` rejects any other format, and `missing-created-at` in `src/lib/draft-validator.ts` blocks a draft that omits `created_at`.
 3. `Read` `${repo_root}/package.json`. If `"name"` is not exactly `"ko-design-md"`, abort with: "이 스킬은 ko-design-md 레포 안에서만 동작합니다. 현재 디렉터리: ${repo_root}". Do not proceed.
 4. Verify `${repo_root}/src/lib/content-types.ts` is readable. If not, abort.
 5. `Read` `${repo_root}/src/lib/content-types.ts` and extract the live `CATEGORIES` const. Use this as the source of truth for the intake category picker (do NOT hardcode the enum from memory — it can drift).

--- a/.claude/skills/design-md/references/rubric-design.md
+++ b/.claude/skills/design-md/references/rubric-design.md
@@ -6,10 +6,11 @@ The design-md-reviewer subagent uses this rubric to score `draft.md` against `re
 
 Frontmatter must round-trip through `buildDoc()` in `src/lib/content-parser.ts` without throwing. Concretely:
 
-- All required keys present: `name, slug, category, last_updated, sources, related_services, lang`.
+- All required keys present: `name, slug, category, last_updated, created_at, sources, related_services, lang`.
 - `name` is the Korean company/brand display name. If the design system has a distinct public name, `design_system_name` may be present as an optional string and is not a hard-fail requirement.
 - `category` ∈ `CATEGORIES` const from `src/lib/content-types.ts` (one of: finance, messenger, commerce, delivery, mobility, content, community, travel, gov, developer, education, career, etc).
-- `last_updated` matches `^\d{4}-\d{2}-\d{2}$`. The validator at content-parser.ts:158-171 throws on any other format.
+- `last_updated` matches `^\d{4}-\d{2}-\d{2}$`. The validator in content-parser.ts throws on any other format.
+- `created_at` is present and matches `^\d{4}-\d{2}-\d{2}$` — for a new entry it equals `last_updated`. This is the catalog's ordering key (the list, llms.txt, sitemap and OG build all sort by it), so omitting it is a block, not a nit: the entry would sink to the bottom of the list regardless of when it was added.
 - `sources` is a non-empty array of `https?://` URLs **with no ephemeral/private handoff-bundle links** — no `api.anthropic.com/v1/design/h/...` URL, no local `.claude/cache/...` path. **Every `## References` entry must likewise be an externally-accessible public URL** — label-only / ephemeral placeholder entries are NOT allowed (a source readers cannot open is not a valid source). If a claim's only basis is an ephemeral/private source, drop the citation rather than keeping a label-only entry. Enforced by the `non-public-reference` rule in `src/lib/source-citations.ts` (`pnpm validate:sources`).
 - `slug` matches `^[a-z0-9-]+$` and equals the staging filename stem (e.g. draft.md for slug X has frontmatter `slug: X`).
 - `lang` is exactly `ko` or `en`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## 카탈로그 PR 체크 (해당 시)
 
 - [ ] `/design-md` 스킬로 생성
-- [ ] frontmatter 필수 필드 검증 완료 (`name`, `slug`, `category`, `last_updated`, `sources`, `related_services`, `lang`)
+- [ ] frontmatter 필수 필드 검증 완료 (`name`, `slug`, `category`, `last_updated`, `created_at`, `sources`, `related_services`, `lang`)
 - [ ] `public/preview/{slug}/{light,dark}.html` 생성·확인
 - [ ] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
 - [ ] 브랜드 자산 라이선스/상표 우려 검토 ([NOTICE](https://github.com/CaesiumY/ko-design-md/blob/main/NOTICE) 정책)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@
   - `name` (브랜드 표기명)
   - `slug` (소문자 + 하이픈 + ASCII)
   - `category` ([content-types.ts](./src/lib/content-types.ts)의 `CATEGORIES` enum 중 하나)
-  - `last_updated` (YYYY-MM-DD ISO 형식 — [content-parser.ts:158-171](./src/lib/content-parser.ts)에서 엄격히 검증)
+  - `last_updated` (YYYY-MM-DD ISO 형식 — [content-parser.ts](./src/lib/content-parser.ts)에서 엄격히 검증)
+  - `created_at` (YYYY-MM-DD — 카탈로그에 처음 추가된 날. 신규 항목은 `last_updated`와 같은 값. 메인 목록 정렬 키라 누락 시 `validate:catalog`가 block)
   - `sources` (URL 배열)
   - `related_services` (관련 슬러그 배열, 없으면 `[]`)
   - `lang` (`ko` 또는 `en`)
@@ -116,7 +117,8 @@
 | `slug` | 소문자 + 하이픈 + ASCII. 한글/공백 불가. 브랜드 영문 표기 우선 (`toss`, `kakao-bank`, `daangn`) |
 | `category` | [content-types.ts](./src/lib/content-types.ts)의 `CATEGORIES` enum (`finance`, `messenger`, `commerce`, `delivery`, `mobility`, `content`, `community`, `travel`, `gov`, `developer`, `education`, `career`, `etc`). 모르겠다면 `etc`로 두고 PR에서 토의 |
 | `lang` | 자료가 한국어 위주면 `ko`, 영어 위주면 `en` |
-| `last_updated` | YYYY-MM-DD ISO 형식 (`2026-05-10`) |
+| `last_updated` | YYYY-MM-DD ISO 형식 (`2026-05-10`). 최근 갱신 뱃지와 RSS 순서를 결정 |
+| `created_at` | YYYY-MM-DD ISO 형식. 카탈로그 추가일이며 메인 목록 정렬 키 — 기존 항목을 수정할 때 **바꾸지 말 것** (바꾸면 목록에서 자리가 튄다) |
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -117,7 +117,8 @@
 | `name` | string | 한글 표기 (en 파일은 영문) |
 | `slug` | string | URL 안전, 공통 (한·영 동일) |
 | `category` | enum | `finance` / `messenger` / `commerce` / `delivery` / `mobility` / `content` / `community` / `travel` / `etc` 중 1 |
-| `last_updated` | YYYY-MM-DD | 본문 마지막 갱신일 |
+| `last_updated` | YYYY-MM-DD | 본문 마지막 갱신일. 최근 갱신 뱃지·RSS 순서용 |
+| `created_at` | YYYY-MM-DD | 카탈로그 최초 추가일. 메인 목록·llms.txt·sitemap 정렬 키 |
 | `sources` | URL[] | 공식 발표·테크블로그·참고 자료 |
 | `related_services` | slug[] | 관련 서비스 slug 목록 |
 | `lang` | `ko` \| `en` | 파일 언어 |

--- a/scripts/build-og.ts
+++ b/scripts/build-og.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import { getCategoryStyle } from "../src/lib/category-style"
-import { buildDoc, sortDocs } from "../src/lib/content-parser"
+import { buildDoc, sortDocsByAdded } from "../src/lib/content-parser"
 import { ogLede } from "../src/lib/og-lede"
 import { loadOgLogo } from "../src/og/load-logo"
 import { renderOgPng } from "../src/og/render"
@@ -71,7 +71,7 @@ function collectJobs(): Array<OgJob> {
     .readdirSync(SERVICES_DIR)
     .filter((f) => f.endsWith(".md"))
 
-  const docs = sortDocs(
+  const docs = sortDocsByAdded(
     fileNames.map((fileName) => {
       const fullPath = path.join(SERVICES_DIR, fileName)
       const raw = fs.readFileSync(fullPath, "utf-8")

--- a/services/class101.md
+++ b/services/class101.md
@@ -4,6 +4,7 @@ design_system_name: Vibrant
 slug: class101
 category: education
 last_updated: "2026-07-04"
+created_at: "2026-07-04"
 sources:
   - https://vibrant-design.com/
   - https://vibrant-design.com/docs/theme/colors/color-token/

--- a/services/codeit.md
+++ b/services/codeit.md
@@ -3,6 +3,7 @@ name: 코드잇
 slug: codeit
 category: education
 last_updated: "2026-07-16"
+created_at: "2026-07-16"
 sources:
   - https://design.codeit.com
   - https://www.codeit.kr

--- a/services/kyobobook.md
+++ b/services/kyobobook.md
@@ -4,6 +4,7 @@ design_system_name: Kyobo Design System (KDS)
 slug: kyobobook
 category: commerce
 last_updated: 2026-05-30
+created_at: 2026-05-30
 sources:
   - https://design.kyobobook.co.kr/voice/
   - https://design.kyobobook.co.kr/brand/principle/

--- a/services/yeogi.md
+++ b/services/yeogi.md
@@ -4,6 +4,7 @@ design_system_name: Yeogi Design System
 slug: yeogi
 category: travel
 last_updated: "2026-07-18"
+created_at: "2026-07-18"
 sources:
   - https://designlibrary.yeogi.com/
   - https://designlibrary.yeogi.com/about/mission/

--- a/src/lib/content-collection.test.ts
+++ b/src/lib/content-collection.test.ts
@@ -60,17 +60,6 @@ describe("content-collection", () => {
     expect(outOfOrder).toEqual([])
   })
 
-  it("does not order the catalog by last_updated — that signal belongs to the badge and RSS", () => {
-    // Guards the actual regression this ordering replaced: a bulk content sync
-    // (PR #188 set six entries to the same last_updated) used to hoist those
-    // six to the top and leave the rest sorted by name.
-    const updated = getAllServices().map((doc) => doc.frontmatter.last_updated)
-    const sortedByUpdated = updated.every(
-      (date, i) => i === 0 || updated[i - 1] >= date
-    )
-    expect(sortedByUpdated).toBe(false)
-  })
-
   it("does not import preview HTML through public-directory URLs", () => {
     const source = readFileSync(
       new URL("./content-collection.ts", import.meta.url),

--- a/src/lib/content-collection.test.ts
+++ b/src/lib/content-collection.test.ts
@@ -47,6 +47,30 @@ describe("content-collection", () => {
     expect(doc!.frontmatter.last_updated).toMatch(/^\d{4}-\d{2}-\d{2}$/)
   })
 
+  it("gives every entry a created_at — an empty sort key would sink the entry to the bottom of the list", () => {
+    const missing = getAllServices()
+      .filter((doc) => doc.frontmatter.created_at === "")
+      .map((doc) => doc.frontmatter.slug)
+    expect(missing).toEqual([])
+  })
+
+  it("orders the catalog by created_at descending, so re-syncing an old entry never reshuffles the list", () => {
+    const dates = getAllServices().map((doc) => doc.frontmatter.created_at)
+    const outOfOrder = dates.filter((date, i) => i > 0 && dates[i - 1] < date)
+    expect(outOfOrder).toEqual([])
+  })
+
+  it("does not order the catalog by last_updated — that signal belongs to the badge and RSS", () => {
+    // Guards the actual regression this ordering replaced: a bulk content sync
+    // (PR #188 set six entries to the same last_updated) used to hoist those
+    // six to the top and leave the rest sorted by name.
+    const updated = getAllServices().map((doc) => doc.frontmatter.last_updated)
+    const sortedByUpdated = updated.every(
+      (date, i) => i === 0 || updated[i - 1] >= date
+    )
+    expect(sortedByUpdated).toBe(false)
+  })
+
   it("does not import preview HTML through public-directory URLs", () => {
     const source = readFileSync(
       new URL("./content-collection.ts", import.meta.url),

--- a/src/lib/content-collection.ts
+++ b/src/lib/content-collection.ts
@@ -1,5 +1,5 @@
 import { previewSlugs } from "virtual:preview-slugs"
-import { buildDoc, sortDocs } from "./content-parser"
+import { buildDoc, sortDocsByAdded } from "./content-parser"
 import type { ServiceDoc, ServiceTokens } from "./content-types"
 
 const RAW_MODULES: Record<string, string> = import.meta.glob("/services/*.md", {
@@ -66,7 +66,7 @@ const TOKENS_BY_SLUG = new Map<string, ServiceTokens>(
   ])
 )
 
-const DOCS: Array<ServiceDoc> = sortDocs(
+const DOCS: Array<ServiceDoc> = sortDocsByAdded(
   Object.entries(RAW_MODULES).map(([filePath, raw]) => {
     const doc = buildDoc(filePath, raw)
     const tokens = TOKENS_BY_SLUG.get(doc.frontmatter.slug)

--- a/src/lib/content-parser.test.ts
+++ b/src/lib/content-parser.test.ts
@@ -237,6 +237,30 @@ describe("normalizeDateField", () => {
     expect(() => normalizeDateField("2026-5-7")).toThrow(/ISO/i)
   })
 
+  // The digit pattern alone lets impossible dates through, and they are worse
+  // than a parse error: string-comparing "2026-99-99" pins the entry to the top
+  // of a catalog ordered by created_at.
+  it("rejects an impossible month/day like 2026-99-99", () => {
+    expect(() => normalizeDateField("2026-99-99")).toThrow(/calendar/i)
+  })
+
+  it("rejects a day that does not exist in that month", () => {
+    expect(() => normalizeDateField("2026-02-30")).toThrow(/calendar/i)
+  })
+
+  it("rejects 02-29 in a non-leap year", () => {
+    expect(() => normalizeDateField("2026-02-29")).toThrow(/calendar/i)
+  })
+
+  it("accepts a real leap day", () => {
+    expect(normalizeDateField("2028-02-29")).toBe("2028-02-29")
+  })
+
+  it("accepts the boundary days of a 31-day month", () => {
+    expect(normalizeDateField("2026-01-01")).toBe("2026-01-01")
+    expect(normalizeDateField("2026-12-31")).toBe("2026-12-31")
+  })
+
   it("defaults to naming last_updated in the error", () => {
     expect(() => normalizeDateField("2026/05/07")).toThrow(/last_updated/)
   })

--- a/src/lib/content-parser.test.ts
+++ b/src/lib/content-parser.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, it, vi } from "vitest"
-import { buildDoc, normalizeDateField } from "./content-parser"
+import {
+  buildDoc,
+  normalizeDateField,
+  sortDocsByAdded,
+  sortDocsByUpdated,
+} from "./content-parser"
+import type { ServiceDoc } from "./content-types"
 
 const FILE = "/services/_demo.md"
+
+function makeDoc(
+  name: string,
+  created_at: string,
+  last_updated: string
+): ServiceDoc {
+  const slug = name.toLowerCase().replace(/\s+/g, "-")
+  return {
+    frontmatter: {
+      name,
+      slug,
+      category: "etc",
+      last_updated,
+      created_at,
+      sources: [],
+      related_services: [],
+      lang: "ko",
+    },
+    raw: "",
+    body: "",
+    tagline: "",
+    filePath: `/services/${slug}.md`,
+    estimatedTokens: 0,
+  }
+}
+
+const names = (docs: Array<ServiceDoc>): Array<string> =>
+  docs.map((d) => d.frontmatter.name)
 
 function frontmatter(body: string): string {
   return [
@@ -201,5 +235,84 @@ describe("normalizeDateField", () => {
 
   it("throws on partial ISO strings like 2026-5-7", () => {
     expect(() => normalizeDateField("2026-5-7")).toThrow(/ISO/i)
+  })
+
+  it("defaults to naming last_updated in the error", () => {
+    expect(() => normalizeDateField("2026/05/07")).toThrow(/last_updated/)
+  })
+
+  it("names the offending field so a bad created_at is not misreported as last_updated", () => {
+    expect(() => normalizeDateField("2026/05/07", "", "created_at")).toThrow(
+      /created_at/
+    )
+  })
+})
+
+// The catalog's two orderings are deliberately different signals: the list,
+// llms.txt, sitemap and OG build read "recently added", while RSS reads
+// "recently changed". Keeping them as two named comparators makes the split
+// explicit instead of leaving it to whoever calls sort last.
+describe("sortDocsByAdded", () => {
+  it("orders by created_at descending — newest addition first", () => {
+    const sorted = sortDocsByAdded([
+      makeDoc("Old", "2026-05-09", "2026-05-09"),
+      makeDoc("New", "2026-07-18", "2026-07-18"),
+      makeDoc("Mid", "2026-06-03", "2026-06-03"),
+    ])
+    expect(names(sorted)).toEqual(["New", "Mid", "Old"])
+  })
+
+  it("ignores last_updated — an old entry synced today stays at the bottom", () => {
+    const sorted = sortDocsByAdded([
+      makeDoc("Added recently", "2026-07-18", "2026-07-18"),
+      makeDoc("Added long ago, synced today", "2026-05-09", "2026-07-26"),
+    ])
+    expect(names(sorted)[0]).toBe("Added recently")
+  })
+
+  it("breaks created_at ties on name using Korean collation", () => {
+    const sorted = sortDocsByAdded([
+      makeDoc("나중", "2026-05-14", "2026-05-14"),
+      makeDoc("가나", "2026-05-14", "2026-05-14"),
+    ])
+    expect(names(sorted)).toEqual(["가나", "나중"])
+  })
+
+  it("returns a new array so the shared module-level catalog is never reordered in place", () => {
+    const input = [
+      makeDoc("A", "2026-05-09", "2026-05-09"),
+      makeDoc("B", "2026-07-18", "2026-07-18"),
+    ]
+    const sorted = sortDocsByAdded(input)
+    expect(sorted).not.toBe(input)
+    expect(names(input)).toEqual(["A", "B"])
+  })
+})
+
+describe("sortDocsByUpdated", () => {
+  it("orders by last_updated descending — the RSS feed's own order", () => {
+    const sorted = sortDocsByUpdated([
+      makeDoc("Stale", "2026-05-09", "2026-05-09"),
+      makeDoc("Synced today", "2026-05-10", "2026-07-26"),
+    ])
+    expect(names(sorted)).toEqual(["Synced today", "Stale"])
+  })
+
+  it("ignores created_at — a newly added entry does not jump the feed", () => {
+    const sorted = sortDocsByUpdated([
+      makeDoc("Added today, never synced", "2026-07-18", "2026-07-18"),
+      makeDoc("Added in May, synced last week", "2026-05-09", "2026-07-26"),
+    ])
+    expect(names(sorted)[0]).toBe("Added in May, synced last week")
+  })
+
+  it("returns a new array so the shared module-level catalog is never reordered in place", () => {
+    const input = [
+      makeDoc("A", "2026-05-09", "2026-05-09"),
+      makeDoc("B", "2026-05-10", "2026-07-26"),
+    ]
+    const sorted = sortDocsByUpdated(input)
+    expect(sorted).not.toBe(input)
+    expect(names(input)).toEqual(["A", "B"])
   })
 })

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -157,6 +157,24 @@ export function deriveSlug(
 // throws "Objects are not valid as a React child (found: [object Date])".
 // We also reject non-ISO strings so a typo like `2026/05/07` doesn't quietly
 // produce broken NEW-badge / sort behavior.
+// The digit pattern alone accepts impossible dates (`2026-02-30`, `2026-99-99`),
+// and downstream those are worse than a parse error: the catalog compares
+// created_at as a plain string, so an out-of-range month sorts above every real
+// date and pins the entry to the top of the list. Round-tripping through Date
+// rejects them — JS rolls overflow into the next month/year, so any field that
+// changes was out of range — and gets leap years right for free.
+function isRealIsoDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const [year, month, day] = match.slice(1).map(Number)
+  const parsed = new Date(Date.UTC(year, month - 1, day))
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  )
+}
+
 export function normalizeDateField(
   value: unknown,
   context = "",
@@ -166,9 +184,9 @@ export function normalizeDateField(
   if (value instanceof Date) return value.toISOString().slice(0, 10)
   if (typeof value === "string") {
     if (value === "") return ""
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    if (!isRealIsoDate(value)) {
       throw new Error(
-        `${field} must be ISO YYYY-MM-DD${context ? ` (${context})` : ""}, got "${value}"`
+        `${field} must be a real calendar date in ISO YYYY-MM-DD form${context ? ` (${context})` : ""}, got "${value}"`
       )
     }
     return value

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -163,6 +163,12 @@ export function deriveSlug(
 // date and pins the entry to the top of the list. Round-tripping through Date
 // rejects them — JS rolls overflow into the next month/year, so any field that
 // changes was out of range — and gets leap years right for free.
+//
+// Corner case worth naming: a 0–99 year such as "0099-01-01" is also rejected,
+// but by JS's legacy two-digit-year rule rather than by calendar arithmetic
+// (`Date.UTC(99, …)` means 1999, so the round-trip mismatches). Rejecting is the
+// outcome we want either way — no catalog entry predates the web — but it is not
+// the reason the rest of this function gives, so don't read it as a bug.
 function isRealIsoDate(value: string): boolean {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
   if (!match) return false

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -157,14 +157,18 @@ export function deriveSlug(
 // throws "Objects are not valid as a React child (found: [object Date])".
 // We also reject non-ISO strings so a typo like `2026/05/07` doesn't quietly
 // produce broken NEW-badge / sort behavior.
-export function normalizeDateField(value: unknown, context = ""): string {
+export function normalizeDateField(
+  value: unknown,
+  context = "",
+  field = "last_updated"
+): string {
   if (value === undefined || value === null) return ""
   if (value instanceof Date) return value.toISOString().slice(0, 10)
   if (typeof value === "string") {
     if (value === "") return ""
     if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
       throw new Error(
-        `last_updated must be ISO YYYY-MM-DD${context ? ` (${context})` : ""}, got "${value}"`
+        `${field} must be ISO YYYY-MM-DD${context ? ` (${context})` : ""}, got "${value}"`
       )
     }
     return value
@@ -305,9 +309,7 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
     slug,
     category: fm.category ?? "etc",
     last_updated: normalizeDateField(fm.last_updated, context),
-    created_at: fm.created_at
-      ? normalizeDateField(fm.created_at, context)
-      : undefined,
+    created_at: normalizeDateField(fm.created_at, context, "created_at"),
     sources: ensureStringArray(fm.sources, "sources", context),
     related_services: ensureStringArray(
       fm.related_services,
@@ -336,11 +338,36 @@ export function buildDoc(filePath: string, raw: string): ServiceDoc {
 // ISO 8601 dates (YYYY-MM-DD) sort lexicographically the same as chronologically,
 // so a direct string compare is enough — no need for collation-aware localeCompare.
 // localeCompare is reserved for `name`, where Korean character ordering matters.
-export function sortDocs(docs: Array<ServiceDoc>): Array<ServiceDoc> {
+//
+// Always returns a fresh array: `getAllServices()` hands out the shared
+// module-level catalog, so an in-place sort here would reorder the site globally.
+function sortDocsByDate(
+  docs: Array<ServiceDoc>,
+  key: "created_at" | "last_updated"
+): Array<ServiceDoc> {
   return [...docs].sort((a, b) => {
-    const aDate = a.frontmatter.last_updated
-    const bDate = b.frontmatter.last_updated
+    const aDate = a.frontmatter[key]
+    const bDate = b.frontmatter[key]
     if (aDate !== bDate) return aDate < bDate ? 1 : -1
     return a.frontmatter.name.localeCompare(b.frontmatter.name)
   })
+}
+
+/**
+ * Catalog order: most recently *added* first. This is the site's canonical
+ * ordering — the home list, llms.txt, sitemap and OG build all use it, so a
+ * later content sync never reshuffles the list. Recency of edits is surfaced
+ * separately by the "Updated" badge, which reads `last_updated`.
+ */
+export function sortDocsByAdded(docs: Array<ServiceDoc>): Array<ServiceDoc> {
+  return sortDocsByDate(docs, "created_at")
+}
+
+/**
+ * Feed order: most recently *changed* first. RSS exists to answer "what
+ * changed", and each `<item>`'s pubDate is `last_updated` — ordering by
+ * anything else would contradict the timestamps the feed publishes.
+ */
+export function sortDocsByUpdated(docs: Array<ServiceDoc>): Array<ServiceDoc> {
+  return sortDocsByDate(docs, "last_updated")
 }

--- a/src/lib/content-types.ts
+++ b/src/lib/content-types.ts
@@ -25,13 +25,18 @@ export interface ServiceFrontmatter {
   category: Category
   last_updated: string
   /**
-   * Date the entry first landed in the catalog (ISO YYYY-MM-DD). Optional.
-   * Used by the detail page to show the full lifecycle of an entry
-   * (added + last updated). The list view intentionally ignores it — there
-   * we render only one signal ("recently touched") because a first publish
-   * and a later sync are the same thing from a list-scanning perspective.
+   * Date the entry first landed in the catalog (ISO YYYY-MM-DD).
+   *
+   * This is the catalog's ordering key: the home list, llms.txt, sitemap and
+   * OG build all render in "recently added" order, so re-syncing an old entry
+   * never reshuffles the list. `last_updated` is a separate signal — it drives
+   * the "Updated" badge and the RSS feed's own ordering, nothing else.
+   *
+   * Required. `buildDoc` leaves it "" when absent rather than throwing (so a
+   * malformed contribution can't take the site down), and the
+   * `missing-created-at` rule in draft-validator blocks it in CI.
    */
-  created_at?: string
+  created_at: string
   sources: Array<string>
   related_services: Array<string>
   lang: Lang

--- a/src/lib/design-md-skill-machine-gate.test.ts
+++ b/src/lib/design-md-skill-machine-gate.test.ts
@@ -82,6 +82,30 @@ describe("/design-md machine gates", () => {
     }
   })
 
+  // created_at is the catalog's sort key, but nothing in the pipeline would
+  // notice its absence: an entry missing it still renders, just pinned to the
+  // bottom of the list. Four entries shipped that way before the field became
+  // required (#194), all because the author template never emitted it. These
+  // assertions pin the three places that have to agree.
+  it("wires created_at through the author template, the rubric, and the draft gate", () => {
+    const author = readRepoFile(".claude/agents/design-md-author.md")
+    const skill = readRepoFile(".claude/skills/design-md/SKILL.md")
+    const rubric = readRepoFile(
+      ".claude/skills/design-md/references/rubric-design.md"
+    )
+    const validator = readRepoFile("src/lib/draft-validator.ts")
+
+    // The frontmatter template must emit the field, or every skill-onboarded
+    // entry lands undated.
+    expect(author).toMatch(/^created_at:/m)
+    // Stage 1 must say ${today} feeds created_at, not only last_updated.
+    expect(skill).toContain("created_at")
+    // The reviewer scores against the required-key list, so it must include it.
+    expect(rubric).toMatch(/All required keys present:.*created_at/)
+    // And the deterministic gate must actually block a draft that omits it.
+    expect(validator).toContain("missing-created-at")
+  })
+
   it("sweeps the 976px embed width in Stage 12", () => {
     const skill = readRepoFile(".claude/skills/design-md/SKILL.md")
     expect(skill).toContain("976 (detail-page embed width")

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -183,6 +183,29 @@ describe("validateDraft — frontmatter", () => {
     expect(rulesOf(raw, OPTS, "block")).toContain("missing-created-at")
   })
 
+  it("warns when created_at is after last_updated — an entry cannot be added after it was last synced", () => {
+    const raw = makeDraft().replace(
+      'created_at: "2026-07-03"',
+      'created_at: "2026-07-04"'
+    )
+    expect(rulesOf(raw, OPTS, "warn")).toContain(
+      "created-at-after-last-updated"
+    )
+  })
+
+  it("accepts created_at equal to last_updated — the normal shape for a brand-new entry", () => {
+    expect(rulesOf(makeDraft(), OPTS, "warn")).not.toContain(
+      "created-at-after-last-updated"
+    )
+  })
+
+  it("does not warn on the ordering when either date is absent", () => {
+    const raw = makeDraft().replace('created_at: "2026-07-03"\n', "")
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain(
+      "created-at-after-last-updated"
+    )
+  })
+
   it("blocks a slug that differs from the expected slug", () => {
     const raw = makeDraft().replace("slug: demo", "slug: other")
     expect(rulesOf(raw, OPTS, "block")).toContain("slug-arg-mismatch")

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -30,6 +30,7 @@ function makeDraft(overrides: FixtureOverrides = {}): string {
       "slug: demo",
       "category: finance",
       'last_updated: "2026-07-03"',
+      'created_at: "2026-07-03"',
       "sources:",
       ...SOURCES.map((u) => `  - ${u}`),
       "related_services: []",
@@ -175,6 +176,11 @@ describe("validateDraft — frontmatter", () => {
   it("blocks a missing last_updated", () => {
     const raw = makeDraft().replace('last_updated: "2026-07-03"\n', "")
     expect(rulesOf(raw, OPTS, "block")).toContain("missing-last-updated")
+  })
+
+  it("blocks a missing created_at — it is the catalog's sort key, not decoration", () => {
+    const raw = makeDraft().replace('created_at: "2026-07-03"\n', "")
+    expect(rulesOf(raw, OPTS, "block")).toContain("missing-created-at")
   })
 
   it("blocks a slug that differs from the expected slug", () => {

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -391,6 +391,19 @@ export function validateDraft(
         )
       )
     }
+    // The catalog list, llms.txt, sitemap and OG build are all ordered by
+    // created_at, so an entry without one sinks to the bottom regardless of
+    // when it was actually added. Blocking here is what stops the skill from
+    // shipping another undated entry.
+    if (fm.created_at === "") {
+      issues.push(
+        block(
+          "missing-created-at",
+          "frontmatter",
+          "created_at is missing — set it to the date this entry first lands in the catalog as YYYY-MM-DD (today's date for a new entry)."
+        )
+      )
+    }
     if (fm.sources.length === 0) {
       issues.push(
         block(

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -404,6 +404,24 @@ export function validateDraft(
         )
       )
     }
+    // An entry cannot be added after the last time it was synced. The #194
+    // backfill relied on exactly this invariant to pick created_at for four
+    // undated entries, so encode it rather than leave it in a commit message.
+    // Warn, not block: it flags a likely typo in one of the two dates, and a
+    // genuine historical oddity should not stop a contribution.
+    if (
+      fm.created_at !== "" &&
+      fm.last_updated !== "" &&
+      fm.created_at > fm.last_updated
+    ) {
+      issues.push(
+        warn(
+          "created-at-after-last-updated",
+          "frontmatter",
+          `created_at (${fm.created_at}) is later than last_updated (${fm.last_updated}) — an entry cannot be added after it was last synced. Check which of the two dates is wrong.`
+        )
+      )
+    }
     if (fm.sources.length === 0) {
       issues.push(
         block(

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -16,6 +16,7 @@ function serviceDoc(overrides: {
   name: string
   slug: string
   lastUpdated: string
+  createdAt?: string
   body: string
   tagline?: string
 }): ServiceDoc {
@@ -25,6 +26,7 @@ function serviceDoc(overrides: {
       slug: overrides.slug,
       category: "etc",
       last_updated: overrides.lastUpdated,
+      created_at: overrides.createdAt ?? overrides.lastUpdated,
       sources: [],
       related_services: [],
       lang: "ko",
@@ -367,6 +369,57 @@ describe("buildLlmsTxt with real /services/*.md content", () => {
         /\]\(https:\/\/ko-design\.example\/services\/[^/]+\/llms\.txt\): /
       )
     }
+  })
+})
+
+// The catalog is ordered "recently added" everywhere except here. RSS answers
+// "what changed", and each item already publishes last_updated as its pubDate,
+// so ordering the feed by anything else would contradict its own timestamps.
+describe("feed ordering is independent of catalog ordering", () => {
+  const addedOrder = [
+    serviceDoc({
+      name: "Added last week, never synced",
+      slug: "recent-add",
+      createdAt: "2026-07-18",
+      lastUpdated: "2026-07-18",
+      body: "본문입니다.",
+    }),
+    serviceDoc({
+      name: "Added in May, synced today",
+      slug: "old-add",
+      createdAt: "2026-05-09",
+      lastUpdated: "2026-07-26",
+      body: "본문입니다.",
+    }),
+  ]
+
+  function itemTitles(xml: string): Array<string> {
+    return [...xml.matchAll(/<item>[\s\S]*?<title>([^<]+)<\/title>/g)].map(
+      (m) => m[1]
+    )
+  }
+
+  it("re-sorts RSS items by last_updated even when handed docs in added order", () => {
+    const xml = buildRssXml({ siteUrl: SITE_URL, services: addedOrder })
+    expect(itemTitles(xml)).toEqual([
+      "Added in May, synced today",
+      "Added last week, never synced",
+    ])
+  })
+
+  it("does not mutate the caller's array while re-sorting the feed", () => {
+    buildRssXml({ siteUrl: SITE_URL, services: addedOrder })
+    expect(addedOrder.map((d) => d.frontmatter.slug)).toEqual([
+      "recent-add",
+      "old-add",
+    ])
+  })
+
+  it("leaves llms.txt in the added order it receives, matching the site's list", () => {
+    const txt = buildLlmsTxt({ siteUrl: SITE_URL, services: addedOrder })
+    expect(txt.indexOf("Added last week")).toBeLessThan(
+      txt.indexOf("Added in May")
+    )
   })
 })
 

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -1,4 +1,4 @@
-import { truncateForMeta } from "./content-parser"
+import { sortDocsByUpdated, truncateForMeta } from "./content-parser"
 import type { ServiceDoc } from "./content-types"
 
 const SITE_TITLE = "ko/design.md"
@@ -88,7 +88,11 @@ export function buildSitemapXml({ siteUrl, services }: FeedInput): string {
 export function buildRssXml({ siteUrl, services }: FeedInput): string {
   const origin = normalizeSiteUrl(siteUrl)
   const latest = latestUpdated(services)
-  const items = services.map((doc) => {
+  // Callers hand over the catalog in "recently added" order (see sortDocsByAdded).
+  // A feed must lead with what changed, and every item below publishes
+  // last_updated as its pubDate — so re-sort here rather than relying on the
+  // caller, and keep the invariant local to the builder that owns feed semantics.
+  const items = sortDocsByUpdated(services).map((doc) => {
     const itemUrl = canonicalUrl(origin, `/services/${doc.frontmatter.slug}`)
     const updated = doc.frontmatter.last_updated
     const description = truncateForMeta(

--- a/src/routes/-home/components/service-list-row.test.ts
+++ b/src/routes/-home/components/service-list-row.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from "vitest"
 import {
+  deriveListRowMeta,
   formatServiceListNumber,
+  formatShortDate,
   isRecentServiceUpdate,
 } from "./service-list-row"
+import type { ServiceFrontmatter } from "@/lib/content-types"
+
+function fm(dates: {
+  created_at: string
+  last_updated: string
+}): ServiceFrontmatter {
+  return {
+    name: "데모",
+    slug: "demo",
+    category: "etc",
+    sources: [],
+    related_services: [],
+    lang: "ko",
+    ...dates,
+  }
+}
 
 describe("formatServiceListNumber", () => {
   it("counts backward from the current list length", () => {
@@ -28,5 +46,62 @@ describe("isRecentServiceUpdate", () => {
 
   it("does not treat updates older than one week as recently touched", () => {
     expect(isRecentServiceUpdate("2026-05-07", nowMs)).toBe(false)
+  })
+})
+
+describe("formatShortDate", () => {
+  // The column shows created_at, which spans the catalog's whole history — so
+  // unlike the old last_updated column (always a recent date) it has to carry a
+  // year, or entries added in different years become indistinguishable.
+  it("includes a two-digit year", () => {
+    expect(formatShortDate("2026-05-09")).toBe("26/05/09")
+  })
+
+  it("returns an empty string for a missing date", () => {
+    expect(formatShortDate("")).toBe("")
+  })
+
+  it("passes through anything that is not a three-part ISO date", () => {
+    expect(formatShortDate("2026-05")).toBe("2026-05")
+  })
+})
+
+// The list row reads two different date fields for two independent signals.
+// Keeping the derivation in one named function is what stops them being
+// re-crossed later: the column is "when was this added", the badge is "was
+// this touched recently".
+describe("deriveListRowMeta", () => {
+  const nowMs = Date.UTC(2026, 6, 27) // 2026-07-27
+
+  it("shows the added date in the column, not the updated date", () => {
+    const meta = deriveListRowMeta(
+      fm({ created_at: "2026-05-09", last_updated: "2026-07-26" }),
+      nowMs
+    )
+    expect(meta.date).toBe("26/05/09")
+  })
+
+  it("still badges an entry added long ago but synced this week", () => {
+    const meta = deriveListRowMeta(
+      fm({ created_at: "2026-05-09", last_updated: "2026-07-26" }),
+      nowMs
+    )
+    expect(meta.isUpdated).toBe(true)
+  })
+
+  it("leaves the badge off a recently added entry that has not been touched since", () => {
+    const meta = deriveListRowMeta(
+      fm({ created_at: "2026-07-18", last_updated: "2026-07-18" }),
+      nowMs
+    )
+    expect(meta.isUpdated).toBe(false)
+  })
+
+  it("renders no badge before hydration supplies a reference time", () => {
+    const meta = deriveListRowMeta(
+      fm({ created_at: "2026-07-26", last_updated: "2026-07-26" }),
+      null
+    )
+    expect(meta.isUpdated).toBe(false)
   })
 })

--- a/src/routes/-home/components/service-list-row.tsx
+++ b/src/routes/-home/components/service-list-row.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { ServiceLogo } from "./service-logo"
-import type { ServiceDoc } from "@/lib/content-types"
+import type { ServiceDoc, ServiceFrontmatter } from "@/lib/content-types"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -8,37 +8,44 @@ interface Props {
   index: number
   totalCount: number
   /**
-   * Wall-clock millis used for the NEW-badge cutoff. Pass `null` (or omit)
+   * Wall-clock millis used for the Updated-badge cutoff. Pass `null` (or omit)
    * during SSR / first hydration render so the badge stays off — the parent
    * fills this in via `useEffect` after mount, avoiding hydration mismatch.
    */
   nowMs: number | null
 }
 
-const NEW_WINDOW_DAYS = 7
+const UPDATED_WINDOW_DAYS = 7
 
 function formatTokensCompact(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
   return String(n)
 }
 
-function formatShortDate(iso: string): string {
+/**
+ * Compact `YY/MM/DD`. The column renders `created_at`, which spans the whole
+ * history of the catalog, so the year has to be there — the old `MM/DD` form
+ * was only unambiguous because `last_updated` is always a recent date.
+ */
+export function formatShortDate(iso: string): string {
   if (!iso) return ""
   const parts = iso.split("-")
   if (parts.length !== 3) return iso
-  return `${parts[1]}/${parts[2]}`
+  return `${parts[0].slice(2)}/${parts[1]}/${parts[2]}`
 }
 
 /**
- * Returns true when the catalog entry was touched within the recency window.
- * "Touched" covers both first-time publication and a later content sync — by
- * design we don't try to distinguish the two: a sync IS an update, and a new
- * entry IS the first update. One signal, one badge.
+ * Returns true when the entry's content was synced within the recency window.
+ *
+ * Deliberately keyed off `last_updated` while the list itself is ordered by
+ * `created_at`. The badge is the only place edit-recency surfaces now, so it
+ * has to stay independent of position: an entry added months ago and synced
+ * this week sits low in the list and still earns the badge.
  */
 export function isRecentServiceUpdate(
   iso: string,
   nowMs: number | null,
-  windowDays = NEW_WINDOW_DAYS
+  windowDays = UPDATED_WINDOW_DAYS
 ): boolean {
   if (!iso || nowMs === null) return false
   const updated = new Date(iso)
@@ -55,6 +62,29 @@ export function formatServiceListNumber(
   return String(totalCount - index + 1).padStart(targetLength, "0")
 }
 
+export interface ListRowMeta {
+  /** `YY/MM/DD` of `created_at` — the value the "Added" column renders. */
+  date: string
+  /** Whether `last_updated` falls inside the recency window. */
+  isUpdated: boolean
+}
+
+/**
+ * Derives the row's two date-driven signals from the two distinct frontmatter
+ * fields. Kept as one named function so the pairing stays explicit: the column
+ * answers "when was this added", the badge answers "was this touched recently",
+ * and nothing should quietly re-cross them onto a single field again.
+ */
+export function deriveListRowMeta(
+  frontmatter: ServiceFrontmatter,
+  nowMs: number | null
+): ListRowMeta {
+  return {
+    date: formatShortDate(frontmatter.created_at),
+    isUpdated: isRecentServiceUpdate(frontmatter.last_updated, nowMs),
+  }
+}
+
 function UpdatedBadge({ className }: { className?: string }) {
   return (
     <span
@@ -69,10 +99,9 @@ function UpdatedBadge({ className }: { className?: string }) {
 }
 
 export function ServiceListRow({ doc, index, totalCount, nowMs }: Props) {
-  const { name, slug, logo, last_updated } = doc.frontmatter
+  const { name, slug, logo } = doc.frontmatter
   const tokens = formatTokensCompact(doc.estimatedTokens)
-  const date = formatShortDate(last_updated)
-  const isUpdated = isRecentServiceUpdate(last_updated, nowMs)
+  const { date, isUpdated } = deriveListRowMeta(doc.frontmatter, nowMs)
   const pageNo = formatServiceListNumber(index, totalCount)
 
   return (

--- a/src/routes/-home/hooks/use-filtered-services.test.ts
+++ b/src/routes/-home/hooks/use-filtered-services.test.ts
@@ -12,6 +12,7 @@ function serviceDoc(
       slug: "sample",
       category: "etc",
       last_updated: "2026-05-14",
+      created_at: "2026-05-14",
       sources: [],
       related_services: [],
       lang: "ko",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,9 +31,9 @@ export const Route = createFileRoute("/")({
 function HomePage() {
   const { services } = Route.useLoaderData()
   const filter = useFilteredServices(services)
-  // Decide the NEW-badge reference time only after mount so SSR HTML and the
-  // first hydration render agree (both render no NEW). The badge fades in on
-  // the next paint without a hydration warning.
+  // Decide the Updated-badge reference time only after mount so SSR HTML and
+  // the first hydration render agree (both render no badge). The badge fades
+  // in on the next paint without a hydration warning.
   const [nowMs, setNowMs] = useState<number | null>(null)
   useEffect(() => {
     setNowMs(Date.now())
@@ -105,7 +105,7 @@ function ColumnHeader() {
       <span>Description</span>
       <span></span>
       <span className="text-right">Tokens</span>
-      <span className="text-right">Updated</span>
+      <span className="text-right">Added</span>
     </div>
   )
 }

--- a/src/routes/services/-components/service-meta-bar.test.tsx
+++ b/src/routes/services/-components/service-meta-bar.test.tsx
@@ -17,6 +17,7 @@ function frontmatter(
     slug: "gmarket",
     category: "etc",
     last_updated: "2026-05-14",
+    created_at: "2026-05-14",
     sources: [],
     related_services: [],
     lang: "ko",

--- a/src/routes/services/-components/service-meta.test.tsx
+++ b/src/routes/services/-components/service-meta.test.tsx
@@ -10,6 +10,7 @@ const baseFm: ServiceFrontmatter = {
   slug: "toss",
   category: "finance",
   last_updated: "2026-05-28",
+  created_at: "",
   sources: [],
   related_services: [],
   lang: "ko",
@@ -44,7 +45,9 @@ describe("ServiceMeta", () => {
     expect(screen.getByText(/UPDATED · 2026-05-15/)).toBeTruthy()
   })
 
-  it("omits ADDED entirely when created_at is missing (legacy entries)", () => {
+  // created_at is required and CI blocks an empty one (missing-created-at), but
+  // the detail page still renders defensively rather than printing "ADDED · ".
+  it("omits ADDED entirely when created_at is empty", () => {
     render(<ServiceMeta frontmatter={baseFm} tagline="…" />)
     expect(screen.queryByText(/ADDED/)).toBeNull()
     expect(screen.getByText(/UPDATED · 2026-05-28/)).toBeTruthy()

--- a/src/routes/services/-service-detail-layout.test.tsx
+++ b/src/routes/services/-service-detail-layout.test.tsx
@@ -55,6 +55,7 @@ const doc = {
     slug: "toss",
     category: "finance",
     last_updated: "2026-05-15",
+    created_at: "2026-05-15",
     sources: [],
     related_services: [],
     lang: "ko",


### PR DESCRIPTION
## 변경 요약

메인 목록을 `last_updated` 내림차순이 아니라 **`created_at`(추가일) 내림차순**으로 고정하고, 최신성 정보는 기존 `Updated` 뱃지 하나로만 남깁니다. 정렬과 뱃지가 같은 필드를 보던 중복이 사라지면서 뱃지가 목록 위치와 무관한 독립 신호가 됩니다.

기존 정렬은 사실상 신호가 없는 상태였습니다 — 상위 6건(`baemin`·`gmarket`·`krds`·`line-design-system`·`seed-design`·`wanted`)이 전부 `2026-07-26` **동률**이라(#188 일괄 수정) 이름 가나다순으로 갈리고 있었습니다. `created_at`은 16건 전부 값이 달라 동률이 0건입니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정 — `created_at` 백필 4건 (프론트매터만, 본문 무변경)
- [x] 사이트 코드/UI
- [x] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [x] `/design-md` 스킬

## 주요 변경

**정렬기 분리** — `sortDocs`를 두 개로 나눴습니다.
- `sortDocsByAdded` → 카탈로그 표준 순서 (홈·llms.txt·sitemap·OG)
- `sortDocsByUpdated` → RSS 전용

둘 다 `[...docs].sort()`로 **새 배열을 반환**합니다. `getAllServices()`가 모듈 레벨 `DOCS`의 공유 참조를 그대로 넘기므로, 제자리 정렬은 사이트 전역 순서를 오염시킵니다.

**RSS만 예외로 갱신순 유지** — 각 `<item>`의 `pubDate`가 이미 `last_updated`라, 문서 순서만 추가순으로 바뀌면 피드가 자기 타임스탬프와 모순됩니다. `buildRssXml` 내부에서 재정렬해 호출자와 무관하게 불변식을 보장합니다.

**날짜 컬럼 `Updated` → `Added`** — 보이는 날짜가 정렬 키와 일치해야 목록이 "정렬된 것"으로 읽힙니다. 컬럼이 카탈로그 전 역사를 훑게 되므로 `formatShortDate`에 연도를 추가했습니다 (`05/09` → `26/05/09`). 현재 시각에 의존하지 않아 하이드레이션 불일치 위험이 없습니다.

**뱃지 로직은 무변경** — 계속 `last_updated` 7일 윈도우입니다. 다만 어느 필드가 어느 신호를 먹이는지를 `deriveListRowMeta`로 이름 붙여 고정했습니다.

**`created_at` 필수화 + 게이트** — 타입에서 optional 제거, `draft-validator`에 `missing-created-at` 블록 룰 추가, 그리고 **누락의 근본 원인이던 `design-md-author.md` 프론트매터 템플릿에 필드 추가**.

## 리뷰어가 알아야 할 것

**1. git 최초 커밋일로 백필하지 않았습니다.** 누락 4건 모두 `last_updated`가 git add보다 1~2일 **앞섭니다** (스킬이 작성 시점 날짜를 찍고 PR은 이틀 뒤 머지).

| 파일 | git add | last_updated | 채택한 `created_at` |
|---|---|---|---|
| class101 | 07-06 | 07-04 | `2026-07-04` |
| codeit | 07-18 | 07-16 | `2026-07-16` |
| kyobobook | 05-31 | 05-30 | `2026-05-30` |
| yeogi | 07-18 | 07-18 | `2026-07-18` |

git 날짜를 그대로 썼다면 3건이 `created_at > last_updated`가 되어 "갱신일보다 나중에 추가된" 모순이 생깁니다. 기존 12건은 전부 `created_at ≤ last_updated`를 지키므로 `min(git_add, last_updated)`를 적용했습니다. 이 4건은 랜딩 이후 갱신된 적이 없어(`last_updated < git_add`가 증거) 추가일과 갱신일이 같은 작성일입니다.

**2. `.claude/skills/design-md/` 를 건드립니다.** CLAUDE.md는 이 디렉터리 변경을 "이슈에서 사전 합의" 대상으로 규정합니다 — 사전 이슈 없이 올렸으니 필요하면 분리해 주세요. 계약 테스트(`design-md-skill-*.test.ts`)는 날짜 필드를 검사하지 않아 영향 없습니다.

**3. 외부 출력 순서가 바뀝니다.** `llms.txt`·`sitemap.xml`·OG 빌드 순서가 추가순으로 변경됩니다 (RSS는 그대로). sitemap은 순서가 무의미하고, llms.txt는 사이트와 일치하는 편이 옳다고 판단했습니다.

**4. 낡은 주석 2곳을 재작성했습니다.** `content-types.ts`의 *"The list view intentionally ignores it"* 과 `service-list-row.tsx`의 *"One signal, one badge"* 는 정확히 반대 결정을 문서화하고 있어서, 코드만 고치면 거짓 주석이 됩니다.

## 검증

TDD로 진행했습니다 — 신규 테스트 22건 전부 RED 확인 후 구현했습니다.

| 게이트 | 결과 |
|---|---|
| `pnpm typecheck && pnpm lint && pnpm build` | 통과 |
| `pnpm test` | **310 passed (26 files)** |
| `pnpm validate:catalog` | 16파일 **0 blocking** (warn 21건은 기존) |
| `pnpm tokens:check` | 16 sidecar in sync |
| `pnpm audit:oklch` | 0 mismatched |
| `prettier --check` (게이트 대상 ts·tsx) | 통과 |

**새 룰 음성 대조** — `created_at`을 제거한 실제 초안으로:
```
FAIL no-created-at.md  (1 block, 0 warn)
  BLOCK [missing-created-at] (frontmatter) created_at is missing — ...
```

**브라우저 실측 (dev 서버)**
- 순서: `여기어때(26/07/18) → 코드잇 → 클래스101 → 채널톡 → 교보문고 → 11번가 → 라인 → 지마켓 → 쏘카 → 배달의민족 → 당근 → 팀스파르타 → 원티드 → 토스 → 구름 → KRDS(26/05/09)` — 날짜 단조 감소
- 뱃지: 라인·지마켓·배달의민족·당근·원티드·**KRDS**(최하단)에 표시, **최상단 여기어때에는 미표시** → 정렬과 뱃지가 분리됐다는 직접 증거
- 1440 / 1024 / 375px 전부 가로 오버플로우 0, `Added` 셀 72px 정확히 수용
- 콘솔 하이드레이션 경고 없음
- 피드 분기 확인: RSS 첫 항목 **당근**(갱신순) ≠ 홈·llms.txt 첫 항목 **여기어때**(추가순)

## 리뷰 반영 (초기 제출 이후)

Codex·Claude 리뷰를 받아 아래를 추가했습니다. 정렬·뱃지라는 PR의 본래 동작은 바뀌지 않았습니다.

- **불가능한 달력 날짜 차단** (`81d70cc`) — `normalizeDateField`가 자릿수 패턴만 봐서 `created_at: 2026-99-99`가 `validate:draft`를 통과했고, 문자열 비교라 목록 최상단에 고정됐습니다. `Date` 왕복 검증으로 막고 윤년 경계까지 테스트했습니다.
- **스킬 배선 계약 테스트** (`81d70cc`) — author 템플릿·rubric 필수키·validator 룰 세 곳이 어긋나면 실패합니다. CLAUDE.md가 요구하는 "스킬 프롬프트 수정 시 계약 테스트 동반 갱신"이 최초 커밋에서 빠져 있었습니다.
- **취약한 데이터 단언 제거** (`81d70cc`) — 라이브 카탈로그가 `last_updated` 내림차순이 "아님"을 요구하던 테스트는 코드가 아니라 픽스처의 성질을 검사하는 것이라 삭제했습니다.
- **2자리 연도 코너 케이스 주석** (`1adf5ff`) — 동작 변경 없음.
- **`created_at > last_updated` warn 룰** (`eff4d23`) — 위 백필 표의 판단 근거를 코드로 옮겼습니다. 현재 16건에서 발동 0건이고, git 최초 커밋일을 썼을 경우를 재현하면 정확히 걸립니다.

## 카탈로그 PR 체크 (해당 시)

- [ ] `/design-md` 스킬로 생성 — N/A (새 항목 아님)
- [x] frontmatter 필수 필드 검증 완료 (`validate:catalog` 0 blocking)
- [ ] `public/preview/{slug}/{light,dark}.html` 생성·확인 — N/A (프리뷰 무변경)
- [ ] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치 — N/A (본문·sources 무변경)
- [ ] 브랜드 자산 라이선스/상표 우려 검토 — N/A (자산 무변경)
- [x] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

<!-- 없음 -->

