### PR TITLE
docs(catalog): socar 프레임워크 단정에 근거를 붙인다

### DIFF
--- a/services/socar.md
+++ b/services/socar.md
@@ -608,7 +608,7 @@ const ok = await Alert.open({ variant: "dialog", title: "예약을 취소할까�
 
 ## References
 
-1. https://socarframe.socar.kr/ — SOCAR Frame 2.0 공식 사이트. Docusaurus 클라이언트 렌더라 어떤 경로도 평범한 GET에는 동일한 166자 셸만 반환한다 — 인용 내용은 브라우저로 렌더해야 확인된다.
+1. https://socarframe.socar.kr/ — SOCAR Frame 2.0 공식 사이트. 어떤 경로도 평범한 GET에는 동일한 166자 셸만 반환하므로 인용 내용은 브라우저로 렌더해야 확인된다. 클라이언트 렌더 스택은 응답 자체에 적혀 있다 — `<meta name="generator" content="Docusaurus v3.5.2">`, 루트 엘리먼트 `id="__docusaurus"`, `<html class="plugin-pages plugin-id-default">`(2026-07-29 확인).
 2. https://socar.kr/
 3. https://socarframe.socar.kr/development/components/Alert
 4. https://socarframe.socar.kr/development/foundation/Colors


### PR DESCRIPTION
#196 리뷰의 후속입니다. 머지 후 도착한 리뷰가 짚은 1건을 처리합니다.

## 지적

`services/socar.md` References #1이 **"Docusaurus 클라이언트 렌더라"**고 프레임워크를 특정했는데, 근거가 문서에도 PR 설명에도 없었습니다. 같은 PR에서 LINE 쪽 "Gatsby" 판단은 `page-data.json`이라는 Gatsby 고유 경로 컨벤션을 명시적 근거로 제시한 것과 대비됩니다.

리뷰어 표현이 정확합니다 — **"이 PR 자체가 검증 없이 확정형으로 서술하면 안 된다는 것을 다루고 있는 만큼, 같은 함정을 작게라도 재현하지 않도록"**. 인용 감사 작업에서 근거 없는 단정을 남긴 건 그냥 앞뒤가 안 맞습니다.

## 확인 결과

주장 자체는 맞았고 빠진 건 근거뿐이었습니다. 응답에 그대로 적혀 있습니다:

```
meta generator : <meta name="generator" content="Docusaurus v3.5.2">
root element   : id="__docusaurus"
html class     : plugin-pages plugin-id-default
```

References 항목에 이 세 마커를 확인 날짜와 함께 적어, 다음 감사자가 같은 판정을 재현할 수 있게 했습니다. 완화("SPA로 보임")가 아니라 근거 명시를 택한 건 실제로 확정할 수 있는 사안이기 때문입니다.

## 나머지 리뷰 항목

| 항목 | 처리 |
|---|---|
| `socar.tokens.json` 재생성 확인 | **이미 했습니다** — `pnpm tokens:build socar` 후 `tokens:check` 통과. PR 설명에 line만 적어 오해를 샀습니다 |
| `page-data.json` 장기 안정성 | 동의하며 조치 없음. References 설명에 `[src:1]`과 같은 페이지의 데이터 파일이라 적어 둬서, 죽더라도 무엇을 대체할지는 남습니다 |
| 네트워크 재확인 요청 | #196 머지 전에 직접 fetch해 증거를 코멘트로 남겼습니다(18 그룹·696 스와치·고유 194색) |

## 검증

**326 tests** · `validate:catalog` 0 blocking / 10 warn · `tokens:check` OK · `audit:oklch` 0 mismatched · `build` OK.