### PR TITLE
fix(catalog): 자동 판정 불가 출처 4건을 브라우저로 확인하고 성격을 명시

### DIFF
--- a/services/baemin.md
+++ b/services/baemin.md
@@ -2,7 +2,7 @@
 name: 배달의민족
 slug: baemin
 category: delivery
-last_updated: "2026-07-26"
+last_updated: "2026-08-02"
 created_at: 2026-05-18
 sources:
   - https://designcompass.org/en/2025/07/23/baemin-2-rebranding/

--- a/services/baemin.md
+++ b/services/baemin.md
@@ -27,7 +27,7 @@ logo: https://getdesign.kr/logos/baemin.svg
 
 ## Brand & Style
 
-배달의민족(배민)은 우아한형제들이 2010년부터 운영해 온 한국 점유율 1위 음식·생필품 배달 슈퍼앱이며, 디자이너 출신 김봉진 의장이 창업했다. 음식배달을 주력으로 한그릇(최소주문금액 없는 1인분)·B마트(자체 물류 1시간 배송)·배민스토어(편의점·마트 즉시배송)·픽업·선물하기·배민클럽 멤버십이 한 앱 안에서 탭으로 묶여 있다 [src:1].
+배달의민족(배민)은 우아한형제들이 2010년부터 운영해 온 한국 점유율 1위 음식·생필품 배달 슈퍼앱이며, 디자이너 출신 김봉진 의장이 창업했다. 모회사·연혁은 우아한형제들 공식 사이트가 근거다 [src:2]. 음식배달을 주력으로 한그릇(최소주문금액 없는 1인분)·B마트(자체 물류 1시간 배송)·배민스토어(편의점·마트 즉시배송)·픽업·선물하기·배민클럽 멤버십이 한 앱 안에서 탭으로 묶여 있다 [src:1].
 
 브랜드 정체성의 출발점은 **"한국 길거리 간판 미학을 디지털로 가져온다"**는 단 한 줄로 요약된다. 1960~70년대 시트지·아크릴·붓글씨 간판의 울퉁불퉁한 손맛을 디지털 폰트와 일러스트로 옮기고, 영문 SaaS의 "Pro/Premium/Plus" 자리에 `한그릇`·`B마트`·`먹깨비` 같은 순우리말 작명을 채워 넣는다. 글로벌 핀테크 미니멀의 슬릭함을 의도적으로 피하고, **"예쁘지는 않지만 사랑스럽다"**(김봉진)는 자기 미감 메타 코멘트를 10년 이상 일관되게 노출해 왔다 [src:1][src:12][src:13].
 
@@ -867,14 +867,14 @@ iOS 상태표시줄 아래 위치하는 검색 화면 헤더. 좌측 `←` back,
 ## References
 
 1. https://designcompass.org/en/2025/07/23/baemin-2-rebranding/ — Baemin 2.0 리브랜드 (2024년 7월, 김범석 대표 코멘트, WORK 폰트 공개)
-2. https://woowahan.com — 우아한형제들 공식 사이트, 모회사 / IR / 폰트 라이선스 진입
+2. https://woowahan.com — 우아한형제들 공식 사이트, 모회사 / IR / 폰트 라이선스 진입 **봇 요청에는 403을 반환한다(WAF)** — 죽은 링크가 아니라 브라우저로 열어야 읽힌다.
 3. https://www.the-pr.co.kr/news/articleView.html?idxno=19376 — 배민 민트 CMYK 65:0:29:0 채택 근거 (The PR)
 4. https://www.specialtimes.co.kr/news/articleView.html?idxno=241987 — 배달이친구들, 꼭두 모티브, 민트 헬멧
 5. https://github.com/google/fonts — BM 시리즈 OFL TTF(한나·주아·도현·연성·개구) 라이선스 검증
 6. https://www.edaily.co.kr/news/read?newsId=01249686625639032 — "우리가 어떤 민족입니까" (2014, 류승룡, HS애드)
 7. https://www.brandbrief.co.kr/news/articleView.html?idxno=5667 — 한명수 CCO 인터뷰: 한나체 모티브, "쉽고 명확하고 위트있게", "공공재 브랜드"
 8. https://design.co.kr/article/15070/ — 김봉진 "배민다움", "예쁘지는 않지만 사랑스럽다"
-9. https://bcut.baemin.com/4941/ — 배민 글림체, 옛 간판 모티프, 을지로 글씨 장인 (B컷 by 배민)
+9. https://bcut.baemin.com/4941/ — 배민 글림체, 옛 간판 모티프, 을지로 글씨 장인 (B컷 by 배민) **봇 요청에는 403을 반환한다(WAF)** — 브라우저로 열면 그림글자 프로젝트 전문이 나온다.
 10. https://noonnu.cc/en/font_page/53 — 주아체 SIL OFL 1.1 라이선스
 11. https://noonnu.cc/en/font_page/55 — 도현체 SIL OFL 1.1 라이선스
 12. https://www.newswatch.kr/news/articleView.html?idxno=57219 — 배달이친구들 한명수 CCO 인용

--- a/services/krds.md
+++ b/services/krds.md
@@ -525,7 +525,7 @@ KRDS는 Figma UI 킷을 공식 배포 채널로 두며, 공식 사이트가 KRDS
 1. https://www.krds.go.kr/html/site/index.html — KRDS 공식 사이트 랜딩(미션, 원칙, 컴포넌트 카테고리)
 2. https://www.krds.go.kr/html/site/style/style_01.html — 디자인 스타일 개요(Standard vs Adaptive Style, 전자정부 웹사이트 품질관리 지침 + WCAG 레벨 AA)
 3. https://www.krds.go.kr/html/site/style/style_02.html — 색상 스타일 페이지(매직 넘버 대비 규약, 정부 블루/그레이/레드 앵커)
-4. https://www.figma.com/@krds — KRDS 공식 Figma 프로필. 공식 사이트가 직접 링크하는 배포 채널이며, KRDS_v1.0.0 UI 킷의 출처.
+4. https://www.figma.com/@krds — KRDS 공식 Figma 프로필. 공식 사이트가 직접 링크하는 배포 채널이며, KRDS_v1.0.0 UI 킷의 출처. 평범한 GET에는 텍스트가 28자뿐인 JS 셸이라 브라우저로 열어야 프로필이 보인다.
 5. https://www.krds.go.kr/html/site/style/style_03.html — 타이포그래피 스타일 페이지(Pretendard GOV 근거, PC/모바일 타입 스케일)
 6. https://designcompass.org/en/2024/04/17/krds/ — KRDS 범위와 컴포넌트 보충 해설
 7. https://www.krds.go.kr/html/site/style/style_04.html — 형태(Shape)·레이아웃 스타일 페이지(래디어스 표준형 5단계·2–12px 상한)

--- a/services/krds.md
+++ b/services/krds.md
@@ -2,7 +2,7 @@
 name: KRDS
 slug: krds
 category: gov
-last_updated: "2026-07-26"
+last_updated: "2026-08-02"
 created_at: 2026-05-09
 sources:
   - https://www.krds.go.kr/html/site/index.html

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -653,6 +653,6 @@ Vapor 시스템은 imagery treatment를 강제하지 않는다. goorm 마케팅 
 
 1. https://vapor-ui.goorm.io/ — 공식 docs/데모 사이트, goorm 네이밍·운영 컨텍스트.
 2. https://blog.goorm.io/vapor-figma-seoul/ — goorm 공식 블로그 "Vapor at Figma Config Seoul 2025", Vapor Squad 조직(2025년 4월 신설, Squad Lead 최준영, CDO 이태성)·SSOT 자동화·MCP Server 컨텍스트.
-3. https://www.figma.com/community/file/1508829832204351721/vapor-design-system — Vapor Design System Figma Community 파일.
+3. https://www.figma.com/community/file/1508829832204351721/vapor-design-system — Vapor Design System Figma Community 파일. 평범한 GET에는 텍스트가 34자뿐인 JS 셸이라 브라우저로 열어야 파일 정보가 보인다.
 4. https://www.npmjs.com/package/@vapor-ui/core — `@vapor-ui/core` npm 페이지(peer 의존, 카테고리, MIT © 2025 goorm Inc.). 팔레트 원본은 이 패키지의 `dist/styles/themes.css.ts.vanilla.css`다.
 5. https://github.com/goorm-dev/vapor-ui — GitHub 모노레포(6 패키지 구조: core / hooks / icons / codemod / color-generator / css-generator, README 카피). **루트 URL 하나가 본문 인용의 대부분을 떠받치고 있어**, 개별 주장을 이 링크만으로 확인하기 어렵다. 토큰 값은 [src:4]의 배포 CSS가, 정책·카피 서술은 이 저장소의 README와 docs 소스가 각각 1차 근거다.


### PR DESCRIPTION
계획서가 **"WAF 3건"**으로 남겨 둔 항목입니다. 실측하니 성격이 둘로 갈렸고 개수도 4건이었습니다.

## 넷 다 살아 있습니다

| URL | 평범한 GET | 브라우저 | 확인한 내용 |
|---|---|---|---|
| `woowahan.com` | **403 (WAF)** | 1991자 | "배민 글꼴 무료 배포" |
| `bcut.baemin.com/4941/` | **403 (WAF)** | 1916자 | 옛 간판 모티프 · 을지로 글씨 장인 · 그림글자 |
| `figma.com/@krds` | 200, **텍스트 28자** | 렌더됨 | "범정부UIUX 디자인 시스템 공식 피그마 리소스 채널", 팔로워 873, `KRDS_v1.0.0` 15.4k 복제 |
| `figma.com/community/…/vapor-design-system` | 200, **텍스트 34자** | 렌더됨 | UI 키트, 93 좋아요, 1k 사용자, Goorm 소유 |

**Figma 2건은 WAF가 아니라 JS 셸이었습니다** — 계획서의 "WAF 3건"이라는 묶음 자체가 부정확했습니다. 200을 반환하니 생존 감사는 통과하지만 텍스트가 28·34자뿐이라 내용은 못 읽습니다.

네 항목 모두 **References 설명이 정확**했고, 브라우저로 열어 확인했습니다.

## References에 "어떻게 열어야 읽히는가"를 적었습니다

감사 메모 규칙(#200)상 References에는 확인 이력이 아니라 **소스의 정적 성격**만 씁니다. 그래서 날짜 스탬프 없이 접근 방법만 적었습니다:

> `2. https://woowahan.com — … **봇 요청에는 403을 반환한다(WAF)** — 죽은 링크가 아니라 브라우저로 열어야 읽힌다.`

목적은 다음 생존 감사가 **403이나 28자를 보고 죽은 링크로 오판하지 않게** 하는 것입니다. 이 시리즈에서 반복 확인된 실패 모드고, npmjs 403(#199)과 같은 처방입니다.

## baemin `[src:2]` 미사용 상태 해소

이 출처가 인용되지 않았던 건 **내용을 읽을 수 없어서**였습니다(PR #188에서 "WAF로 확인 불가라 손대지 않음"으로 남겨 뒀습니다). 이제 확인했으므로 모회사·연혁 문장에 붙였습니다 — 우아한형제들 공식 사이트가 그 주장의 자연스러운 근거입니다.

억지 인용이 아니라 **읽지 못해 비워 뒀던 자리를 채운 것**이고, 카탈로그 경고가 **10 → 9**로 줄었습니다.

## 검증

**326 tests** · `validate:catalog` 17 files 0 blocking / **9 warn**(10에서 감소) · `tokens:check` OK · `audit:oklch` 0 mismatched · `build` OK.