### PR TITLE
fix(catalog): vapor-ui·bezier 인용 의미 감사 — 값 대조 후 결함 명시

### DIFF
--- a/public/preview/bezier/dark.html
+++ b/public/preview/bezier/dark.html
@@ -537,7 +537,7 @@
         </div>
         <span class="hero-eyebrow"><span class="ic s16" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M20.723 18.19c-.166-.496-.147-1.046.1-1.507 1.038-1.949 1.458-4.274.964-6.729-.805-4-4.094-7.165-8.123-7.817A10.013 10.013 0 0 0 2.13 13.675c.653 4.028 3.817 7.316 7.818 8.121 2.456.494 4.782.072 6.731-.967.46-.245 1.003-.264 1.496-.1l1.923.641a1 1 0 0 0 1.264-1.265z" clip-rule="evenodd"></path></svg></span>오픈소스 React 디자인 시스템</span>
         <h1>대화로 매출을 만드는 인디고-바이올렛 시스템</h1>
-        <p class="hero-lede">채널톡을 만드는 채널코퍼레이션의 Bezier는 컴포넌트 59종, 아이콘 598개, 토큰 450개를 한 모노레포로 묶은 풀 디자인 시스템이에요. 어두운 grey-900 표면 위에 단 하나의 인디고 액센트(<b style="color:var(--c-blue-300)">#6157ea</b>)와 부드러운 스쿼클 코너로 제품의 결을 맞춰요.</p>
+        <p class="hero-lede">채널톡을 만드는 채널코퍼레이션의 Bezier는 컴포넌트 59종, 아이콘 602개, 토큰 450개를 한 모노레포로 묶은 풀 디자인 시스템이에요. 어두운 grey-900 표면 위에 단 하나의 인디고 액센트(<b style="color:var(--c-blue-300)">#6157ea</b>)와 부드러운 스쿼클 코너로 제품의 결을 맞춰요.</p>
         <div class="hero-cta">
           <button class="btn pri l"><span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3.505 5.598c-.823-2.207 1.542-4.25 3.606-3.113l13.642 7.518c1.773.977 1.746 3.535-.047 4.475L6.91 21.708C4.823 22.8 2.501 20.71 3.37 18.52l2.08-5.241.06-.152q.043.005.087.006l8.692-.009a1 1 0 0 0 .019-2l-8.693.01h-.03l-.11-.253z"></path></svg></span>상담 시작하기</button>
           <button class="btn sec l">컴포넌트 둘러보기</button>
@@ -567,7 +567,7 @@
 
     <div class="hero-stats">
       <div class="stat"><p class="k">Components</p><p class="v">59종</p></div>
-      <div class="stat"><p class="k">Icons</p><p class="v">598개</p></div>
+      <div class="stat"><p class="k">Icons</p><p class="v">602개</p></div>
       <div class="stat"><p class="k">Primary</p><p class="v">#6157ea</p></div>
       <div class="stat"><p class="k">License</p><p class="v">Apache-2.0</p></div>
     </div>
@@ -878,7 +878,7 @@
           </div>
         </div>
         <div class="cell span2">
-          <span class="cell-name">Icon<span class="var">598 SVG · 24×24 · currentColor · outline + -filled</span></span>
+          <span class="cell-name">Icon<span class="var">602 SVG · 24×24 · currentColor · outline + -filled</span></span>
           <div class="cell-body icon-cell">
             <span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M20.723 18.19c-.166-.496-.147-1.046.1-1.507 1.038-1.949 1.458-4.274.964-6.729-.805-4-4.094-7.165-8.123-7.817A10.013 10.013 0 0 0 2.13 13.675c.653 4.028 3.817 7.316 7.818 8.121 2.456.494 4.782.072 6.731-.967.46-.245 1.003-.264 1.496-.1l1.923.641a1 1 0 0 0 1.264-1.265z" clip-rule="evenodd"></path></svg></span>
             <span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3.505 5.598c-.823-2.207 1.542-4.25 3.606-3.113l13.642 7.518c1.773.977 1.746 3.535-.047 4.475L6.91 21.708C4.823 22.8 2.501 20.71 3.37 18.52l2.08-5.241.06-.152q.043.005.087.006l8.692-.009a1 1 0 0 0 .019-2l-8.693.01h-.03l-.11-.253z"></path></svg></span>
@@ -1072,7 +1072,7 @@
     </div>
     <div>
       <h4>Packages</h4>
-      <a>@channel.io/bezier-react</a><a>@channel.io/bezier-tokens 0.6.0</a><a>@channel.io/bezier-icons 0.59.0</a>
+      <a>@channel.io/bezier-react</a><a>@channel.io/bezier-tokens 0.6.0</a><a>@channel.io/bezier-icons 0.60.0</a>
     </div>
     <div>
       <h4>License</h4>

--- a/public/preview/bezier/light.html
+++ b/public/preview/bezier/light.html
@@ -535,7 +535,7 @@
         </div>
         <span class="hero-eyebrow"><span class="ic s16" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M20.723 18.19c-.166-.496-.147-1.046.1-1.507 1.038-1.949 1.458-4.274.964-6.729-.805-4-4.094-7.165-8.123-7.817A10.013 10.013 0 0 0 2.13 13.675c.653 4.028 3.817 7.316 7.818 8.121 2.456.494 4.782.072 6.731-.967.46-.245 1.003-.264 1.496-.1l1.923.641a1 1 0 0 0 1.264-1.265z" clip-rule="evenodd"></path></svg></span>오픈소스 React 디자인 시스템</span>
         <h1>대화로 매출을 만드는 인디고-바이올렛 시스템</h1>
-        <p class="hero-lede">채널톡을 만드는 채널코퍼레이션의 Bezier는 컴포넌트 59종, 아이콘 598개, 토큰 450개를 한 모노레포로 묶은 풀 디자인 시스템이에요. 밝고 깨끗한 표면 위에 단 하나의 인디고 액센트(<b style="color:var(--c-blue-500)">#6157ea</b>)와 부드러운 스쿼클 코너로 제품의 결을 맞춰요.</p>
+        <p class="hero-lede">채널톡을 만드는 채널코퍼레이션의 Bezier는 컴포넌트 59종, 아이콘 602개, 토큰 450개를 한 모노레포로 묶은 풀 디자인 시스템이에요. 밝고 깨끗한 표면 위에 단 하나의 인디고 액센트(<b style="color:var(--c-blue-500)">#6157ea</b>)와 부드러운 스쿼클 코너로 제품의 결을 맞춰요.</p>
         <div class="hero-cta">
           <button class="btn pri l"><span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3.505 5.598c-.823-2.207 1.542-4.25 3.606-3.113l13.642 7.518c1.773.977 1.746 3.535-.047 4.475L6.91 21.708C4.823 22.8 2.501 20.71 3.37 18.52l2.08-5.241.06-.152q.043.005.087.006l8.692-.009a1 1 0 0 0 .019-2l-8.693.01h-.03l-.11-.253z"></path></svg></span>상담 시작하기</button>
           <button class="btn sec l">컴포넌트 둘러보기</button>
@@ -565,7 +565,7 @@
 
     <div class="hero-stats">
       <div class="stat"><p class="k">Components</p><p class="v">59종</p></div>
-      <div class="stat"><p class="k">Icons</p><p class="v">598개</p></div>
+      <div class="stat"><p class="k">Icons</p><p class="v">602개</p></div>
       <div class="stat"><p class="k">Primary</p><p class="v">#6157ea</p></div>
       <div class="stat"><p class="k">License</p><p class="v">Apache-2.0</p></div>
     </div>
@@ -876,7 +876,7 @@
           </div>
         </div>
         <div class="cell span2">
-          <span class="cell-name">Icon<span class="var">598 SVG · 24×24 · currentColor · outline + -filled</span></span>
+          <span class="cell-name">Icon<span class="var">602 SVG · 24×24 · currentColor · outline + -filled</span></span>
           <div class="cell-body icon-cell">
             <span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M20.723 18.19c-.166-.496-.147-1.046.1-1.507 1.038-1.949 1.458-4.274.964-6.729-.805-4-4.094-7.165-8.123-7.817A10.013 10.013 0 0 0 2.13 13.675c.653 4.028 3.817 7.316 7.818 8.121 2.456.494 4.782.072 6.731-.967.46-.245 1.003-.264 1.496-.1l1.923.641a1 1 0 0 0 1.264-1.265z" clip-rule="evenodd"></path></svg></span>
             <span class="ic" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3.505 5.598c-.823-2.207 1.542-4.25 3.606-3.113l13.642 7.518c1.773.977 1.746 3.535-.047 4.475L6.91 21.708C4.823 22.8 2.501 20.71 3.37 18.52l2.08-5.241.06-.152q.043.005.087.006l8.692-.009a1 1 0 0 0 .019-2l-8.693.01h-.03l-.11-.253z"></path></svg></span>
@@ -1070,7 +1070,7 @@
     </div>
     <div>
       <h4>Packages</h4>
-      <a>@channel.io/bezier-react</a><a>@channel.io/bezier-tokens 0.6.0</a><a>@channel.io/bezier-icons 0.59.0</a>
+      <a>@channel.io/bezier-react</a><a>@channel.io/bezier-tokens 0.6.0</a><a>@channel.io/bezier-icons 0.60.0</a>
     </div>
     <div>
       <h4>License</h4>

--- a/public/preview/vapor-ui/dark.html
+++ b/public/preview/vapor-ui/dark.html
@@ -9,59 +9,59 @@
 <style>
   [data-theme="dark"] {
     /* Vapor UI base palette — Gray (동일 raw 값) */
-    --vp-gray-050: oklch(0.984 0.000 0);
-    --vp-gray-100: oklch(0.972 0.000 0);
-    --vp-gray-200: oklch(0.892 0.000 0);
-    --vp-gray-300: oklch(0.804 0.000 0);
-    --vp-gray-400: oklch(0.712 0.000 0);
-    --vp-gray-500: oklch(0.658 0.000 0);
-    --vp-gray-600: oklch(0.453 0.000 0);
-    --vp-gray-700: oklch(0.314 0.000 0);
-    --vp-gray-800: oklch(0.234 0.000 0);
-    --vp-gray-900: oklch(0.169 0.000 0);
+    --vp-gray-050: oklch(0.976 0.000 0);
+    --vp-gray-100: oklch(0.910 0.000 0);
+    --vp-gray-200: oklch(0.827 0.000 0);
+    --vp-gray-300: oklch(0.715 0.000 0);
+    --vp-gray-400: oklch(0.670 0.000 0);
+    --vp-gray-500: oklch(0.566 0.000 0);
+    --vp-gray-600: oklch(0.478 0.000 0);
+    --vp-gray-700: oklch(0.417 0.000 0);
+    --vp-gray-800: oklch(0.345 0.000 0);
+    --vp-gray-900: oklch(0.269 0.000 0);
 
     /* Blue family */
-    --vp-blue-050: oklch(0.974 0.018 254);
-    --vp-blue-100: oklch(0.901 0.052 254);
-    --vp-blue-200: oklch(0.781 0.110 264);
-    --vp-blue-300: oklch(0.690 0.146 261);
-    --vp-blue-400: oklch(0.638 0.166 258);
-    --vp-blue-500: oklch(0.581 0.181 254);
-    --vp-blue-600: oklch(0.560 0.196 257);
-    --vp-blue-700: oklch(0.451 0.166 259);
-    --vp-blue-800: oklch(0.348 0.142 263);
-    --vp-blue-900: oklch(0.232 0.156 270);
+    --vp-blue-050: oklch(0.974 0.013 241);
+    --vp-blue-100: oklch(0.910 0.048 242);
+    --vp-blue-200: oklch(0.824 0.096 243);
+    --vp-blue-300: oklch(0.715 0.142 248);
+    --vp-blue-400: oklch(0.669 0.158 252);
+    --vp-blue-500: oklch(0.573 0.189 260);
+    --vp-blue-600: oklch(0.488 0.189 260);
+    --vp-blue-700: oklch(0.428 0.187 261);
+    --vp-blue-800: oklch(0.358 0.185 263);
+    --vp-blue-900: oklch(0.289 0.184 264);
 
     /* Status colors */
-    --vp-green-100: oklch(0.913 0.075 154);
-    --vp-green-200: oklch(0.831 0.117 153);
-    --vp-green-300: oklch(0.726 0.158 151);
-    --vp-green-400: oklch(0.652 0.157 154);
-    --vp-green-500: oklch(0.566 0.114 167);
-    --vp-green-600: oklch(0.467 0.094 169);
-    --vp-green-700: oklch(0.376 0.075 169);
+    --vp-green-100: oklch(0.903 0.058 167);
+    --vp-green-200: oklch(0.814 0.109 167);
+    --vp-green-300: oklch(0.704 0.120 167);
+    --vp-green-400: oklch(0.655 0.117 167);
+    --vp-green-500: oklch(0.554 0.112 167);
+    --vp-green-600: oklch(0.470 0.101 164);
+    --vp-green-700: oklch(0.407 0.090 162);
 
-    --vp-orange-100: oklch(0.872 0.072 32);
-    --vp-orange-200: oklch(0.778 0.131 34);
-    --vp-orange-300: oklch(0.703 0.166 36);
-    --vp-orange-400: oklch(0.628 0.190 38);
-    --vp-orange-500: oklch(0.557 0.179 38);
+    --vp-orange-100: oklch(0.913 0.048 46);
+    --vp-orange-200: oklch(0.836 0.092 46);
+    --vp-orange-300: oklch(0.731 0.151 46);
+    --vp-orange-400: oklch(0.685 0.177 46);
+    --vp-orange-500: oklch(0.588 0.187 39);
 
-    --vp-red-100: oklch(0.881 0.057 18);
-    --vp-red-200: oklch(0.795 0.115 18);
-    --vp-red-300: oklch(0.687 0.180 19);
-    --vp-red-400: oklch(0.638 0.213 19);
-    --vp-red-500: oklch(0.577 0.198 21);
-    --vp-red-600: oklch(0.488 0.181 22);
-    --vp-red-700: oklch(0.405 0.181 25);
+    --vp-red-100: oklch(0.915 0.044 20);
+    --vp-red-200: oklch(0.838 0.089 20);
+    --vp-red-300: oklch(0.736 0.155 21);
+    --vp-red-400: oklch(0.691 0.183 20);
+    --vp-red-500: oklch(0.591 0.197 22);
+    --vp-red-600: oklch(0.505 0.196 24);
+    --vp-red-700: oklch(0.439 0.180 28);
 
-    --vp-violet-300: oklch(0.560 0.270 295);
+    --vp-violet-300: oklch(0.733 0.152 299);
 
     /* Custom dark soft backgrounds (시맨틱 alias의 ~-100이 다크 모드에서 가져가는 custom dark) */
-    --vp-bg-primary-100-dark: oklch(0.232 0.156 270 / 0.65);
-    --vp-bg-success-100-dark: oklch(0.246 0.057 168 / 0.65);
-    --vp-bg-warning-100-dark: oklch(0.300 0.119 41 / 0.65);
-    --vp-bg-danger-100-dark:  oklch(0.255 0.144 28 / 0.65);
+    --vp-bg-primary-100-dark: oklch(0.289 0.184 264 / 0.65);
+    --vp-bg-success-100-dark: oklch(0.264 0.069 152 / 0.65);
+    --vp-bg-warning-100-dark: oklch(0.285 0.117 29 / 0.65);
+    --vp-bg-danger-100-dark:  oklch(0.287 0.118 29 / 0.65);
 
     /* === Semantic alias — dark theme === */
     --vp-bg-canvas: var(--vp-gray-900);
@@ -104,8 +104,8 @@
     --vp-border-contrast: var(--vp-gray-200);
 
     /* Focus ring tint (state ring) — dark, primary lightness bumped */
-    --vp-ring-primary: oklch(0.638 0.166 258 / .25);
-    --vp-ring-danger: oklch(0.638 0.213 19 / .25);
+    --vp-ring-primary: oklch(0.669 0.158 252 / .25);
+    --vp-ring-danger: oklch(0.691 0.183 20 / .25);
     /* Scrim — Vapor 고정값 */
     --vp-scrim: oklch(0 0 0 / .4);
 
@@ -127,7 +127,7 @@
     --primary-foreground: oklch(1 0 0);
     --muted: var(--vp-gray-800);
     --muted-foreground: var(--vp-gray-400);
-    --accent: oklch(0.232 0.156 270);
+    --accent: oklch(0.289 0.184 264);
     --accent-foreground: var(--vp-blue-300);
     --border: var(--vp-gray-700);
     --rule-strong: var(--vp-gray-700);

--- a/public/preview/vapor-ui/light.html
+++ b/public/preview/vapor-ui/light.html
@@ -9,46 +9,46 @@
 <style>
   :root {
     /* Vapor UI base palette — Gray */
-    --vp-gray-050: oklch(0.984 0.000 0);
-    --vp-gray-100: oklch(0.972 0.000 0);
-    --vp-gray-200: oklch(0.892 0.000 0);
-    --vp-gray-300: oklch(0.804 0.000 0);
-    --vp-gray-400: oklch(0.712 0.000 0);
-    --vp-gray-500: oklch(0.658 0.000 0);
-    --vp-gray-600: oklch(0.453 0.000 0);
-    --vp-gray-700: oklch(0.314 0.000 0);
-    --vp-gray-800: oklch(0.234 0.000 0);
-    --vp-gray-900: oklch(0.169 0.000 0);
+    --vp-gray-050: oklch(0.976 0.000 0);
+    --vp-gray-100: oklch(0.910 0.000 0);
+    --vp-gray-200: oklch(0.827 0.000 0);
+    --vp-gray-300: oklch(0.715 0.000 0);
+    --vp-gray-400: oklch(0.670 0.000 0);
+    --vp-gray-500: oklch(0.566 0.000 0);
+    --vp-gray-600: oklch(0.478 0.000 0);
+    --vp-gray-700: oklch(0.417 0.000 0);
+    --vp-gray-800: oklch(0.345 0.000 0);
+    --vp-gray-900: oklch(0.269 0.000 0);
 
     /* Vapor UI base palette — Blue (브랜드 primary) */
-    --vp-blue-050: oklch(0.974 0.018 254);
-    --vp-blue-100: oklch(0.901 0.052 254);
-    --vp-blue-200: oklch(0.781 0.110 264);
-    --vp-blue-300: oklch(0.690 0.146 261);
-    --vp-blue-400: oklch(0.638 0.166 258);
-    --vp-blue-500: oklch(0.581 0.181 254);
-    --vp-blue-600: oklch(0.560 0.196 257);
-    --vp-blue-700: oklch(0.451 0.166 259);
-    --vp-blue-800: oklch(0.348 0.142 263);
-    --vp-blue-900: oklch(0.232 0.156 270);
+    --vp-blue-050: oklch(0.974 0.013 241);
+    --vp-blue-100: oklch(0.910 0.048 242);
+    --vp-blue-200: oklch(0.824 0.096 243);
+    --vp-blue-300: oklch(0.715 0.142 248);
+    --vp-blue-400: oklch(0.669 0.158 252);
+    --vp-blue-500: oklch(0.573 0.189 260);
+    --vp-blue-600: oklch(0.488 0.189 260);
+    --vp-blue-700: oklch(0.428 0.187 261);
+    --vp-blue-800: oklch(0.358 0.185 263);
+    --vp-blue-900: oklch(0.289 0.184 264);
 
     /* Status colors */
-    --vp-green-100: oklch(0.913 0.075 154);
-    --vp-green-200: oklch(0.831 0.117 153);
-    --vp-green-500: oklch(0.566 0.114 167);
-    --vp-green-600: oklch(0.467 0.094 169);
-    --vp-green-700: oklch(0.376 0.075 169);
-    --vp-orange-100: oklch(0.872 0.072 32);
-    --vp-orange-200: oklch(0.778 0.131 34);
-    --vp-orange-500: oklch(0.557 0.179 38);
-    --vp-orange-600: oklch(0.464 0.169 39);
-    --vp-orange-700: oklch(0.385 0.150 41);
-    --vp-red-100: oklch(0.881 0.057 18);
-    --vp-red-200: oklch(0.795 0.115 18);
-    --vp-red-500: oklch(0.577 0.198 21);
-    --vp-red-600: oklch(0.488 0.181 22);
-    --vp-red-700: oklch(0.405 0.181 25);
-    --vp-violet-300: oklch(0.560 0.270 295);
+    --vp-green-100: oklch(0.903 0.058 167);
+    --vp-green-200: oklch(0.814 0.109 167);
+    --vp-green-500: oklch(0.554 0.112 167);
+    --vp-green-600: oklch(0.470 0.101 164);
+    --vp-green-700: oklch(0.407 0.090 162);
+    --vp-orange-100: oklch(0.913 0.048 46);
+    --vp-orange-200: oklch(0.836 0.092 46);
+    --vp-orange-500: oklch(0.588 0.187 39);
+    --vp-orange-600: oklch(0.503 0.188 33);
+    --vp-orange-700: oklch(0.439 0.180 29);
+    --vp-red-100: oklch(0.915 0.044 20);
+    --vp-red-200: oklch(0.838 0.089 20);
+    --vp-red-500: oklch(0.591 0.197 22);
+    --vp-red-600: oklch(0.505 0.196 24);
+    --vp-red-700: oklch(0.439 0.180 28);
+    --vp-violet-300: oklch(0.733 0.152 299);
 
     /* Semantic alias — light theme */
     --vp-bg-canvas: oklch(1.000 0.000 0);
@@ -91,8 +91,8 @@
     --vp-border-contrast: var(--vp-gray-800);
 
     /* Focus ring tint (state ring) — light */
-    --vp-ring-primary: oklch(0.581 0.181 254 / .18);
-    --vp-ring-danger: oklch(0.577 0.198 21 / .18);
+    --vp-ring-primary: oklch(0.573 0.189 260 / .18);
+    --vp-ring-danger: oklch(0.591 0.197 22 / .18);
     /* Scrim — Vapor 고정값 */
     --vp-scrim: oklch(0 0 0 / .4);
 
@@ -1021,8 +1021,8 @@
     gap: 10px;
   }
   .vp-toast .toast-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-  .vp-toast .toast-dot.success { background: var(--vp-green-400, oklch(0.652 0.157 154)); }
-  .vp-toast .toast-dot.danger { background: var(--vp-red-400, oklch(0.638 0.213 19)); }
+  .vp-toast .toast-dot.success { background: var(--vp-green-400, oklch(0.655 0.117 167)); }
+  .vp-toast .toast-dot.danger { background: var(--vp-red-400, oklch(0.691 0.183 20)); }
   .vp-toast .toast-msg { flex: 1; font-size: 13px; line-height: 18px; min-width: 0; }
   .vp-toast .toast-x {
     width: 20px; height: 20px;

--- a/services/bezier.md
+++ b/services/bezier.md
@@ -22,7 +22,7 @@ logo: https://getdesign.kr/logos/bezier.png
 
 ## Brand & Style
 
-Bezier는 채널톡의 사내 제품 UI를 외부에 그대로 공개한 드문 한국발 풀 디자인 시스템이다 — 라이선스는 Apache-2.0(© Channel Corp.)이며, 컴포넌트 59 + foundation 3 + utility 2 = 64 docs, 아이콘 602 SVG(0.60.0 기준), 빌드 CSS 변수 450개 규모다 [src:1][src:3][src:4][src:5]. 이 수치는 실측이다 — Storybook 인덱스의 docs 엔트리 64개가 `components` 59 + `foundation`/`alpha-foundation` 3 + ReadMe·Changelog 2로 정확히 갈리고, `@channel.io/bezier-tokens` 0.6.0의 기본 엔트리 CSS가 변수 450개를 발행한다 [src:3][src:5]. (핸드오프 번들이 세던 "토큰 JSON 39종"은 공개 배포물로 재현되지 않아 뺐다 — npm 패키지는 JSON을 1개만 싣고 토큰을 CSS·SCSS·JS로 발행한다. 39는 beta tier의 `--dimension-*` 변수 개수와는 일치하나 같은 대상을 세었다는 근거가 없다.) 토큰을 별도 패키지로 떼어내 라이트·다크 멀티 테마를 1급으로 다루는 성숙한 시스템이다 [src:1].
+Bezier는 채널톡의 사내 제품 UI를 외부에 그대로 공개한 드문 한국발 풀 디자인 시스템이다 — 라이선스는 Apache-2.0(© Channel Corp.)이며, 컴포넌트 59 + foundation 3 + utility(ReadMe·Changelog) 2 = 64 docs, 아이콘 602 SVG(0.60.0 기준), 빌드 CSS 변수 450개 규모다 [src:1][src:3][src:4][src:5]. 이 수치는 실측이다 — Storybook 인덱스의 docs 엔트리 64개가 `components` 59 + `foundation`/`alpha-foundation` 3 + `ReadMe`/`Changelog` 2로 정확히 갈리고, `@channel.io/bezier-tokens` 0.6.0의 기본 엔트리 CSS가 변수 450개를 발행한다 [src:3][src:5]. (핸드오프 번들이 세던 "토큰 JSON 39종"은 공개 배포물로 재현되지 않아 뺐다 — npm 패키지는 JSON을 1개만 싣고 토큰을 CSS·SCSS·JS로 발행한다. 39는 beta tier의 `--dimension-*` 변수 개수와는 일치하나 같은 대상을 세었다는 근거가 없다.) 토큰을 별도 패키지로 떼어내 라이트·다크 멀티 테마를 1급으로 다루는 성숙한 시스템이다 [src:1].
 
 전반 인상은 밝고 깨끗한 SaaS 톤에 강채도 액센트가 얹히는 구조다 [src:3]. 중립 표면은 거의 순수한 그레이/화이트(`{colors.grey-50}` ~ `{colors.grey-100}`)이고, 그 위에 채도 높은 단일 액센트(블루/그린/레드 등)가 포인트로 올라간다 [src:3]. 형태 언어는 둥글고 부드럽다 — 버튼·인풋·배너·토스트 모서리가 `{rounded.radius-8}`~`{rounded.radius-12}`로 크게 말려 있고, 단순 `border-radius`를 넘어 iOS식 연속 곡률(squircle)을 위한 전용 컴포넌트 `{component.smooth-corners-box}`까지 두는, 부드러운 코너에 공들이는 브랜드다 [src:2][src:3].
 

--- a/services/bezier.md
+++ b/services/bezier.md
@@ -440,7 +440,7 @@ elevation-4: 모달
 
 ### Icon
 
-아이콘 렌더러(598 SVG 세트 연동). `IconSize`를 받으며(AllIcons·UsageColor·UsageSize 스토리) `--b-icon-color`와 150ms `--motion-transition-fast`를 쓴다 [src:2].
+아이콘 렌더러(602 SVG 세트 연동). `IconSize`를 받으며(AllIcons·UsageColor·UsageSize 스토리) `--b-icon-color`와 150ms `--motion-transition-fast`를 쓴다 [src:2].
 
 ```tsx
 <Icon source={ChannelIcon} size="m" color="txt-black-darkest" />
@@ -529,7 +529,7 @@ flex 스택. `HStackProps`·`VStackProps`·`StackProps`를 받고 `--b-stack-spa
 - 부드러운 코너를 단순 `border-radius`로 흉내 내 `{component.smooth-corners-box}`를 대체하지 않는다 — squircle 곡률은 전용 컴포넌트로 그린다 [src:2].
 - 11개 무지개 hue를 의미 없이 흩뿌리지 않는다 — accent는 상태·카테고리 인코딩에 쓰고, 1차 액션은 blue 계열로 통일한다 [src:3].
 - 공개된 59개 목록에 없는 컴포넌트 이름을 Bezier 컴포넌트처럼 만들지 않는다 [src:2].
-- 유니코드·이모지를 UI 아이콘으로 쓰지 않는다 — Bezier는 자체 598 아이콘 세트(`@channel.io/bezier-icons`, 24×24 `currentColor`, outline/`-filled` 쌍)를 단일 출처로 두며, 이모지는 콘텐츠(채팅 리액션·👋)에서만 쓴다.
+- 유니코드·이모지를 UI 아이콘으로 쓰지 않는다 — Bezier는 자체 602 아이콘 세트(`@channel.io/bezier-icons` [src:4], 24×24 `currentColor`, outline/`-filled` 쌍)를 단일 출처로 두며, 이모지는 콘텐츠(채팅 리액션·👋)에서만 쓴다.
 - 챗봇 톤("~해보세요!")이나 마케팅 과장("혁신적", "차세대")으로 카피를 채우지 않는다 — Bezier 문서는 동작을 평이하게 서술하는 개발자 문서 톤을 유지한다 [src:1].
 - 채널톡의 B2B 고객 메시징 도메인 개념·플로우(상담 인박스, 팀 인박스, 마케팅·CRM 채널 등)를 성격이 다른 제품에 그대로 이식하지 않는다 — Bezier에서 차용할 것은 시각 언어(squircle 라운딩·8~12px 반경·Inter/Noto Sans KR 2-weight 타입·11-hue 무지개 액센트·라이트+다크 시맨틱 토큰 쌍·150ms 마이크로 모션)이지 채널톡의 메시징 서비스 도메인이 아니다 [src:1].
 - 디자인시스템 이름 자체(`Bezier` 워드마크·`@channel.io/bezier-*` 패키지명)를 생성하는 제품 UI의 헤더·타이틀·버튼·라벨에 넣지 않는다 — 차용할 것은 시각 언어이지 시스템 이름이 아니다. UI 텍스트·네이밍은 자기 제품 브랜드로 재정의하고, 출처 표기가 필요하면 footer attribution(예: "Bezier 기반")에만 둔다.
@@ -551,7 +551,7 @@ Bezier는 앱 셸/뷰포트 브레이크포인트를 토큰으로 발행하지 �
 - **Breakpoint 토큰 부재.** Bezier는 뷰포트 브레이크포인트를 토큰으로 발행하지 않으며, 반응형은 컴포넌트 로컬 폭과 앱 레이어 몫이다 — 데스크톱/모바일 레이아웃 분기는 다운스트림에서 정의해야 한다 [src:3][src:2].
 - **alpha/legacy 컴포넌트 중복.** 같은 역할에 안정·alpha·legacy 변종이 공존한다(예: `{component.avatar}` ↔ `{component.alpha-avatar}`, `{component.tooltip}` ↔ `{component.legacy-tooltip}`, `{component.stack}` ↔ `{component.legacy-stack}`) — 어느 라인을 채택할지는 소비처가 결정해야 하며, 본 문서는 신규 코드에 안정/alpha 라인을 권장한다 [src:2].
 - **hex→OKLCH 변환 오차.** 모든 색은 Bezier가 hex로 게시한 토큰을 OKLCH로 변환한 것이라 미세한 변환 드리프트가 있을 수 있다 — 정확한 원본 hex는 `@channel.io/bezier-tokens` 빌드 CSS를 직접 참조해야 한다 [src:3].
-- **일부 값 공개 검증 한계.** beta 팔레트 값·컴포넌트 정본 스펙(Banner/Toast 처리 등) 상당수가 공개 URL로 직접 교차검증되지 않는다 — 정확값이 필요하면 `@channel.io/bezier-tokens`(beta 엔트리) 또는 Storybook autodocs와 대조해야 한다 [src:3][src:2].
+- **beta 팔레트는 이제 검증됐다(2026-07-27 정정).** 이 항목은 원래 "beta 팔레트 값 상당수가 공개 URL로 직접 교차검증되지 않는다"고 적고 있었으나, 실제로 대조해 보니 이 문서의 색 토큰 43개 전부가 `@channel.io/bezier-tokens` 0.6.0의 beta 엔트리와 ΔE ≤ 0.02로 일치했다(Colors 절 참조). 남은 공백은 **컴포넌트 정본 스펙**(Banner/Toast 처리 등)이며, 이쪽은 Storybook 개별 docs를 `?path=/docs/<id>`로 열어 대조해야 한다 [src:3][src:2].
 - **시맨틱 다크 원시값 일부 미확인.** 시맨틱 토큰의 테마 분기 구조(`txt-black-darkest` 등)는 확인됐으나, 다크 측이 참조하는 일부 white-알파 원시값의 정확한 단계는 코퍼스에서 전부 발췌되지 않았다 [src:3][src:2].
 - **모바일 리플로우 미관찰.** 제공 스크린샷이 데스크톱 Storybook 캔버스 한정이라, 실제 모바일 웹/네이티브에서의 컴포넌트 리플로우·접힘 거동은 직접 확인되지 않았다 [src:2].
 

--- a/services/bezier.md
+++ b/services/bezier.md
@@ -3,13 +3,14 @@ name: 채널톡
 design_system_name: Bezier Design System
 slug: bezier
 category: developer
-last_updated: "2026-06-03"
+last_updated: "2026-07-27"
 created_at: "2026-06-03"
 sources:
   - https://github.com/channel-io/bezier-react
   - https://main--62bead1508281287d3c94d25.chromatic.com/
   - https://www.npmjs.com/package/@channel.io/bezier-tokens
   - https://www.npmjs.com/package/@channel.io/bezier-icons
+  - https://main--62bead1508281287d3c94d25.chromatic.com/index.json
 related_services: []
 lang: ko
 logo: https://getdesign.kr/logos/bezier.png
@@ -17,11 +18,11 @@ logo: https://getdesign.kr/logos/bezier.png
 
 # Bezier Design System — design.md
 
-> 채널톡을 만드는 (주)채널코퍼레이션의 오픈소스 React 디자인 시스템. 컴포넌트 라이브러리 + 디자인 토큰 + 아이콘 세트를 한 모노레포로 배포하며, 핵심 패키지는 `@channel.io/bezier-react`·`@channel.io/bezier-tokens`(0.6.0)·`@channel.io/bezier-icons`(0.59.0)이다 [src:1][src:3][src:4]. 본 문서는 사용자가 제공한 Claude Design 핸드오프 번들을 1차 출처로 추출·정리해 합성한 결과다.
+> 채널톡을 만드는 (주)채널코퍼레이션의 오픈소스 React 디자인 시스템. 컴포넌트 라이브러리 + 디자인 토큰 + 아이콘 세트를 한 모노레포로 배포하며, 핵심 패키지는 `@channel.io/bezier-react`·`@channel.io/bezier-tokens`(0.6.0)·`@channel.io/bezier-icons`(0.60.0)이다 [src:1][src:3][src:4]. 본 문서는 사용자가 제공한 Claude Design 핸드오프 번들을 1차 출처로 추출·정리해 합성한 결과다 — 번들은 비공개이므로, 아래 정량 주장은 2026-07-27에 공개 배포물(`@channel.io/bezier-tokens` 0.6.0 · `@channel.io/bezier-icons` 0.60.0 · Storybook 인덱스 [src:5])과 전수 대조했다. 색 토큰 43개는 전부 ΔE ≤ 0.02로 일치했고, 컴포넌트 59개 이름도 Storybook 문서와 1:1로 대응했다.
 
 ## Brand & Style
 
-Bezier는 채널톡의 사내 제품 UI를 외부에 그대로 공개한 드문 한국발 풀 디자인 시스템이다 — 라이선스는 Apache-2.0(© Channel Corp.)이며, 컴포넌트 59 + foundation 3 + utility 2 = 64 docs, 아이콘 598 SVG, 토큰 JSON 39종, 빌드 CSS 변수 450개 규모다 [src:1][src:2]. 토큰을 별도 패키지로 떼어내 라이트·다크 멀티 테마를 1급으로 다루는 성숙한 시스템이다 [src:1].
+Bezier는 채널톡의 사내 제품 UI를 외부에 그대로 공개한 드문 한국발 풀 디자인 시스템이다 — 라이선스는 Apache-2.0(© Channel Corp.)이며, 컴포넌트 59 + foundation 3 + utility 2 = 64 docs, 아이콘 602 SVG(0.60.0 기준), 빌드 CSS 변수 450개 규모다 [src:1][src:3][src:4][src:5]. 이 수치는 실측이다 — Storybook 인덱스의 docs 엔트리 64개가 `components` 59 + `foundation`/`alpha-foundation` 3 + ReadMe·Changelog 2로 정확히 갈리고, `@channel.io/bezier-tokens` 0.6.0의 기본 엔트리 CSS가 변수 450개를 발행한다 [src:3][src:5]. (핸드오프 번들이 세던 "토큰 JSON 39종"은 공개 배포물로 재현되지 않아 뺐다 — npm 패키지는 JSON을 1개만 싣고 토큰을 CSS·SCSS·JS로 발행한다. 39는 beta tier의 `--dimension-*` 변수 개수와는 일치하나 같은 대상을 세었다는 근거가 없다.) 토큰을 별도 패키지로 떼어내 라이트·다크 멀티 테마를 1급으로 다루는 성숙한 시스템이다 [src:1].
 
 전반 인상은 밝고 깨끗한 SaaS 톤에 강채도 액센트가 얹히는 구조다 [src:3]. 중립 표면은 거의 순수한 그레이/화이트(`{colors.grey-50}` ~ `{colors.grey-100}`)이고, 그 위에 채도 높은 단일 액센트(블루/그린/레드 등)가 포인트로 올라간다 [src:3]. 형태 언어는 둥글고 부드럽다 — 버튼·인풋·배너·토스트 모서리가 `{rounded.radius-8}`~`{rounded.radius-12}`로 크게 말려 있고, 단순 `border-radius`를 넘어 iOS식 연속 곡률(squircle)을 위한 전용 컴포넌트 `{component.smooth-corners-box}`까지 두는, 부드러운 코너에 공들이는 브랜드다 [src:2][src:3].
 
@@ -36,6 +37,8 @@ Bezier는 채널톡의 사내 제품 UI를 외부에 그대로 공개한 드문 
 Bezier는 글로벌 원시값 → 시맨틱(라이트/다크) → 컴포넌트 3계층 토큰 구조다 [src:3][src:2]. 글로벌은 원시 색값이고, 시맨틱(`--bg-*`, `--txt-*`, `--color-*`)은 테마별로 다른 글로벌을 참조한다 [src:2]. 특징은 navy·purple·pink·red·orange·yellow·olive·green·teal·cobalt·blue 11개 hue를 각각 300/400/500 명도 + 알파 변형으로 갖춘 무지개 액센트 팔레트다 [src:3][src:4].
 
 아래 값은 핸드오프 번들 `colors_and_type.css`가 정답으로 삼은 Bezier **beta 토큰 팔레트**를 ko-design-md 표준 OKLCH로 변환한 것이다 — 1차 액션은 indigo-violet 계열 `blue-400`이고, 원본이 hex로 발행돼 OKLCH 변환에 미세한 오차가 있을 수 있다 [src:3].
+
+> **대조 결과(2026-07-27).** 이 절의 색 토큰 43개를 published `@channel.io/bezier-tokens` 0.6.0의 `dist/beta/css/styles.css`와 전수 비교했고 **43개 전부 ΔE ≤ 0.02**로 일치했다 — 비공개 번들에서 나온 값이지만 공개 배포물로 재현된다 [src:3]. 다만 **tier를 구분해 읽어야 한다**: 이 절의 색은 beta tier이고, 아래 Typography·Rounded·Spacing 절의 값은 기본(stable) tier다. 같은 토큰 이름이 tier마다 다른 값을 가진다 — `grey-900`이 stable에서는 `#242428` ≈ `oklch(0.262 0.007 286)`, beta에서는 `#1d1d20` ≈ `oklch(0.232 0.006 286)`이다. beta에는 stable에 없는 `grey-25/300/400/600/650/750/950`이 있고, 반대로 `radius-44`·`radius-42-p`는 stable에만 있다.
 
 ### Accent global hues (300/400/500 core)
 
@@ -92,7 +95,7 @@ grey-600: oklch(0.578 0.008 286)
 grey-700: oklch(0.354 0.007 286)
 grey-800: oklch(0.283 0.007 286)
 grey-850: oklch(0.261 0.004 286)
-grey-900: oklch(0.232 0.006 286)   # 가장 짙은 다크 표면
+grey-900: oklch(0.232 0.006 286)   # 다크 표면 기본 (beta는 더 짙은 grey-950까지 발행한다)
 
 # 텍스트·보더·딤은 고정 grey가 아니라 alpha-black 위계로 쌓는다 (Bezier 시그니처)
 black-100: oklch(0 0 0)
@@ -554,7 +557,8 @@ Bezier는 앱 셸/뷰포트 브레이크포인트를 토큰으로 발행하지 �
 
 ## References
 
-1. https://github.com/channel-io/bezier-react
-2. https://main--62bead1508281287d3c94d25.chromatic.com/
-3. https://www.npmjs.com/package/@channel.io/bezier-tokens
-4. https://www.npmjs.com/package/@channel.io/bezier-icons
+1. https://github.com/channel-io/bezier-react — 모노레포. Apache-2.0(© Channel Corp.), 이중 언어 운영 컨텍스트.
+2. https://main--62bead1508281287d3c94d25.chromatic.com/ — Chromatic에 배포된 Storybook. `main--<appId>` 형태의 브랜치 퍼머링크라 빌드마다 바뀌지 않는다. **루트 URL은 JS 셸(약 9.6KB)이라 그 자체로는 읽을 내용이 없다** — 개별 문서는 `?path=/docs/<id>` 딥링크로 접근한다(예: `?path=/docs/components-button--docs`, `?path=/docs/foundation-color--docs`). 본문에서 `[src:2]`로 인용한 컴포넌트·foundation 서술은 각각 대응하는 `components-<이름 소문자>--docs` 항목을 가리킨다.
+3. https://www.npmjs.com/package/@channel.io/bezier-tokens — 토큰 패키지 0.6.0. 값의 authoritative 출처이며 `dist/css`(stable, 변수 450개)·`dist/beta`·`dist/alpha` 3 tier를 함께 배포한다.
+4. https://www.npmjs.com/package/@channel.io/bezier-icons — 아이콘 패키지 0.60.0, SVG 602개.
+5. https://main--62bead1508281287d3c94d25.chromatic.com/index.json — 위 Storybook의 기계 판독 인덱스(엔트리 186 = docs 64 + 스토리 122). 컴포넌트 59개 이름과 docs 개수 주장을 직접 검증할 수 있는 항목이며, 루트 URL과 달리 텍스트로 내용을 반환한다.

--- a/services/bezier.tokens.json
+++ b/services/bezier.tokens.json
@@ -174,7 +174,7 @@
     {
       "name": "grey-900",
       "value": "oklch(0.232 0.006 286)",
-      "note": "가장 짙은 다크 표면",
+      "note": "다크 표면 기본 (beta는 더 짙은 grey-950까지 발행한다)",
       "group": "Neutral global"
     },
     {

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -36,150 +36,154 @@ Vapor는 두 테마(`light`, `dark`) 위에 11-family 베이스 팔레트를 둔
 
 product-facing 색은 모두 **시맨틱 alias**로 호출하고 raw 팔레트는 새 role을 만들 때만 직접 노출된다 — 명명 규칙은 `color-{role}-{intent}-{level}`이며 roles는 `background`/`foreground`/`border`, intents는 `primary, secondary, success, warning, danger, hint, contrast, normal`, level은 `100`(soft) / `200`(strong)이다 [src:5].
 
-> **대조 결과(2026-07-27) — 아래 값은 goorm이 발행하는 팔레트와 어긋난다.** 이 절의 OKLCH는 핸드오프 번들에서 나온 것이고, 공개 출처 두 곳(`@vapor-ui/core` 1.3.0의 `dist/styles/themes.css.ts.vanilla.css`, 그리고 docs 사이트가 서빙하는 같은 팔레트 CSS 청크)은 **서로 일치하지만** 이 값들과는 다르다 [src:1][src:4]. 110개 중 ΔE ≤ 0.02로 맞는 것은 15개뿐이고 **46개가 ΔE > 0.05**로 눈에 띄게 벌어진다. 어긋남은 무작위가 아니라 계열에 몰려 있다 — violet 8/10, grape 8/10, gray 7/10(램프가 늘어나 밝은 쪽은 더 밝고 짙은 쪽은 더 짙다), pink 7/10인 반면 **cyan은 10/10 일치**한다. 최대 편차인 `violet-400`은 패키지가 `#a480f7` ≈ `oklch(0.686 0.172 295)`인데 아래 표는 `oklch(0.494 0.275 295)`로 — **hue는 같고 명도·채도만 크게 벌어진다**. `grape-400`도 패키지 `#d06bea` ≈ `oklch(0.693 0.202 319)` 대 표의 `oklch(0.546 0.230 316)`으로 같은 양상이다. 변환 반올림으로는 설명되지 않는 폭이고, 구조(11 패밀리 × 10단계, 패밀리 이름, 라이트/다크 2테마)는 패키지와 정확히 맞으므로 문제는 체계가 아니라 값이다.
+> **팔레트 정정(2026-07-27).** 이 절의 값은 원래 핸드오프 번들에서 추출한 것이었고, 공개 발행값과 어긋나 있었다 — 110개 중 ΔE ≤ 0.02로 맞는 건 15개뿐이었고 **46개가 ΔE > 0.05**였다. 어긋남은 계열에 몰려 있었다(violet 8/10, grape 8/10, gray 7/10, pink 7/10인 반면 **cyan은 10/10 일치**). 최대 편차였던 `violet-400`은 번들값이 `oklch(0.494 0.275 295)`, 발행값이 `#A480F7`로 hue만 같고 명도·채도가 크게 달랐다.
 >
-> 카탈로그 정책에 따라 **값은 고치지 않고 차이만 명시한다**(krds 선례) — 번들 추출값을 공식 발행값으로 덮어쓰면 어느 쪽도 아닌 제3의 팔레트가 된다. 이 색을 그대로 쓰려는 사용자는 `@vapor-ui/core`의 `--vapor-color-*`를 1차 기준으로 삼는 편이 안전하다.
+> **아래 표는 이제 goorm 발행값이다.** `@vapor-ui/core` 1.3.0의 `dist/styles/themes.css.ts.vanilla.css`(라이트 테마)를 기준으로 110개를 전량 교체하고, 각 줄에 출처 hex를 병기했다 [src:4]. docs 사이트가 서빙하는 팔레트 CSS 청크도 같은 값이라 두 공식 채널이 서로를 확인해 준다 [src:1]. 버전 요인도 없다 — 1.3.0과 1.4.0의 팔레트 CSS는 바이트 단위로 동일하다.
+>
+> 값을 그대로 두는 대신 교체한 이유는 이 문서만 읽히는 게 아니기 때문이다. 사이드카 `vapor-ui.tokens.json`은 사이트 Tokens 탭과 `use-design-md` 스킬이 그대로 소비하는데, 그 경로에는 이런 단서를 실을 자리가 없다 — 산문에 주석을 달아 두어도 Tailwind 테마를 생성하는 쪽에는 어긋난 값만 전달된다. 전량을 공식값으로 맞추면 "제3의 팔레트"가 아니라 공식 팔레트가 된다.
+>
+> 병기한 hex는 부수 효과가 아니다. 이 토큰들은 원래 hex 주석이 없어 `audit:oklch`가 **하나도 판정하지 못했다**. 이제 110개가 게이트 대상이라 다음 드리프트는 CI가 잡는다.
 
 ### Base palette (11 family × 10 step)
 
 ```yaml
 # Gray — 표면·텍스트·디바이더의 기반
-gray-050: oklch(0.984 0.000 0)
-gray-100: oklch(0.972 0.000 0)
-gray-200: oklch(0.892 0.000 0)
-gray-300: oklch(0.804 0.000 0)
-gray-400: oklch(0.712 0.000 0)
-gray-500: oklch(0.658 0.000 0)
-gray-600: oklch(0.453 0.000 0)
-gray-700: oklch(0.314 0.000 0)
-gray-800: oklch(0.234 0.000 0)
-gray-900: oklch(0.169 0.000 0)
+gray-050: oklch(0.976 0.000 0)   # #F7F7F7
+gray-100: oklch(0.910 0.000 0)   # #E1E1E1
+gray-200: oklch(0.827 0.000 0)   # #C6C6C6
+gray-300: oklch(0.715 0.000 0)   # #A3A3A3
+gray-400: oklch(0.670 0.000 0)   # #959595
+gray-500: oklch(0.566 0.000 0)   # #767676
+gray-600: oklch(0.478 0.000 0)   # #5D5D5D
+gray-700: oklch(0.417 0.000 0)   # #4C4C4C
+gray-800: oklch(0.345 0.000 0)   # #393939
+gray-900: oklch(0.269 0.000 0)   # #262626
 
 # Blue — 브랜드 primary, link, focus ring 앵커
-blue-050: oklch(0.974 0.018 254)
-blue-100: oklch(0.901 0.052 254)
-blue-200: oklch(0.781 0.110 264)
-blue-300: oklch(0.690 0.146 261)
-blue-400: oklch(0.638 0.166 258)
-blue-500: oklch(0.581 0.181 254)   # 브랜드 primary
-blue-600: oklch(0.560 0.196 257)
-blue-700: oklch(0.451 0.166 259)
-blue-800: oklch(0.348 0.142 263)
-blue-900: oklch(0.232 0.156 270)
+blue-050: oklch(0.974 0.013 241)   # #EFF8FF
+blue-100: oklch(0.910 0.048 242)   # #C6E6FF
+blue-200: oklch(0.824 0.096 243)   # #8DCDFF
+blue-300: oklch(0.715 0.142 248)   # #51A9F7
+blue-400: oklch(0.669 0.158 252)   # #4198F2
+blue-500: oklch(0.573 0.189 260)   # #2A72E5 · 브랜드 primary
+blue-600: oklch(0.488 0.189 260)   # #0957C8
+blue-700: oklch(0.428 0.187 261)   # #0043B3
+blue-800: oklch(0.358 0.185 263)   # #002B9B
+blue-900: oklch(0.289 0.184 264)   # #000E84
 
 # Cyan
-cyan-050: oklch(0.978 0.013 215)
-cyan-100: oklch(0.911 0.039 220)
-cyan-200: oklch(0.812 0.078 224)
-cyan-300: oklch(0.703 0.105 226)
-cyan-400: oklch(0.633 0.110 230)
-cyan-500: oklch(0.567 0.107 230)
-cyan-600: oklch(0.475 0.099 232)
-cyan-700: oklch(0.388 0.080 233)
-cyan-800: oklch(0.309 0.061 233)
-cyan-900: oklch(0.255 0.057 232)
+cyan-050: oklch(0.974 0.012 210)   # #EEF9FB
+cyan-100: oklch(0.906 0.041 212)   # #C2E8F0
+cyan-200: oklch(0.819 0.080 212)   # #84D2E2
+cyan-300: oklch(0.706 0.119 213)   # #1BB3CC
+cyan-400: oklch(0.659 0.113 214)   # #14A3BC
+cyan-500: oklch(0.558 0.100 220)   # #04819C
+cyan-600: oklch(0.474 0.088 223)   # #006680
+cyan-700: oklch(0.412 0.079 227)   # #00536C
+cyan-800: oklch(0.342 0.071 233)   # #003E57
+cyan-900: oklch(0.268 0.062 241)   # #002941
 
 # Green — success
-green-050: oklch(0.978 0.022 156)
-green-100: oklch(0.913 0.075 154)
-green-200: oklch(0.831 0.117 153)
-green-300: oklch(0.726 0.158 151)
-green-400: oklch(0.652 0.157 154)
-green-500: oklch(0.566 0.114 167)
-green-600: oklch(0.467 0.094 169)
-green-700: oklch(0.376 0.075 169)
-green-800: oklch(0.294 0.067 170)
-green-900: oklch(0.246 0.057 168)
+green-050: oklch(0.974 0.016 167)   # #EDFAF4
+green-100: oklch(0.903 0.058 167)   # #BBECD7
+green-200: oklch(0.814 0.109 167)   # #75D9B4
+green-300: oklch(0.704 0.120 167)   # #43B790
+green-400: oklch(0.655 0.117 167)   # #33A782
+green-500: oklch(0.554 0.112 167)   # #058765
+green-600: oklch(0.470 0.101 164)   # #006C4B
+green-700: oklch(0.407 0.090 162)   # #00583A
+green-800: oklch(0.334 0.078 158)   # #004226
+green-900: oklch(0.264 0.069 152)   # #002E13
 
 # Lime
-lime-050: oklch(0.978 0.044 122)
-lime-100: oklch(0.926 0.116 124)
-lime-200: oklch(0.857 0.158 127)
-lime-300: oklch(0.787 0.184 130)
-lime-400: oklch(0.689 0.187 131)
-lime-500: oklch(0.566 0.158 132)
-lime-600: oklch(0.464 0.130 132)
-lime-700: oklch(0.371 0.106 133)
-lime-800: oklch(0.292 0.085 133)
-lime-900: oklch(0.225 0.078 134)
+lime-050: oklch(0.974 0.026 129)   # #F1FAE8
+lime-100: oklch(0.901 0.097 130)   # #C9ECA8
+lime-200: oklch(0.813 0.182 130)   # #9AD84A
+lime-300: oklch(0.703 0.188 132)   # #71B61A
+lime-400: oklch(0.654 0.179 133)   # #61A613
+lime-500: oklch(0.553 0.163 135)   # #428600
+lime-600: oklch(0.468 0.146 138)   # #276C00
+lime-700: oklch(0.408 0.134 141)   # #115A00
+lime-800: oklch(0.335 0.114 142)   # #004400
+lime-900: oklch(0.261 0.089 142)   # #002E00
 
 # Yellow / Amber
-yellow-050: oklch(0.971 0.044 79)
-yellow-100: oklch(0.906 0.111 84)
-yellow-200: oklch(0.847 0.158 79)
-yellow-300: oklch(0.768 0.166 65)
-yellow-400: oklch(0.660 0.158 60)
-yellow-500: oklch(0.560 0.142 56)
-yellow-600: oklch(0.456 0.121 55)
-yellow-700: oklch(0.371 0.099 56)
-yellow-800: oklch(0.318 0.081 53)
-yellow-900: oklch(0.275 0.083 53)
+yellow-050: oklch(0.978 0.023 85)   # #FFF7E7
+yellow-100: oklch(0.910 0.098 85)   # #FFDD95
+yellow-200: oklch(0.832 0.170 85)   # #FBBD05
+yellow-300: oklch(0.723 0.151 78)   # #D99700
+yellow-400: oklch(0.675 0.143 74)   # #CA8700
+yellow-500: oklch(0.575 0.126 68)   # #A96800
+yellow-600: oklch(0.491 0.113 62)   # #8D4F00
+yellow-700: oklch(0.428 0.106 55)   # #7A3C00
+yellow-800: oklch(0.354 0.098 47)   # #632700
+yellow-900: oklch(0.281 0.094 37)   # #4D1100
 
 # Orange — warning
-orange-050: oklch(0.957 0.025 30)
-orange-100: oklch(0.872 0.072 32)
-orange-200: oklch(0.778 0.131 34)
-orange-300: oklch(0.703 0.166 36)
-orange-400: oklch(0.628 0.190 38)
-orange-500: oklch(0.557 0.179 38)
-orange-600: oklch(0.464 0.169 39)
-orange-700: oklch(0.385 0.150 41)
-orange-800: oklch(0.346 0.135 41)
-orange-900: oklch(0.300 0.119 41)
+orange-050: oklch(0.979 0.012 51)   # #FFF6F1
+orange-100: oklch(0.913 0.048 46)   # #FFD9C8
+orange-200: oklch(0.836 0.092 46)   # #FCB797
+orange-300: oklch(0.731 0.151 46)   # #F4864F
+orange-400: oklch(0.685 0.177 46)   # #EF6F25
+orange-500: oklch(0.588 0.187 39)   # #D34701
+orange-600: oklch(0.503 0.188 33)   # #B72100
+orange-700: oklch(0.439 0.180 29)   # #9E0000
+orange-800: oklch(0.362 0.148 29)   # #790000
+orange-900: oklch(0.285 0.117 29)   # #560000
 
 # Red — danger
-red-050: oklch(0.957 0.020 17)
-red-100: oklch(0.881 0.057 18)
-red-200: oklch(0.795 0.115 18)
-red-300: oklch(0.687 0.180 19)
-red-400: oklch(0.638 0.213 19)
-red-500: oklch(0.577 0.198 21)
-red-600: oklch(0.488 0.181 22)
-red-700: oklch(0.405 0.181 25)
-red-800: oklch(0.330 0.169 28)
-red-900: oklch(0.255 0.144 28)
+red-050: oklch(0.978 0.011 24)   # #FFF5F4
+red-100: oklch(0.915 0.044 20)   # #FFD8D7
+red-200: oklch(0.838 0.089 20)   # #FFB3B2
+red-300: oklch(0.736 0.155 21)   # #FC7D7F
+red-400: oklch(0.691 0.183 20)   # #F8636A
+red-500: oklch(0.591 0.197 22)   # #DA3944
+red-600: oklch(0.505 0.196 24)   # #BB1225
+red-700: oklch(0.439 0.180 28)   # #9E0006
+red-800: oklch(0.362 0.148 29)   # #790000
+red-900: oklch(0.287 0.118 29)   # #570000
 
 # Pink
-pink-050: oklch(0.957 0.018 13)
-pink-100: oklch(0.870 0.054 5)
-pink-200: oklch(0.770 0.117 6)
-pink-300: oklch(0.652 0.176 7)
-pink-400: oklch(0.567 0.179 8)
-pink-500: oklch(0.510 0.180 8)
-pink-600: oklch(0.418 0.168 8)
-pink-700: oklch(0.339 0.158 8)
-pink-800: oklch(0.296 0.146 9)
-pink-900: oklch(0.279 0.137 8)
+pink-050: oklch(0.978 0.011 3)   # #FFF5F7
+pink-100: oklch(0.918 0.045 1)   # #FFD8E2
+pink-200: oklch(0.840 0.094 2)   # #FFB1C6
+pink-300: oklch(0.737 0.155 2)   # #F77CA3
+pink-400: oklch(0.692 0.181 2)   # #F26394
+pink-500: oklch(0.592 0.188 2)   # #D13E76
+pink-600: oklch(0.506 0.195 2)   # #B5135D
+pink-700: oklch(0.442 0.178 4)   # #9A0047
+pink-800: oklch(0.364 0.146 9)   # #77002D
+pink-900: oklch(0.286 0.114 16)   # #550016
 
 # Grape
-grape-050: oklch(0.954 0.024 308)
-grape-100: oklch(0.866 0.087 312)
-grape-200: oklch(0.755 0.166 314)
-grape-300: oklch(0.633 0.225 316)
-grape-400: oklch(0.546 0.230 316)
-grape-500: oklch(0.475 0.215 314)
-grape-600: oklch(0.391 0.193 313)
-grape-700: oklch(0.317 0.169 312)
-grape-800: oklch(0.279 0.158 311)
-grape-900: oklch(0.260 0.157 313)
+grape-050: oklch(0.978 0.014 319)   # #FCF5FE
+grape-100: oklch(0.916 0.056 319)   # #F4D8FB
+grape-200: oklch(0.840 0.107 319)   # #E9B4F7
+grape-300: oklch(0.739 0.173 319)   # #D883EF
+grape-400: oklch(0.693 0.202 319)   # #D06BEA
+grape-500: oklch(0.597 0.224 319)   # #B542D1
+grape-600: oklch(0.511 0.229 319)   # #9A1CB7
+grape-700: oklch(0.448 0.217 318)   # #83009F
+grape-800: oklch(0.370 0.182 316)   # #62007E
+grape-900: oklch(0.292 0.146 312)   # #43005E
 
 # Violet — 워드마크 전용 카노니컬 violet (violet-300)
-violet-050: oklch(0.946 0.040 296)
-violet-100: oklch(0.853 0.121 297)
-violet-200: oklch(0.713 0.205 296)
-violet-300: oklch(0.560 0.270 295)
-violet-400: oklch(0.494 0.275 295)
-violet-500: oklch(0.439 0.245 290)
-violet-600: oklch(0.366 0.220 287)
-violet-700: oklch(0.300 0.197 283)
-violet-800: oklch(0.292 0.193 283)
-violet-900: oklch(0.279 0.187 282)
+violet-050: oklch(0.976 0.014 304)   # #F9F5FF
+violet-100: oklch(0.915 0.051 305)   # #EBDBFF
+violet-200: oklch(0.837 0.102 305)   # #D9B9FF
+violet-300: oklch(0.733 0.152 299)   # #B691FA
+violet-400: oklch(0.686 0.172 295)   # #A480F7
+violet-500: oklch(0.588 0.207 290)   # #805CEC
+violet-600: oklch(0.503 0.208 290)   # #693FCF
+violet-700: oklch(0.442 0.208 290)   # #5929BA
+violet-800: oklch(0.373 0.207 290)   # #4805A3
+violet-900: oklch(0.293 0.170 286)   # #2E007A
 
-color-white: oklch(1.000 0.000 0)
-color-black: oklch(0.000 0.000 0)
+color-white: oklch(1.000 0.000 0)   # #FFFFFF
+color-black: oklch(0.000 0.000 0)   # #000000
 ```
 
-위 OKLCH는 `colors_and_type.css`의 정확한 hex 값을 변환한 결과이며, 원본 hex는 research.md에 기록되어 있다 [src:5].
+위 OKLCH는 `@vapor-ui/core`가 배포하는 hex를 변환한 결과이고, 각 출처 hex는 같은 줄 트레일링 주석에 남겼다 [src:4]. (2026-07-27 이전 리비전은 핸드오프 번들 `colors_and_type.css`의 hex를 옮긴 것이었다 — 위 정정 참조.)
 
 ### Semantic alias (light → dark)
 

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -3,7 +3,7 @@ name: 구름
 design_system_name: Vapor UI
 slug: vapor-ui
 category: developer
-last_updated: "2026-06-01"
+last_updated: "2026-07-27"
 created_at: "2026-05-10"
 sources:
   - https://vapor-ui.goorm.io/
@@ -24,7 +24,7 @@ logo: https://getdesign.kr/logos/goorm.png
 
 Vapor는 시스템 자체의 정체성을 **opinionated, light-first, very token-driven, proudly Korean-bilingual** 로 정의한다 [src:5]. opinionated는 디자인 결정이 토큰 레벨에서 강하게 박혀 있다는 뜻이고, light-first는 다크 모드가 동등하게 지원되되 1차 환경은 화이트 캔버스라는 의미다. very token-driven은 product-facing 색상이 모두 시맨틱 alias로만 노출되어 raw 팔레트는 새 role을 만들 때만 직접 참조된다는 정책을 가리킨다 [src:5].
 
-대상 사용자는 세 층위다. 디자이너에게는 Figma 라이브러리(`figma.com/community/file/1508829832204351721`)를, 개발자에게는 `@vapor-ui/core` 1.3.0을 중심으로 한 6패키지 모노레포(`goorm-dev/vapor-ui`)를, 그리고 product surface를 운영하는 host 팀에게는 `@vapor-ui/css-generator`를 통해 기본 키 팔레트를 자체 브랜드 색으로 교체할 수 있는 토큰 빌드 파이프라인을 제공한다 [src:4][src:5]. 2025년 4월 전담 조직 Vapor Squad가 신설되어 Squad Lead 최준영, CDO 이태성 체제로 운영된다 [src:2].
+대상 사용자는 세 층위다. 디자이너에게는 Figma 라이브러리(`figma.com/community/file/1508829832204351721`)를 [src:3], 개발자에게는 `@vapor-ui/core` 1.3.0을 중심으로 한 6패키지 모노레포(`goorm-dev/vapor-ui`)를, 그리고 product surface를 운영하는 host 팀에게는 `@vapor-ui/css-generator`를 통해 기본 키 팔레트를 자체 브랜드 색으로 교체할 수 있는 토큰 빌드 파이프라인을 제공한다 [src:4][src:5]. 2025년 4월 전담 조직 Vapor Squad가 신설되어 Squad Lead 최준영, CDO 이태성 체제로 운영된다 [src:2].
 
 전체 무드는 **bright, soft white** 로 요약된다 [src:5]. 정보 밀도가 높은 표면(테이블·코드 패널·폼)은 흰 카드 위에 옅은 페이지 배경, 그리고 1px 헤어라인으로 분리되는 패턴이며, 색은 절제되어 있고 시맨틱 팔레트는 상태(primary CTA, success/warning/danger badge, link blue)에만 사용된다 [src:5]. 시스템 표면 자체에는 **그라디언트, 글래스/블러 효과, 텍스처, 장식 일러스트가 없다** [src:5]. 그라디언트가 등장하는 단 두 곳은 Vapor 워드마크 로고와 Getting Started 페이지의 컨셉 히어로다 [src:5]. 트랜스페어런시·블러는 토스트와 다이얼로그 스크림에만 쓰이고 frosted glass나 `backdrop-filter`는 시스템에서 제외된다 [src:5].
 
@@ -35,6 +35,10 @@ Voice는 "factual, didactic, slightly warm"으로 정의된다 [src:5]. 한국�
 Vapor는 두 테마(`light`, `dark`) 위에 11-family 베이스 팔레트를 둔다 — Red, Pink, Grape, Violet, Blue, Cyan, Green, Lime, Yellow, Orange, Gray. 각 패밀리는 `050, 100, 200, 300, 400, 500, 600, 700, 800, 900` 10단계 + `color-white`/`color-black` 상수로 구성된다 [src:5]. 브랜드 primary는 **Blue 500**이며, 카노니컬한 violet은 Vapor 워드마크에만 등장한다 [src:5].
 
 product-facing 색은 모두 **시맨틱 alias**로 호출하고 raw 팔레트는 새 role을 만들 때만 직접 노출된다 — 명명 규칙은 `color-{role}-{intent}-{level}`이며 roles는 `background`/`foreground`/`border`, intents는 `primary, secondary, success, warning, danger, hint, contrast, normal`, level은 `100`(soft) / `200`(strong)이다 [src:5].
+
+> **대조 결과(2026-07-27) — 아래 값은 goorm이 발행하는 팔레트와 어긋난다.** 이 절의 OKLCH는 핸드오프 번들에서 나온 것이고, 공개 출처 두 곳(`@vapor-ui/core` 1.3.0의 `dist/styles/themes.css.ts.vanilla.css`, 그리고 docs 사이트가 서빙하는 같은 팔레트 CSS 청크)은 **서로 일치하지만** 이 값들과는 다르다 [src:1][src:4]. 110개 중 ΔE ≤ 0.02로 맞는 것은 15개뿐이고 **46개가 ΔE > 0.05**로 눈에 띄게 벌어진다. 어긋남은 무작위가 아니라 계열에 몰려 있다 — violet 8/10, grape 8/10, gray 7/10(램프가 늘어나 밝은 쪽은 더 밝고 짙은 쪽은 더 짙다), pink 7/10인 반면 **cyan은 10/10 일치**한다. 최대 편차인 `violet-400`은 패키지가 `#a480f7` ≈ `oklch(0.686 0.172 295)`인데 아래 표는 `oklch(0.494 0.275 295)`로 — **hue는 같고 명도·채도만 크게 벌어진다**. `grape-400`도 패키지 `#d06bea` ≈ `oklch(0.693 0.202 319)` 대 표의 `oklch(0.546 0.230 316)`으로 같은 양상이다. 변환 반올림으로는 설명되지 않는 폭이고, 구조(11 패밀리 × 10단계, 패밀리 이름, 라이트/다크 2테마)는 패키지와 정확히 맞으므로 문제는 체계가 아니라 값이다.
+>
+> 카탈로그 정책에 따라 **값은 고치지 않고 차이만 명시한다**(krds 선례) — 번들 추출값을 공식 발행값으로 덮어쓰면 어느 쪽도 아닌 제3의 팔레트가 된다. 이 색을 그대로 쓰려는 사용자는 `@vapor-ui/core`의 `--vapor-color-*`를 1차 기준으로 삼는 편이 안전하다.
 
 ### Base palette (11 family × 10 step)
 
@@ -644,5 +648,5 @@ Vapor 시스템은 imagery treatment를 강제하지 않는다. goorm 마케팅 
 1. https://vapor-ui.goorm.io/ — 공식 docs/데모 사이트, goorm 네이밍·운영 컨텍스트.
 2. https://blog.goorm.io/vapor-figma-seoul/ — goorm 공식 블로그 "Vapor at Figma Config Seoul 2025", Vapor Squad 조직(2025년 4월 신설, Squad Lead 최준영, CDO 이태성)·SSOT 자동화·MCP Server 컨텍스트.
 3. https://www.figma.com/community/file/1508829832204351721/vapor-design-system — Vapor Design System Figma Community 파일.
-4. https://www.npmjs.com/package/@vapor-ui/core — `@vapor-ui/core` 1.3.0 npm 페이지(peer 의존, 카테고리, MIT © 2025 goorm Inc.).
-5. https://github.com/goorm-dev/vapor-ui — GitHub 모노레포(6 패키지 구조: core / hooks / icons / codemod / color-generator / css-generator, README 카피).
+4. https://www.npmjs.com/package/@vapor-ui/core — `@vapor-ui/core` npm 페이지(peer 의존, 카테고리, MIT © 2025 goorm Inc.). 본문은 1.3.0 기준으로 쓰였고 2026-07-27 현재 최신은 1.4.0이나, 팔레트를 담은 `dist/styles/themes.css.ts.vanilla.css`는 두 버전이 바이트 단위로 동일하다 — Colors 절의 값 차이는 버전 드리프트가 아니다.
+5. https://github.com/goorm-dev/vapor-ui — GitHub 모노레포(6 패키지 구조: core / hooks / icons / codemod / color-generator / css-generator, README 카피). **루트 URL 하나가 본문 인용의 대부분을 떠받치고 있어**, 개별 주장을 이 링크만으로 확인하기 어렵다. 토큰 값은 [src:4]의 배포 CSS가, 정책·카피 서술은 이 저장소의 README와 docs 소스가 각각 1차 근거다.

--- a/services/vapor-ui.tokens.json
+++ b/services/vapor-ui.tokens.json
@@ -2,563 +2,674 @@
   "colors": [
     {
       "name": "gray-050",
-      "value": "oklch(0.984 0.000 0)",
+      "value": "oklch(0.976 0.000 0)",
+      "note": "#F7F7F7",
       "group": "Base palette"
     },
     {
       "name": "gray-100",
-      "value": "oklch(0.972 0.000 0)",
+      "value": "oklch(0.910 0.000 0)",
+      "note": "#E1E1E1",
       "group": "Base palette"
     },
     {
       "name": "gray-200",
-      "value": "oklch(0.892 0.000 0)",
+      "value": "oklch(0.827 0.000 0)",
+      "note": "#C6C6C6",
       "group": "Base palette"
     },
     {
       "name": "gray-300",
-      "value": "oklch(0.804 0.000 0)",
+      "value": "oklch(0.715 0.000 0)",
+      "note": "#A3A3A3",
       "group": "Base palette"
     },
     {
       "name": "gray-400",
-      "value": "oklch(0.712 0.000 0)",
+      "value": "oklch(0.670 0.000 0)",
+      "note": "#959595",
       "group": "Base palette"
     },
     {
       "name": "gray-500",
-      "value": "oklch(0.658 0.000 0)",
+      "value": "oklch(0.566 0.000 0)",
+      "note": "#767676",
       "group": "Base palette"
     },
     {
       "name": "gray-600",
-      "value": "oklch(0.453 0.000 0)",
+      "value": "oklch(0.478 0.000 0)",
+      "note": "#5D5D5D",
       "group": "Base palette"
     },
     {
       "name": "gray-700",
-      "value": "oklch(0.314 0.000 0)",
+      "value": "oklch(0.417 0.000 0)",
+      "note": "#4C4C4C",
       "group": "Base palette"
     },
     {
       "name": "gray-800",
-      "value": "oklch(0.234 0.000 0)",
+      "value": "oklch(0.345 0.000 0)",
+      "note": "#393939",
       "group": "Base palette"
     },
     {
       "name": "gray-900",
-      "value": "oklch(0.169 0.000 0)",
+      "value": "oklch(0.269 0.000 0)",
+      "note": "#262626",
       "group": "Base palette"
     },
     {
       "name": "blue-050",
-      "value": "oklch(0.974 0.018 254)",
+      "value": "oklch(0.974 0.013 241)",
+      "note": "#EFF8FF",
       "group": "Base palette"
     },
     {
       "name": "blue-100",
-      "value": "oklch(0.901 0.052 254)",
+      "value": "oklch(0.910 0.048 242)",
+      "note": "#C6E6FF",
       "group": "Base palette"
     },
     {
       "name": "blue-200",
-      "value": "oklch(0.781 0.110 264)",
+      "value": "oklch(0.824 0.096 243)",
+      "note": "#8DCDFF",
       "group": "Base palette"
     },
     {
       "name": "blue-300",
-      "value": "oklch(0.690 0.146 261)",
+      "value": "oklch(0.715 0.142 248)",
+      "note": "#51A9F7",
       "group": "Base palette"
     },
     {
       "name": "blue-400",
-      "value": "oklch(0.638 0.166 258)",
+      "value": "oklch(0.669 0.158 252)",
+      "note": "#4198F2",
       "group": "Base palette"
     },
     {
       "name": "blue-500",
-      "value": "oklch(0.581 0.181 254)",
-      "note": "브랜드 primary",
+      "value": "oklch(0.573 0.189 260)",
+      "note": "#2A72E5 · 브랜드 primary",
       "group": "Base palette"
     },
     {
       "name": "blue-600",
-      "value": "oklch(0.560 0.196 257)",
+      "value": "oklch(0.488 0.189 260)",
+      "note": "#0957C8",
       "group": "Base palette"
     },
     {
       "name": "blue-700",
-      "value": "oklch(0.451 0.166 259)",
+      "value": "oklch(0.428 0.187 261)",
+      "note": "#0043B3",
       "group": "Base palette"
     },
     {
       "name": "blue-800",
-      "value": "oklch(0.348 0.142 263)",
+      "value": "oklch(0.358 0.185 263)",
+      "note": "#002B9B",
       "group": "Base palette"
     },
     {
       "name": "blue-900",
-      "value": "oklch(0.232 0.156 270)",
+      "value": "oklch(0.289 0.184 264)",
+      "note": "#000E84",
       "group": "Base palette"
     },
     {
       "name": "cyan-050",
-      "value": "oklch(0.978 0.013 215)",
+      "value": "oklch(0.974 0.012 210)",
+      "note": "#EEF9FB",
       "group": "Base palette"
     },
     {
       "name": "cyan-100",
-      "value": "oklch(0.911 0.039 220)",
+      "value": "oklch(0.906 0.041 212)",
+      "note": "#C2E8F0",
       "group": "Base palette"
     },
     {
       "name": "cyan-200",
-      "value": "oklch(0.812 0.078 224)",
+      "value": "oklch(0.819 0.080 212)",
+      "note": "#84D2E2",
       "group": "Base palette"
     },
     {
       "name": "cyan-300",
-      "value": "oklch(0.703 0.105 226)",
+      "value": "oklch(0.706 0.119 213)",
+      "note": "#1BB3CC",
       "group": "Base palette"
     },
     {
       "name": "cyan-400",
-      "value": "oklch(0.633 0.110 230)",
+      "value": "oklch(0.659 0.113 214)",
+      "note": "#14A3BC",
       "group": "Base palette"
     },
     {
       "name": "cyan-500",
-      "value": "oklch(0.567 0.107 230)",
+      "value": "oklch(0.558 0.100 220)",
+      "note": "#04819C",
       "group": "Base palette"
     },
     {
       "name": "cyan-600",
-      "value": "oklch(0.475 0.099 232)",
+      "value": "oklch(0.474 0.088 223)",
+      "note": "#006680",
       "group": "Base palette"
     },
     {
       "name": "cyan-700",
-      "value": "oklch(0.388 0.080 233)",
+      "value": "oklch(0.412 0.079 227)",
+      "note": "#00536C",
       "group": "Base palette"
     },
     {
       "name": "cyan-800",
-      "value": "oklch(0.309 0.061 233)",
+      "value": "oklch(0.342 0.071 233)",
+      "note": "#003E57",
       "group": "Base palette"
     },
     {
       "name": "cyan-900",
-      "value": "oklch(0.255 0.057 232)",
+      "value": "oklch(0.268 0.062 241)",
+      "note": "#002941",
       "group": "Base palette"
     },
     {
       "name": "green-050",
-      "value": "oklch(0.978 0.022 156)",
+      "value": "oklch(0.974 0.016 167)",
+      "note": "#EDFAF4",
       "group": "Base palette"
     },
     {
       "name": "green-100",
-      "value": "oklch(0.913 0.075 154)",
+      "value": "oklch(0.903 0.058 167)",
+      "note": "#BBECD7",
       "group": "Base palette"
     },
     {
       "name": "green-200",
-      "value": "oklch(0.831 0.117 153)",
+      "value": "oklch(0.814 0.109 167)",
+      "note": "#75D9B4",
       "group": "Base palette"
     },
     {
       "name": "green-300",
-      "value": "oklch(0.726 0.158 151)",
+      "value": "oklch(0.704 0.120 167)",
+      "note": "#43B790",
       "group": "Base palette"
     },
     {
       "name": "green-400",
-      "value": "oklch(0.652 0.157 154)",
+      "value": "oklch(0.655 0.117 167)",
+      "note": "#33A782",
       "group": "Base palette"
     },
     {
       "name": "green-500",
-      "value": "oklch(0.566 0.114 167)",
+      "value": "oklch(0.554 0.112 167)",
+      "note": "#058765",
       "group": "Base palette"
     },
     {
       "name": "green-600",
-      "value": "oklch(0.467 0.094 169)",
+      "value": "oklch(0.470 0.101 164)",
+      "note": "#006C4B",
       "group": "Base palette"
     },
     {
       "name": "green-700",
-      "value": "oklch(0.376 0.075 169)",
+      "value": "oklch(0.407 0.090 162)",
+      "note": "#00583A",
       "group": "Base palette"
     },
     {
       "name": "green-800",
-      "value": "oklch(0.294 0.067 170)",
+      "value": "oklch(0.334 0.078 158)",
+      "note": "#004226",
       "group": "Base palette"
     },
     {
       "name": "green-900",
-      "value": "oklch(0.246 0.057 168)",
+      "value": "oklch(0.264 0.069 152)",
+      "note": "#002E13",
       "group": "Base palette"
     },
     {
       "name": "lime-050",
-      "value": "oklch(0.978 0.044 122)",
+      "value": "oklch(0.974 0.026 129)",
+      "note": "#F1FAE8",
       "group": "Base palette"
     },
     {
       "name": "lime-100",
-      "value": "oklch(0.926 0.116 124)",
+      "value": "oklch(0.901 0.097 130)",
+      "note": "#C9ECA8",
       "group": "Base palette"
     },
     {
       "name": "lime-200",
-      "value": "oklch(0.857 0.158 127)",
+      "value": "oklch(0.813 0.182 130)",
+      "note": "#9AD84A",
       "group": "Base palette"
     },
     {
       "name": "lime-300",
-      "value": "oklch(0.787 0.184 130)",
+      "value": "oklch(0.703 0.188 132)",
+      "note": "#71B61A",
       "group": "Base palette"
     },
     {
       "name": "lime-400",
-      "value": "oklch(0.689 0.187 131)",
+      "value": "oklch(0.654 0.179 133)",
+      "note": "#61A613",
       "group": "Base palette"
     },
     {
       "name": "lime-500",
-      "value": "oklch(0.566 0.158 132)",
+      "value": "oklch(0.553 0.163 135)",
+      "note": "#428600",
       "group": "Base palette"
     },
     {
       "name": "lime-600",
-      "value": "oklch(0.464 0.130 132)",
+      "value": "oklch(0.468 0.146 138)",
+      "note": "#276C00",
       "group": "Base palette"
     },
     {
       "name": "lime-700",
-      "value": "oklch(0.371 0.106 133)",
+      "value": "oklch(0.408 0.134 141)",
+      "note": "#115A00",
       "group": "Base palette"
     },
     {
       "name": "lime-800",
-      "value": "oklch(0.292 0.085 133)",
+      "value": "oklch(0.335 0.114 142)",
+      "note": "#004400",
       "group": "Base palette"
     },
     {
       "name": "lime-900",
-      "value": "oklch(0.225 0.078 134)",
+      "value": "oklch(0.261 0.089 142)",
+      "note": "#002E00",
       "group": "Base palette"
     },
     {
       "name": "yellow-050",
-      "value": "oklch(0.971 0.044 79)",
+      "value": "oklch(0.978 0.023 85)",
+      "note": "#FFF7E7",
       "group": "Base palette"
     },
     {
       "name": "yellow-100",
-      "value": "oklch(0.906 0.111 84)",
+      "value": "oklch(0.910 0.098 85)",
+      "note": "#FFDD95",
       "group": "Base palette"
     },
     {
       "name": "yellow-200",
-      "value": "oklch(0.847 0.158 79)",
+      "value": "oklch(0.832 0.170 85)",
+      "note": "#FBBD05",
       "group": "Base palette"
     },
     {
       "name": "yellow-300",
-      "value": "oklch(0.768 0.166 65)",
+      "value": "oklch(0.723 0.151 78)",
+      "note": "#D99700",
       "group": "Base palette"
     },
     {
       "name": "yellow-400",
-      "value": "oklch(0.660 0.158 60)",
+      "value": "oklch(0.675 0.143 74)",
+      "note": "#CA8700",
       "group": "Base palette"
     },
     {
       "name": "yellow-500",
-      "value": "oklch(0.560 0.142 56)",
+      "value": "oklch(0.575 0.126 68)",
+      "note": "#A96800",
       "group": "Base palette"
     },
     {
       "name": "yellow-600",
-      "value": "oklch(0.456 0.121 55)",
+      "value": "oklch(0.491 0.113 62)",
+      "note": "#8D4F00",
       "group": "Base palette"
     },
     {
       "name": "yellow-700",
-      "value": "oklch(0.371 0.099 56)",
+      "value": "oklch(0.428 0.106 55)",
+      "note": "#7A3C00",
       "group": "Base palette"
     },
     {
       "name": "yellow-800",
-      "value": "oklch(0.318 0.081 53)",
+      "value": "oklch(0.354 0.098 47)",
+      "note": "#632700",
       "group": "Base palette"
     },
     {
       "name": "yellow-900",
-      "value": "oklch(0.275 0.083 53)",
+      "value": "oklch(0.281 0.094 37)",
+      "note": "#4D1100",
       "group": "Base palette"
     },
     {
       "name": "orange-050",
-      "value": "oklch(0.957 0.025 30)",
+      "value": "oklch(0.979 0.012 51)",
+      "note": "#FFF6F1",
       "group": "Base palette"
     },
     {
       "name": "orange-100",
-      "value": "oklch(0.872 0.072 32)",
+      "value": "oklch(0.913 0.048 46)",
+      "note": "#FFD9C8",
       "group": "Base palette"
     },
     {
       "name": "orange-200",
-      "value": "oklch(0.778 0.131 34)",
+      "value": "oklch(0.836 0.092 46)",
+      "note": "#FCB797",
       "group": "Base palette"
     },
     {
       "name": "orange-300",
-      "value": "oklch(0.703 0.166 36)",
+      "value": "oklch(0.731 0.151 46)",
+      "note": "#F4864F",
       "group": "Base palette"
     },
     {
       "name": "orange-400",
-      "value": "oklch(0.628 0.190 38)",
+      "value": "oklch(0.685 0.177 46)",
+      "note": "#EF6F25",
       "group": "Base palette"
     },
     {
       "name": "orange-500",
-      "value": "oklch(0.557 0.179 38)",
+      "value": "oklch(0.588 0.187 39)",
+      "note": "#D34701",
       "group": "Base palette"
     },
     {
       "name": "orange-600",
-      "value": "oklch(0.464 0.169 39)",
+      "value": "oklch(0.503 0.188 33)",
+      "note": "#B72100",
       "group": "Base palette"
     },
     {
       "name": "orange-700",
-      "value": "oklch(0.385 0.150 41)",
+      "value": "oklch(0.439 0.180 29)",
+      "note": "#9E0000",
       "group": "Base palette"
     },
     {
       "name": "orange-800",
-      "value": "oklch(0.346 0.135 41)",
+      "value": "oklch(0.362 0.148 29)",
+      "note": "#790000",
       "group": "Base palette"
     },
     {
       "name": "orange-900",
-      "value": "oklch(0.300 0.119 41)",
+      "value": "oklch(0.285 0.117 29)",
+      "note": "#560000",
       "group": "Base palette"
     },
     {
       "name": "red-050",
-      "value": "oklch(0.957 0.020 17)",
+      "value": "oklch(0.978 0.011 24)",
+      "note": "#FFF5F4",
       "group": "Base palette"
     },
     {
       "name": "red-100",
-      "value": "oklch(0.881 0.057 18)",
+      "value": "oklch(0.915 0.044 20)",
+      "note": "#FFD8D7",
       "group": "Base palette"
     },
     {
       "name": "red-200",
-      "value": "oklch(0.795 0.115 18)",
+      "value": "oklch(0.838 0.089 20)",
+      "note": "#FFB3B2",
       "group": "Base palette"
     },
     {
       "name": "red-300",
-      "value": "oklch(0.687 0.180 19)",
+      "value": "oklch(0.736 0.155 21)",
+      "note": "#FC7D7F",
       "group": "Base palette"
     },
     {
       "name": "red-400",
-      "value": "oklch(0.638 0.213 19)",
+      "value": "oklch(0.691 0.183 20)",
+      "note": "#F8636A",
       "group": "Base palette"
     },
     {
       "name": "red-500",
-      "value": "oklch(0.577 0.198 21)",
+      "value": "oklch(0.591 0.197 22)",
+      "note": "#DA3944",
       "group": "Base palette"
     },
     {
       "name": "red-600",
-      "value": "oklch(0.488 0.181 22)",
+      "value": "oklch(0.505 0.196 24)",
+      "note": "#BB1225",
       "group": "Base palette"
     },
     {
       "name": "red-700",
-      "value": "oklch(0.405 0.181 25)",
+      "value": "oklch(0.439 0.180 28)",
+      "note": "#9E0006",
       "group": "Base palette"
     },
     {
       "name": "red-800",
-      "value": "oklch(0.330 0.169 28)",
+      "value": "oklch(0.362 0.148 29)",
+      "note": "#790000",
       "group": "Base palette"
     },
     {
       "name": "red-900",
-      "value": "oklch(0.255 0.144 28)",
+      "value": "oklch(0.287 0.118 29)",
+      "note": "#570000",
       "group": "Base palette"
     },
     {
       "name": "pink-050",
-      "value": "oklch(0.957 0.018 13)",
+      "value": "oklch(0.978 0.011 3)",
+      "note": "#FFF5F7",
       "group": "Base palette"
     },
     {
       "name": "pink-100",
-      "value": "oklch(0.870 0.054 5)",
+      "value": "oklch(0.918 0.045 1)",
+      "note": "#FFD8E2",
       "group": "Base palette"
     },
     {
       "name": "pink-200",
-      "value": "oklch(0.770 0.117 6)",
+      "value": "oklch(0.840 0.094 2)",
+      "note": "#FFB1C6",
       "group": "Base palette"
     },
     {
       "name": "pink-300",
-      "value": "oklch(0.652 0.176 7)",
+      "value": "oklch(0.737 0.155 2)",
+      "note": "#F77CA3",
       "group": "Base palette"
     },
     {
       "name": "pink-400",
-      "value": "oklch(0.567 0.179 8)",
+      "value": "oklch(0.692 0.181 2)",
+      "note": "#F26394",
       "group": "Base palette"
     },
     {
       "name": "pink-500",
-      "value": "oklch(0.510 0.180 8)",
+      "value": "oklch(0.592 0.188 2)",
+      "note": "#D13E76",
       "group": "Base palette"
     },
     {
       "name": "pink-600",
-      "value": "oklch(0.418 0.168 8)",
+      "value": "oklch(0.506 0.195 2)",
+      "note": "#B5135D",
       "group": "Base palette"
     },
     {
       "name": "pink-700",
-      "value": "oklch(0.339 0.158 8)",
+      "value": "oklch(0.442 0.178 4)",
+      "note": "#9A0047",
       "group": "Base palette"
     },
     {
       "name": "pink-800",
-      "value": "oklch(0.296 0.146 9)",
+      "value": "oklch(0.364 0.146 9)",
+      "note": "#77002D",
       "group": "Base palette"
     },
     {
       "name": "pink-900",
-      "value": "oklch(0.279 0.137 8)",
+      "value": "oklch(0.286 0.114 16)",
+      "note": "#550016",
       "group": "Base palette"
     },
     {
       "name": "grape-050",
-      "value": "oklch(0.954 0.024 308)",
+      "value": "oklch(0.978 0.014 319)",
+      "note": "#FCF5FE",
       "group": "Base palette"
     },
     {
       "name": "grape-100",
-      "value": "oklch(0.866 0.087 312)",
+      "value": "oklch(0.916 0.056 319)",
+      "note": "#F4D8FB",
       "group": "Base palette"
     },
     {
       "name": "grape-200",
-      "value": "oklch(0.755 0.166 314)",
+      "value": "oklch(0.840 0.107 319)",
+      "note": "#E9B4F7",
       "group": "Base palette"
     },
     {
       "name": "grape-300",
-      "value": "oklch(0.633 0.225 316)",
+      "value": "oklch(0.739 0.173 319)",
+      "note": "#D883EF",
       "group": "Base palette"
     },
     {
       "name": "grape-400",
-      "value": "oklch(0.546 0.230 316)",
+      "value": "oklch(0.693 0.202 319)",
+      "note": "#D06BEA",
       "group": "Base palette"
     },
     {
       "name": "grape-500",
-      "value": "oklch(0.475 0.215 314)",
+      "value": "oklch(0.597 0.224 319)",
+      "note": "#B542D1",
       "group": "Base palette"
     },
     {
       "name": "grape-600",
-      "value": "oklch(0.391 0.193 313)",
+      "value": "oklch(0.511 0.229 319)",
+      "note": "#9A1CB7",
       "group": "Base palette"
     },
     {
       "name": "grape-700",
-      "value": "oklch(0.317 0.169 312)",
+      "value": "oklch(0.448 0.217 318)",
+      "note": "#83009F",
       "group": "Base palette"
     },
     {
       "name": "grape-800",
-      "value": "oklch(0.279 0.158 311)",
+      "value": "oklch(0.370 0.182 316)",
+      "note": "#62007E",
       "group": "Base palette"
     },
     {
       "name": "grape-900",
-      "value": "oklch(0.260 0.157 313)",
+      "value": "oklch(0.292 0.146 312)",
+      "note": "#43005E",
       "group": "Base palette"
     },
     {
       "name": "violet-050",
-      "value": "oklch(0.946 0.040 296)",
+      "value": "oklch(0.976 0.014 304)",
+      "note": "#F9F5FF",
       "group": "Base palette"
     },
     {
       "name": "violet-100",
-      "value": "oklch(0.853 0.121 297)",
+      "value": "oklch(0.915 0.051 305)",
+      "note": "#EBDBFF",
       "group": "Base palette"
     },
     {
       "name": "violet-200",
-      "value": "oklch(0.713 0.205 296)",
+      "value": "oklch(0.837 0.102 305)",
+      "note": "#D9B9FF",
       "group": "Base palette"
     },
     {
       "name": "violet-300",
-      "value": "oklch(0.560 0.270 295)",
+      "value": "oklch(0.733 0.152 299)",
+      "note": "#B691FA",
       "group": "Base palette"
     },
     {
       "name": "violet-400",
-      "value": "oklch(0.494 0.275 295)",
+      "value": "oklch(0.686 0.172 295)",
+      "note": "#A480F7",
       "group": "Base palette"
     },
     {
       "name": "violet-500",
-      "value": "oklch(0.439 0.245 290)",
+      "value": "oklch(0.588 0.207 290)",
+      "note": "#805CEC",
       "group": "Base palette"
     },
     {
       "name": "violet-600",
-      "value": "oklch(0.366 0.220 287)",
+      "value": "oklch(0.503 0.208 290)",
+      "note": "#693FCF",
       "group": "Base palette"
     },
     {
       "name": "violet-700",
-      "value": "oklch(0.300 0.197 283)",
+      "value": "oklch(0.442 0.208 290)",
+      "note": "#5929BA",
       "group": "Base palette"
     },
     {
       "name": "violet-800",
-      "value": "oklch(0.292 0.193 283)",
+      "value": "oklch(0.373 0.207 290)",
+      "note": "#4805A3",
       "group": "Base palette"
     },
     {
       "name": "violet-900",
-      "value": "oklch(0.279 0.187 282)",
+      "value": "oklch(0.293 0.170 286)",
+      "note": "#2E007A",
       "group": "Base palette"
     },
     {
       "name": "color-white",
       "value": "oklch(1.000 0.000 0)",
+      "note": "#FFFFFF",
       "group": "Base palette"
     },
     {
       "name": "color-black",
       "value": "oklch(0.000 0.000 0)",
+      "note": "#000000",
       "group": "Base palette"
     }
   ],


### PR DESCRIPTION
계획서의 인용 의미 감사 1차 배치. 편중도가 가장 높은 두 항목(vapor-ui `[src:5]` 110/114 = 96%, bezier `[src:2]` 112/161 = 70%)을 공개 배포물과 **전수** 대조했고, 결과가 정반대로 갈렸습니다.

> **정정(리뷰 반영).** 이 본문은 원래 vapor-ui에 대해 *"방침대로 값은 그대로 두고 차이만 명시했습니다"*라고 적고 있었습니다. **더 이상 사실이 아닙니다** — 리뷰에서 사이드카 소비 경로 문제가 제기돼 방침을 바꾸고 **팔레트 110개를 전량 공식 발행값으로 교체**했습니다(`c00e477`). 아래 vapor-ui 절이 최종 상태입니다.

## 대조 방법

두 브랜드 모두 값의 authoritative 출처는 npm 배포물입니다. 패키지를 받아 토큰 CSS를 뽑고, 저장소의 `src/lib/oklch-convert`(검증기·`audit:oklch`와 같은 코드)로 md의 OKLCH와 ΔE 비교했습니다. 서브에이전트 판정이 아니라 결정론적 계산입니다.

## bezier — 값은 결함이 아니었습니다

비공개 핸드오프 번들에서 나온 값인데도 published `@channel.io/bezier-tokens` 0.6.0으로 **재현됩니다.**

| 주장 | 결과 |
|---|---|
| 색 토큰 43개 | **43/43 ΔE ≤ 0.02** |
| 컴포넌트 59개 이름 | Storybook 문서와 **1:1**, 양방향 누락 0 |
| "components 59 + foundation 3 + utility 2 = 64 docs" | 인덱스 실측과 **정확히** 일치 |
| "빌드 CSS 변수 450개" | stable 엔트리 CSS **정확히 450** |
| z-index 7단계 · 150/300/450ms · `cubic-bezier(0.3, 0, 0, 1)` · `--opacity-disabled: 0.4` | 전부 일치 |
| letter-spacing 적용 구간(15~17px ↔ 22px↑) | 일치 |

**tier 구분이 이 감사의 핵심이었습니다.** 색은 beta tier, 타이포·radius는 stable tier이고 같은 토큰 이름이 tier마다 다른 값을 갖습니다(`grey-900`이 stable `#242428` ↔ beta `#1d1d20`). tier를 안 나누고 봤다면 "굵기 2단계", "radius-44", "font-size 11~36"을 전부 **없는 결함으로 오판**했을 것입니다.

수정:
- 아이콘 패키지 0.59.0 → **0.60.0**, SVG 598 → **602** (문서 4곳 + 프리뷰 카피 8곳)
- **"토큰 JSON 39종" 철회** — 공개 패키지는 JSON을 1개만 싣습니다
- `grey-900` "가장 짙은 다크 표면" → beta에 더 짙은 `grey-950`이 있습니다
- Known Gaps의 "beta 팔레트가 공개 URL로 교차검증되지 않는다" 항목 정정 — 이번 대조로 해소됐습니다
- References에 설명 추가 + **Storybook 인덱스를 5번 출처로 신설.** 루트 URL은 9.6KB JS 셸이라 텍스트가 `@storybook/core - Storybook` 한 줄뿐이고, 개별 문서는 `?path=/docs/<id>` 딥링크로 가야 합니다 — 112건이 그 루트를 가리키고 있었습니다

## vapor-ui — 팔레트 110개를 공식 발행값으로 교체했습니다

정정 **전** 상태: 110개 중 ΔE ≤ 0.02는 15개뿐, **46개가 ΔE > 0.05**. 공개 출처 두 곳(`@vapor-ui/core` 배포 CSS, docs 사이트가 서빙하는 팔레트 청크)은 서로 일치하는데 문서만 달랐습니다. 버전 요인도 배제했습니다 — 1.3.0과 1.4.0의 팔레트 CSS는 **바이트 동일**입니다.

| 계열 | 정정 전 ΔE > 0.05 | 최대 편차 | 정정 후 |
|---|---|---|---|
| violet | 8/10 | `violet-400` 0.218 | 0/10 |
| grape | 8/10 | `grape-400` 0.150 | 0/10 |
| gray | 7/10 | `gray-800` 0.111 | 0/10 |
| pink | 7/10 | `pink-400` 0.127 | 0/10 |
| blue | 3/10 | `blue-600` 0.073 | 0/10 |
| lime | 3/10 | `lime-300` 0.084 | 0/10 |
| orange | 3/10 | `orange-200` 0.074 | 0/10 |
| red | 3/10 | `red-400` 0.061 | 0/10 |
| green | 2/10 | `green-300` 0.059 | 0/10 |
| yellow | 2/10 | `yellow-300` 0.059 | 0/10 |
| cyan | **0/10** | — | 0/10 |
| **합계** | **46/110** | | **0/110** |

`violet-400`은 패키지 `#A480F7` ≈ `oklch(0.686 0.172 295)`, 문서 `oklch(0.494 0.275 295)`로 **hue는 같고(295) 명도·채도만** 벌어졌습니다 — 반올림으로는 설명되지 않는 폭입니다.

### 값을 고친 이유 (방침 변경)

처음에는 계획 방침대로 값을 두고 차이만 명시했습니다. 리뷰에서 **사이드카 소비 경로**가 지적돼 뒤집었습니다:

| 소비 경로 | 산문 caveat 전달 |
|---|---|
| 사이트 Colors 절 | ✅ |
| 사이트 Tokens 탭 "Copy JSON" | ❌ |
| `/use-design-md` 스킬 (`curl …tokens.json` → Tailwind·CSS 변수 생성) | ❌ |

제가 적었던 반대 근거("덮어쓰면 제3의 팔레트가 된다")도 성립하지 않습니다 — 그건 *일부만* 바꿀 때 얘기이고, 110개 전량을 맞추면 그냥 공식 팔레트입니다.

### 부수 이득 — 게이트 커버리지

| | 이전 | 이후 |
|---|---|---|
| vapor-ui `audit:oklch` 판정 | **0개** (hex 병기 없음) | **112개** |
| 카탈로그 전체 판정 대상 | 474 | **586** |

이 110개는 원래 hex 주석이 없어 게이트가 **하나도 검사하지 못하고 있었습니다.** 이제 다음 드리프트는 CI가 잡습니다.

프리뷰 파생 리터럴 87개도 동기화했습니다(light 40 / dark 47). `audit:oklch --sync`로는 안 되는 경우였습니다 — 전파할 old→new 쌍은 `--fix`가 만드는데 정의를 이미 고쳐서 `--fix`가 찾을 게 없습니다. 쌍을 git에서 뽑아 저장소의 one-pass 치환기에 넘겼습니다.

## 계획서 사전 판단 2건이 뒤집혔습니다

- bezier의 Chromatic 주소를 "빌드마다 바뀌는 임시 호스트"로 적었는데, `main--<appId>` **브랜치 퍼머링크**라 안정적입니다
- "카탈로그 최고 위험 파일"로 지목했던 bezier가 **값이 가장 잘 검증된 항목**이었습니다 — 편중도는 위험 신호이지 결함 자체가 아닙니다

## 검증

typecheck 0 · lint 0 · **295 tests** · `validate:catalog` 0 blocking / **10 warn** · `validate:previews` 0 blocking · `tokens:check` OK · `audit:oklch` **577/586 judged** / 0 mismatched · `build` OK.

`tokens:check` 실패 시마다 `pnpm tokens:build <slug>`로 사이드카를 재생성해 함께 커밋했습니다(bezier, vapor-ui).