### PR TITLE
fix(catalog): socar 색 토큰 56개를 발행값 정확 변환으로 + 게이트 대상 0 → 56

### DIFF
--- a/public/preview/socar/dark.html
+++ b/public/preview/socar/dark.html
@@ -18,55 +18,55 @@
      * shell is the correct, expected result (not an inverted fake-dark).
      */
     :root {
-      --sf-primary-regular: oklch(0.620 0.219 257);
-      --sf-primary-strong: oklch(0.586 0.236 261);
-      --sf-primary-heavy: oklch(0.526 0.224 263);
-      --sf-service-business: oklch(0.395 0.197 266);
-      --sf-blue-50: oklch(0.962 0.022 248);
-      --sf-blue-100: oklch(0.917 0.040 240);
-      --sf-blue-200: oklch(0.789 0.111 234);
-      --sf-secondary-bg: oklch(0.917 0.040 240);
+      --sf-primary-regular: oklch(0.599 0.220 258);
+      --sf-primary-strong: oklch(0.569 0.237 260);
+      --sf-primary-heavy: oklch(0.498 0.226 262);
+      --sf-service-business: oklch(0.388 0.193 263);
+      --sf-blue-50: oklch(0.966 0.017 248);
+      --sf-blue-100: oklch(0.931 0.035 247);
+      --sf-blue-200: oklch(0.832 0.089 247);
+      --sf-secondary-bg: oklch(0.931 0.035 247);
 
-      --sf-gray-50: oklch(0.984 0.002 286);
-      --sf-gray-100: oklch(0.967 0.004 271);
-      --sf-gray-200: oklch(0.927 0.009 264);
-      --sf-gray-300: oklch(0.851 0.018 264);
-      --sf-gray-400: oklch(0.781 0.027 267);
-      --sf-gray-500: oklch(0.687 0.035 265);
-      --sf-gray-600: oklch(0.519 0.039 263);
-      --sf-gray-700: oklch(0.405 0.036 264);
-      --sf-gray-800: oklch(0.331 0.034 264);
-      --sf-gray-900: oklch(0.268 0.030 263);
-      --sf-gray-1000: oklch(0.211 0.026 261);
+      --sf-gray-50: oklch(0.983 0.003 286);
+      --sf-gray-100: oklch(0.965 0.007 277);
+      --sf-gray-200: oklch(0.931 0.010 267);
+      --sf-gray-300: oklch(0.859 0.017 263);
+      --sf-gray-400: oklch(0.792 0.024 267);
+      --sf-gray-500: oklch(0.708 0.025 264);
+      --sf-gray-600: oklch(0.553 0.028 260);
+      --sf-gray-700: oklch(0.449 0.032 257);
+      --sf-gray-800: oklch(0.372 0.035 258);
+      --sf-gray-900: oklch(0.302 0.027 258);
+      --sf-gray-1000: oklch(0.217 0.022 261);
 
-      --sf-text-strong: oklch(0.211 0.026 261);
-      --sf-text-primary: oklch(0.331 0.034 264);
-      --sf-text-secondary: oklch(0.519 0.039 263);
-      --sf-text-tertiary: oklch(0.687 0.035 265);
-      --sf-text-disabled: oklch(0.781 0.027 267);
+      --sf-text-strong: oklch(0.217 0.022 261);
+      --sf-text-primary: oklch(0.372 0.035 258);
+      --sf-text-secondary: oklch(0.553 0.028 260);
+      --sf-text-tertiary: oklch(0.708 0.025 264);
+      --sf-text-disabled: oklch(0.792 0.024 267);
 
-      --sf-background-regular: oklch(0.967 0.004 271);
-      --sf-border-regular: oklch(0.927 0.009 264);
-      --sf-divider-regular: oklch(0.927 0.009 264);
+      --sf-background-regular: oklch(0.965 0.007 277);
+      --sf-border-regular: oklch(0.931 0.010 267);
+      --sf-divider-regular: oklch(0.931 0.010 267);
       --sf-white: oklch(1.000 0.000 0);
       --sf-black: oklch(0.000 0.000 0);
 
-      --sf-information-weak: oklch(0.962 0.022 248);
-      --sf-information-regular: oklch(0.620 0.219 257);
-      --sf-positive-weak: oklch(0.974 0.043 158);
-      --sf-positive-regular: oklch(0.745 0.176 162);
-      --sf-caution-weak: oklch(0.978 0.030 92);
-      --sf-caution-regular: oklch(0.741 0.166 56);
-      --sf-negative-weak: oklch(0.957 0.025 14);
-      --sf-negative-regular: oklch(0.649 0.219 19);
-      --sf-notification-red: oklch(0.649 0.219 19);
-      --sf-accent-purple: oklch(0.617 0.214 295);
+      --sf-information-weak: oklch(0.966 0.017 248);
+      --sf-information-regular: oklch(0.599 0.220 258);
+      --sf-positive-weak: oklch(0.976 0.031 160);
+      --sf-positive-regular: oklch(0.740 0.171 159);
+      --sf-caution-weak: oklch(0.980 0.025 89);
+      --sf-caution-regular: oklch(0.744 0.181 56);
+      --sf-negative-weak: oklch(0.968 0.017 4);
+      --sf-negative-regular: oklch(0.659 0.229 18);
+      --sf-notification-red: oklch(0.659 0.229 18);
+      --sf-accent-purple: oklch(0.643 0.210 293);
 
-      --sf-location-rental: oklch(0.620 0.219 257);
-      --sf-location-return: oklch(0.487 0.260 268);
+      --sf-location-rental: oklch(0.599 0.220 258);
+      --sf-location-return: oklch(0.503 0.251 268);
 
-      --sf-shadow-sm: 0 1px 2px oklch(0.211 0.026 261 / 0.04);
-      --sf-shadow-card: 0 2px 4px oklch(0.211 0.026 261 / 0.06);
+      --sf-shadow-sm: 0 1px 2px oklch(0.217 0.022 261 / 0.04);
+      --sf-shadow-card: 0 2px 4px oklch(0.217 0.022 261 / 0.06);
       --sf-shadow-tip: 0 2px 4px oklch(0.000 0.000 0 / 0.12);
       --sf-shadow-sheet: 0 0 20px oklch(0.000 0.000 0 / 0.25);
 
@@ -789,7 +789,7 @@
       background: oklch(0.000 0.000 0 / 0.08);
     }
 
-    .sf-action.tertiary.is-pressed::after { background: oklch(0.211 0.026 261 / 0.06); }
+    .sf-action.tertiary.is-pressed::after { background: oklch(0.217 0.022 261 / 0.06); }
 
     .sf-action[disabled],
     .sf-action.is-disabled {
@@ -1033,7 +1033,7 @@
       user-select: none;
     }
 
-    .control-row.is-pressed { transform: scale(0.97); background: oklch(0.211 0.026 261 / 0.06); }
+    .control-row.is-pressed { transform: scale(0.97); background: oklch(0.217 0.022 261 / 0.06); }
     .control-row.dis { color: var(--sf-text-disabled); cursor: not-allowed; }
 
     .ck-box, .rd-box {
@@ -1283,7 +1283,7 @@
       overflow: hidden;
     }
 
-    .sheet-backdrop { position: absolute; inset: 0; background: oklch(0.211 0.026 261 / 0.44); }
+    .sheet-backdrop { position: absolute; inset: 0; background: oklch(0.217 0.022 261 / 0.44); }
 
     .sheet {
       position: absolute;
@@ -1313,7 +1313,7 @@
       overflow: hidden;
     }
 
-    .alert-demo .alert-backdrop { position: absolute; inset: 0; background: oklch(0.211 0.026 261 / 0.44); }
+    .alert-demo .alert-backdrop { position: absolute; inset: 0; background: oklch(0.217 0.022 261 / 0.44); }
 
     .alert-card {
       position: relative;

--- a/public/preview/socar/light.html
+++ b/public/preview/socar/light.html
@@ -14,55 +14,55 @@
      * dark.html sibling can darken the shell while SOCAR cards stay true.
      */
     :root {
-      --sf-primary-regular: oklch(0.620 0.219 257);
-      --sf-primary-strong: oklch(0.586 0.236 261);
-      --sf-primary-heavy: oklch(0.526 0.224 263);
-      --sf-service-business: oklch(0.395 0.197 266);
-      --sf-blue-50: oklch(0.962 0.022 248);
-      --sf-blue-100: oklch(0.917 0.040 240);
-      --sf-blue-200: oklch(0.789 0.111 234);
-      --sf-secondary-bg: oklch(0.917 0.040 240);
+      --sf-primary-regular: oklch(0.599 0.220 258);
+      --sf-primary-strong: oklch(0.569 0.237 260);
+      --sf-primary-heavy: oklch(0.498 0.226 262);
+      --sf-service-business: oklch(0.388 0.193 263);
+      --sf-blue-50: oklch(0.966 0.017 248);
+      --sf-blue-100: oklch(0.931 0.035 247);
+      --sf-blue-200: oklch(0.832 0.089 247);
+      --sf-secondary-bg: oklch(0.931 0.035 247);
 
-      --sf-gray-50: oklch(0.984 0.002 286);
-      --sf-gray-100: oklch(0.967 0.004 271);
-      --sf-gray-200: oklch(0.927 0.009 264);
-      --sf-gray-300: oklch(0.851 0.018 264);
-      --sf-gray-400: oklch(0.781 0.027 267);
-      --sf-gray-500: oklch(0.687 0.035 265);
-      --sf-gray-600: oklch(0.519 0.039 263);
-      --sf-gray-700: oklch(0.405 0.036 264);
-      --sf-gray-800: oklch(0.331 0.034 264);
-      --sf-gray-900: oklch(0.268 0.030 263);
-      --sf-gray-1000: oklch(0.211 0.026 261);
+      --sf-gray-50: oklch(0.983 0.003 286);
+      --sf-gray-100: oklch(0.965 0.007 277);
+      --sf-gray-200: oklch(0.931 0.010 267);
+      --sf-gray-300: oklch(0.859 0.017 263);
+      --sf-gray-400: oklch(0.792 0.024 267);
+      --sf-gray-500: oklch(0.708 0.025 264);
+      --sf-gray-600: oklch(0.553 0.028 260);
+      --sf-gray-700: oklch(0.449 0.032 257);
+      --sf-gray-800: oklch(0.372 0.035 258);
+      --sf-gray-900: oklch(0.302 0.027 258);
+      --sf-gray-1000: oklch(0.217 0.022 261);
 
-      --sf-text-strong: oklch(0.211 0.026 261);
-      --sf-text-primary: oklch(0.331 0.034 264);
-      --sf-text-secondary: oklch(0.519 0.039 263);
-      --sf-text-tertiary: oklch(0.687 0.035 265);
-      --sf-text-disabled: oklch(0.781 0.027 267);
+      --sf-text-strong: oklch(0.217 0.022 261);
+      --sf-text-primary: oklch(0.372 0.035 258);
+      --sf-text-secondary: oklch(0.553 0.028 260);
+      --sf-text-tertiary: oklch(0.708 0.025 264);
+      --sf-text-disabled: oklch(0.792 0.024 267);
 
-      --sf-background-regular: oklch(0.967 0.004 271);
-      --sf-border-regular: oklch(0.927 0.009 264);
-      --sf-divider-regular: oklch(0.927 0.009 264);
+      --sf-background-regular: oklch(0.965 0.007 277);
+      --sf-border-regular: oklch(0.931 0.010 267);
+      --sf-divider-regular: oklch(0.931 0.010 267);
       --sf-white: oklch(1.000 0.000 0);
       --sf-black: oklch(0.000 0.000 0);
 
-      --sf-information-weak: oklch(0.962 0.022 248);
-      --sf-information-regular: oklch(0.620 0.219 257);
-      --sf-positive-weak: oklch(0.974 0.043 158);
-      --sf-positive-regular: oklch(0.745 0.176 162);
-      --sf-caution-weak: oklch(0.978 0.030 92);
-      --sf-caution-regular: oklch(0.741 0.166 56);
-      --sf-negative-weak: oklch(0.957 0.025 14);
-      --sf-negative-regular: oklch(0.649 0.219 19);
-      --sf-notification-red: oklch(0.649 0.219 19);
-      --sf-accent-purple: oklch(0.617 0.214 295);
+      --sf-information-weak: oklch(0.966 0.017 248);
+      --sf-information-regular: oklch(0.599 0.220 258);
+      --sf-positive-weak: oklch(0.976 0.031 160);
+      --sf-positive-regular: oklch(0.740 0.171 159);
+      --sf-caution-weak: oklch(0.980 0.025 89);
+      --sf-caution-regular: oklch(0.744 0.181 56);
+      --sf-negative-weak: oklch(0.968 0.017 4);
+      --sf-negative-regular: oklch(0.659 0.229 18);
+      --sf-notification-red: oklch(0.659 0.229 18);
+      --sf-accent-purple: oklch(0.643 0.210 293);
 
-      --sf-location-rental: oklch(0.620 0.219 257);
-      --sf-location-return: oklch(0.487 0.260 268);
+      --sf-location-rental: oklch(0.599 0.220 258);
+      --sf-location-return: oklch(0.503 0.251 268);
 
-      --sf-shadow-sm: 0 1px 2px oklch(0.211 0.026 261 / 0.04);
-      --sf-shadow-card: 0 2px 4px oklch(0.211 0.026 261 / 0.06);
+      --sf-shadow-sm: 0 1px 2px oklch(0.217 0.022 261 / 0.04);
+      --sf-shadow-card: 0 2px 4px oklch(0.217 0.022 261 / 0.06);
       --sf-shadow-tip: 0 2px 4px oklch(0.000 0.000 0 / 0.12);
       --sf-shadow-sheet: 0 0 20px oklch(0.000 0.000 0 / 0.25);
 
@@ -772,7 +772,7 @@
       background: oklch(0.000 0.000 0 / 0.08);
     }
 
-    .sf-action.tertiary.is-pressed::after { background: oklch(0.211 0.026 261 / 0.06); }
+    .sf-action.tertiary.is-pressed::after { background: oklch(0.217 0.022 261 / 0.06); }
 
     .sf-action[disabled],
     .sf-action.is-disabled {
@@ -1016,7 +1016,7 @@
       user-select: none;
     }
 
-    .control-row.is-pressed { transform: scale(0.97); background: oklch(0.211 0.026 261 / 0.06); }
+    .control-row.is-pressed { transform: scale(0.97); background: oklch(0.217 0.022 261 / 0.06); }
     .control-row.dis { color: var(--sf-text-disabled); cursor: not-allowed; }
 
     .ck-box, .rd-box {
@@ -1266,7 +1266,7 @@
       overflow: hidden;
     }
 
-    .sheet-backdrop { position: absolute; inset: 0; background: oklch(0.211 0.026 261 / 0.44); }
+    .sheet-backdrop { position: absolute; inset: 0; background: oklch(0.217 0.022 261 / 0.44); }
 
     .sheet {
       position: absolute;
@@ -1296,7 +1296,7 @@
       overflow: hidden;
     }
 
-    .alert-demo .alert-backdrop { position: absolute; inset: 0; background: oklch(0.211 0.026 261 / 0.44); }
+    .alert-demo .alert-backdrop { position: absolute; inset: 0; background: oklch(0.217 0.022 261 / 0.44); }
 
     .alert-card {
       position: relative;

--- a/services/baemin.md
+++ b/services/baemin.md
@@ -867,14 +867,14 @@ iOS 상태표시줄 아래 위치하는 검색 화면 헤더. 좌측 `←` back,
 ## References
 
 1. https://designcompass.org/en/2025/07/23/baemin-2-rebranding/ — Baemin 2.0 리브랜드 (2024년 7월, 김범석 대표 코멘트, WORK 폰트 공개)
-2. https://woowahan.com — 우아한형제들 공식 사이트, 모회사 / IR / 폰트 라이선스 진입 **봇 요청에는 403을 반환한다(WAF)** — 죽은 링크가 아니라 브라우저로 열어야 읽힌다.
+2. https://woowahan.com — 우아한형제들 공식 사이트, 모회사 / IR / 폰트 라이선스 진입. **봇 요청에는 403을 반환한다(WAF)** — 죽은 링크가 아니라 브라우저로 열어야 읽힌다.
 3. https://www.the-pr.co.kr/news/articleView.html?idxno=19376 — 배민 민트 CMYK 65:0:29:0 채택 근거 (The PR)
 4. https://www.specialtimes.co.kr/news/articleView.html?idxno=241987 — 배달이친구들, 꼭두 모티브, 민트 헬멧
 5. https://github.com/google/fonts — BM 시리즈 OFL TTF(한나·주아·도현·연성·개구) 라이선스 검증
 6. https://www.edaily.co.kr/news/read?newsId=01249686625639032 — "우리가 어떤 민족입니까" (2014, 류승룡, HS애드)
 7. https://www.brandbrief.co.kr/news/articleView.html?idxno=5667 — 한명수 CCO 인터뷰: 한나체 모티브, "쉽고 명확하고 위트있게", "공공재 브랜드"
 8. https://design.co.kr/article/15070/ — 김봉진 "배민다움", "예쁘지는 않지만 사랑스럽다"
-9. https://bcut.baemin.com/4941/ — 배민 글림체, 옛 간판 모티프, 을지로 글씨 장인 (B컷 by 배민) **봇 요청에는 403을 반환한다(WAF)** — 브라우저로 열면 그림글자 프로젝트 전문이 나온다.
+9. https://bcut.baemin.com/4941/ — 배민 글림체, 옛 간판 모티프, 을지로 글씨 장인 (B컷 by 배민). **봇 요청에는 403을 반환한다(WAF)** — 브라우저로 열면 그림글자 프로젝트 전문이 나온다.
 10. https://noonnu.cc/en/font_page/53 — 주아체 SIL OFL 1.1 라이선스
 11. https://noonnu.cc/en/font_page/55 — 도현체 SIL OFL 1.1 라이선스
 12. https://www.newswatch.kr/news/articleView.html?idxno=57219 — 배달이친구들 한명수 CCO 인용

--- a/services/socar.md
+++ b/services/socar.md
@@ -64,59 +64,57 @@ SOCAR Frame 2.0(쏘카프레임 2.0)는 쏘카의 디자인 시스템이며, 브
 
 ## Colors
 
-> **대조 결과(2026-07-29).** 공식 Colors 페이지를 렌더해 발행 토큰 163개를 뽑고 이 문서의 색 토큰 59개와 맞춰 봤다. 결과는 셋으로 갈린다 [src:4].
+> **팔레트 정정(2026-08-02).** 이 절의 값은 원래 공개 hex를 손으로 OKLCH 변환한 것이었고, 그 변환이 부정확했다 — 이름이 맞는 56개 중 **39개가 게이트 허용 오차(ΔE 0.01)를 넘었다**(최대 `blue-200` 0.054, `accent-magenta` 0.056). 색이 다른 게 아니라 변환 잔차였고, 문서 스스로 "공개된 hex 토큰을 변환한 것"이라 적고 있었으므로 값이 서술을 따라가지 못한 상태였다.
 >
-> - **이름이 맞는 44개 중 26개가 ΔE ≤ 0.02**로 일치하고, 나머지 18개는 ΔE 0.022~0.056으로 근소하게 벌어진다(최대 `accent-magenta` 0.056, `blue-200` 0.054). 색이 다르다기보다 유도 과정의 잔차로 보인다 — `primary-regular`의 발행값 `#0078FF`는 `oklch(0.599 0.220 258)`이고 아래 표는 `oklch(0.620 0.219 257)`이라, 채도·색상은 같고 명도만 0.021 밝다. 기준으로 삼을 값은 발행 hex 쪽이다.
-> - **시맨틱 상태 토큰 12개는 이름이 다르다.** 이 문서는 `information-weak`·`positive-regular`·`caution-strong`·`negative-*` 식으로 적지만 SOCAR Frame이 발행하는 이름은 `status-` 접두사가 붙은 `status-information-weak` 형태다. 값은 같으므로 색이 아니라 **참조명이 어긋난 것**이고, 그대로 복사하면 존재하지 않는 토큰을 부르게 된다.
-> - `dimmed-regular`·`pressed-regular`·`pressed-dark-regular` 3개는 Colors 페이지 표에 없다.
+> **이제 56개 전부가 발행 hex의 정확한 변환값이다** [src:4]. 각 줄에 출처 hex를 병기해 `audit:oklch` 판정 대상으로 들였다 — 이 파일은 병기가 없어 **판정 대상이 0개**였고 지금은 56개다. 다음 드리프트는 CI가 잡는다.
 >
-> 방침대로 값과 이름은 그대로 두고 차이만 명시한다.
+> **시맨틱 상태 토큰 12개는 이름이 다르다.** 이 문서는 `information-weak` 식으로 적지만 발행명은 `status-` 접두사가 붙은 `status-information-weak`다. 값은 같으므로 참조명만 어긋난 것이고, 그대로 복사하면 존재하지 않는 토큰을 부르게 된다 — 각 토큰 줄에 발행명을 병기했다. `dimmed-regular`·`pressed-regular`·`pressed-dark-regular` 3개는 Colors 표에 없어 병기할 발행값이 없다.
 >
-> **검증 방법을 남겨 둔다.** `socarframe.socar.kr`은 어떤 경로를 요청하든 **똑같은 166자 셸**(내비 크롬 + 저작권 한 줄)을 돌려준다 — 루트든 `/development/foundation/Colors`든 응답 텍스트가 동일하다. 토큰 이름은 사이트 번들에도 없다. 이 문서에서 **233건의 인용이 그 도메인**을 가리키고, `socar.kr`(일반 서비스 페이지)을 가리키는 4건만 예외다. 즉 인용 대부분이 200을 반환하면서도 **자동 재검사로는 아무것도 확인되지 않는다.** 위 대조는 페이지를 실제로 렌더해서 얻은 것이다.
+> **검증 방법을 남겨 둔다.** `socarframe.socar.kr`은 어떤 경로를 요청하든 **똑같은 166자 셸**을 돌려준다 — 루트든 `/development/foundation/Colors`든 응답 텍스트가 동일하고 토큰 이름은 사이트 번들에도 없다. 이 문서에서 233건의 인용이 그 도메인을 가리키므로, 인용 대부분이 200을 반환하면서도 **자동 재검사로는 아무것도 확인되지 않는다.** 위 대조는 페이지를 실제로 렌더해서 얻은 것이다.
 
 SOCAR Frame 2.0은 공식 Colors 페이지에 전체 토큰 세트를 게시하며, 색상 클래스는 `tw-{bg|text|border|fill}-{name}-{step}` 패턴을 따른다 [src:4][src:1]. 아래 값은 공개된 hex 토큰을 ko-design-md 표준에 맞게 OKLCH로 변환한 것이며, **라이트 모드 전용으로 다크 변형은 존재하지 않는다** [src:4][src:1].
 
 ```yaml
 # Brand / primary (action)
-primary-regular: oklch(0.620 0.219 257)   # service-socar / blue-500
-primary-strong: oklch(0.586 0.236 261)    # pressed / blue-600
-primary-heavy: oklch(0.526 0.224 263)     # heaviest / blue-700
-service-business: oklch(0.395 0.197 266)  # SOCAR Business / blue-900
+primary-regular: oklch(0.599 0.220 258)   # #0078FF · service-socar / blue-500
+primary-strong: oklch(0.569 0.237 260)    # #0069FF · pressed / blue-600
+primary-heavy: oklch(0.498 0.226 262)     # #0052E0 · heaviest / blue-700
+service-business: oklch(0.388 0.193 263)  # #0033A9 · SOCAR Business / blue-900
 
 # Blue ramp (brand axis; named steps used by components)
-blue-50: oklch(0.962 0.022 248)
-blue-100: oklch(0.917 0.040 240)
-blue-200: oklch(0.789 0.111 234)   # input focus border
-blue-500: oklch(0.620 0.219 257)   # = primary-regular
+blue-50: oklch(0.966 0.017 248)   # #EBF5FF
+blue-100: oklch(0.931 0.035 247)   # #D6EBFF
+blue-200: oklch(0.832 0.089 247)   # #99CEFF · input focus border
+blue-500: oklch(0.599 0.220 258)   # #0078FF · = primary-regular
 
 # Neutral grays (faintly blue-tinted ramp)
-gray-50: oklch(0.984 0.002 286)
-gray-100: oklch(0.967 0.004 271)
-gray-200: oklch(0.927 0.009 264)
-gray-300: oklch(0.851 0.018 264)
-gray-400: oklch(0.781 0.027 267)
-gray-500: oklch(0.687 0.035 265)
-gray-600: oklch(0.519 0.039 263)
-gray-700: oklch(0.405 0.036 264)
-gray-800: oklch(0.331 0.034 264)
-gray-900: oklch(0.268 0.030 263)
-gray-1000: oklch(0.211 0.026 261)
+gray-50: oklch(0.983 0.003 286)   # #F9F9FB
+gray-100: oklch(0.965 0.007 277)   # #F2F3F8
+gray-200: oklch(0.931 0.010 267)   # #E5E8EF
+gray-300: oklch(0.859 0.017 263)   # #CBD1DC
+gray-400: oklch(0.792 0.024 267)   # #B4BBCB
+gray-500: oklch(0.708 0.025 264)   # #99A1B1
+gray-600: oklch(0.553 0.028 260)   # #697383
+gray-700: oklch(0.449 0.032 257)   # #4A5667
+gray-800: oklch(0.372 0.035 258)   # #354153
+gray-900: oklch(0.302 0.027 258)   # #262F3C
+gray-1000: oklch(0.217 0.022 261)   # #141A24
 
 # Semantic — text
-text-strong: oklch(0.211 0.026 261)    # gray-1000
-text-primary: oklch(0.331 0.034 264)   # gray-800, default body text
-text-secondary: oklch(0.519 0.039 263) # gray-600
-text-tertiary: oklch(0.687 0.035 265)  # gray-500
-text-disabled: oklch(0.781 0.027 267)  # gray-400
+text-strong: oklch(0.217 0.022 261)    # #141A24 · gray-1000
+text-primary: oklch(0.372 0.035 258)   # #354153 · gray-800, default body text
+text-secondary: oklch(0.553 0.028 260) # #697383 · gray-600
+text-tertiary: oklch(0.708 0.025 264)  # #99A1B1 · gray-500
+text-disabled: oklch(0.792 0.024 267)  # #B4BBCB · gray-400
 
 # Semantic — surface / structure
-background-regular: oklch(0.967 0.004 271)  # app-surface wash
-border-regular: oklch(0.927 0.009 264)
-border-weak: oklch(0.967 0.004 271)
-divider-regular: oklch(0.927 0.009 264)
-divider-weak: oklch(0.967 0.004 271)
-white: oklch(1.000 0.000 0)                 # body background
-black: oklch(0.000 0.000 0)
+background-regular: oklch(0.965 0.007 277)  # #F2F3F8 · app-surface wash
+border-regular: oklch(0.931 0.010 267)   # #E5E8EF
+border-weak: oklch(0.965 0.007 277)   # #F2F3F8
+divider-regular: oklch(0.931 0.010 267)   # #E5E8EF
+divider-weak: oklch(0.965 0.007 277)   # #F2F3F8
+white: oklch(1.000 0.000 0)                 # #FFFFFF · body background
+black: oklch(0.000 0.000 0)   # #000000
 
 # Semantic — overlay (translucent)
 dimmed-regular: oklch(0.211 0.026 261 / 0.44)      # modal/sheet dim · 공식 Colors 표에 없음
@@ -124,35 +122,35 @@ pressed-regular: oklch(0.211 0.026 261 / 0.06)     # press-ripple · 공식 Colo
 pressed-dark-regular: oklch(0.000 0.000 0 / 0.08)  # press-ripple on dark fill · 공식 Colors 표에 없음
 
 # Semantic — status (weak / regular / strong)
-information-weak: oklch(0.962 0.022 248)   # 발행명은 status-information-weak
-information-regular: oklch(0.620 0.219 257)   # 발행명은 status-information-regular
-information-strong: oklch(0.586 0.236 261)   # 발행명은 status-information-strong
-positive-weak: oklch(0.974 0.043 158)   # 발행명은 status-positive-weak
-positive-regular: oklch(0.745 0.176 162)   # 발행명은 status-positive-regular
-positive-strong: oklch(0.706 0.165 163)   # 발행명은 status-positive-strong
-caution-weak: oklch(0.978 0.030 92)   # 발행명은 status-caution-weak
-caution-regular: oklch(0.741 0.166 56)   # 발행명은 status-caution-regular
-caution-strong: oklch(0.712 0.166 53)   # 발행명은 status-caution-strong
-negative-weak: oklch(0.957 0.025 14)   # 발행명은 status-negative-weak
-negative-regular: oklch(0.649 0.219 19)   # 발행명은 status-negative-regular
-negative-strong: oklch(0.594 0.249 21)   # 발행명은 status-negative-strong
-notification-red: oklch(0.649 0.219 19)  # badge / notification dot
+information-weak: oklch(0.966 0.017 248)   # #EBF5FF · 발행명은 status-information-weak
+information-regular: oklch(0.599 0.220 258)   # #0078FF · 발행명은 status-information-regular
+information-strong: oklch(0.569 0.237 260)   # #0069FF · 발행명은 status-information-strong
+positive-weak: oklch(0.976 0.031 160)   # #E6FEF0 · 발행명은 status-positive-weak
+positive-regular: oklch(0.740 0.171 159)   # #04CA81 · 발행명은 status-positive-regular
+positive-strong: oklch(0.701 0.151 163)   # #00BB83 · 발행명은 status-positive-strong
+caution-weak: oklch(0.980 0.025 89)   # #FFF8E6 · 발행명은 status-caution-weak
+caution-regular: oklch(0.744 0.181 56)   # #FF8800 · 발행명은 status-caution-regular
+caution-strong: oklch(0.714 0.186 51)   # #FA7900 · 발행명은 status-caution-strong
+negative-weak: oklch(0.968 0.017 4)   # #FFF0F3 · 발행명은 status-negative-weak
+negative-regular: oklch(0.659 0.229 18)   # #FF3A5B · 발행명은 status-negative-regular
+negative-strong: oklch(0.618 0.242 21)   # #F51441 · 발행명은 status-negative-strong
+notification-red: oklch(0.659 0.229 18)  # #FF3A5B · badge / notification dot
 
 # Semantic — accent (one representative step per hue)
-accent-red: oklch(0.649 0.219 19)
-accent-orange: oklch(0.741 0.166 56)
-accent-green: oklch(0.745 0.176 162)
-accent-lightblue: oklch(0.681 0.156 232)
-accent-purple: oklch(0.617 0.214 295)
-accent-redorange: oklch(0.683 0.205 41)
-accent-indigo: oklch(0.572 0.234 268)
-accent-magenta: oklch(0.640 0.245 7)
-accent-lime: oklch(0.794 0.214 130)
-accent-cyan: oklch(0.733 0.137 207)
+accent-red: oklch(0.659 0.229 18)   # #FF3A5B
+accent-orange: oklch(0.744 0.181 56)   # #FF8800
+accent-green: oklch(0.740 0.171 159)   # #04CA81
+accent-lightblue: oklch(0.716 0.165 240)   # #00AEFF
+accent-purple: oklch(0.643 0.210 293)   # #956BFF
+accent-redorange: oklch(0.709 0.194 45)   # #FF7017
+accent-indigo: oklch(0.586 0.225 270)   # #4B68FF
+accent-magenta: oklch(0.681 0.231 358)   # #FF4397
+accent-lime: oklch(0.793 0.213 131)   # #8AD510
+accent-cyan: oklch(0.762 0.130 204)   # #01C9D7
 
 # Semantic — domain-specific (mobility)
-location-rental: oklch(0.620 0.219 257)  # pickup marker
-location-return: oklch(0.487 0.260 268)  # return marker / indigo-700
+location-rental: oklch(0.599 0.220 258)  # #0078FF · pickup marker
+location-return: oklch(0.503 0.251 268)  # #2C46F0 · return marker / indigo-700
 ```
 
 색상 축은 채도 높은 파랑(`{colors.primary-regular}`)이며, 동일 hue를 strong/heavy로 단계화해 눌림 상태를 표현한다 [src:4]. `{colors.primary-regular}`(blue-500)는 유일한 브랜드 색이고, strong/heavy는 press·강한 CTA 용도일 뿐 장식에 쓰지 않는다 [src:4][src:9]. 회색 램프는 순수 회색이 아니라 푸른 기가 옅게 도는 톤이라 전체 온도가 차갑게 읽힌다 [src:1][src:4]. 상태색은 information / positive / caution / negative를 각각 weak·regular·strong 3단계로 분리하며 — weak는 틴트 표면, regular는 아이콘/텍스트 — 배지·알림 점에는 `{colors.notification-red}`를 사용한다 [src:4][src:1]. accent는 10개의 범주형 램프로 차종·위치·상태를 태깅하는 용도이며, 한 화면에 두 개의 accent가 동시에 나오는 일은 드물다 [src:4]. 모빌리티 도메인 토큰으로 픽업 마커 `{colors.location-rental}`와 반납 마커 `{colors.location-return}`가 별도로 정의되어, 쏘카존 기반 지도 UI를 색으로 구분한다 [src:4][src:2].

--- a/services/socar.md
+++ b/services/socar.md
@@ -117,8 +117,8 @@ white: oklch(1.000 0.000 0)                 # #FFFFFF · body background
 black: oklch(0.000 0.000 0)   # #000000
 
 # Semantic — overlay (translucent)
-dimmed-regular: oklch(0.211 0.026 261 / 0.44)      # modal/sheet dim · 공식 Colors 표에 없음
-pressed-regular: oklch(0.211 0.026 261 / 0.06)     # press-ripple · 공식 Colors 표에 없음
+dimmed-regular: oklch(0.217 0.022 261 / 0.44)      # modal/sheet dim · gray-1000의 알파 변형 · 공식 Colors 표에 없음
+pressed-regular: oklch(0.217 0.022 261 / 0.06)     # press-ripple · gray-1000의 알파 변형 · 공식 Colors 표에 없음
 pressed-dark-regular: oklch(0.000 0.000 0 / 0.08)  # press-ripple on dark fill · 공식 Colors 표에 없음
 
 # Semantic — status (weak / regular / strong)
@@ -246,7 +246,7 @@ radius-circle: 9999   # full pill / circle
 SOCAR Frame 2.0의 깊이 언어는 절제되어 있다 — 표면 분리는 드롭섀도가 아니라 1px 디바이더(`{colors.divider-regular}`)와 `{colors.background-regular}` 배경 워시가 담당하며, 흰 카드가 밝은 회색 필드 위에 간격과 헤어라인으로 구분된다 [src:1][src:4][src:screenshot:home.jpg]. 그림자는 사실상 두 레시피로 희소하다 — 카드는 그림자 대신 디바이더를 받는다 [src:1][src:5].
 
 ```yaml
-shadow-sm: 0 1px 2px oklch(0.211 0.026 261 / 0.04)
+shadow-sm: 0 1px 2px oklch(0.217 0.022 261 / 0.04)
 shadow-tip: 0 2px 4px oklch(0.000 0.000 0 / 0.12)
 shadow-sheet: 0 0 20px oklch(0.000 0.000 0 / 0.25)
 ```

--- a/services/socar.md
+++ b/services/socar.md
@@ -76,29 +76,29 @@ SOCAR Frame 2.0은 공식 Colors 페이지에 전체 토큰 세트를 게시하�
 
 ```yaml
 # Brand / primary (action)
-primary-regular: oklch(0.599 0.220 258)   # #0078FF · service-socar / blue-500
-primary-strong: oklch(0.569 0.237 260)    # #0069FF · pressed / blue-600
-primary-heavy: oklch(0.498 0.226 262)     # #0052E0 · heaviest / blue-700
-service-business: oklch(0.388 0.193 263)  # #0033A9 · SOCAR Business / blue-900
+primary-regular: oklch(0.599 0.220 258)  # #0078FF · service-socar / blue-500
+primary-strong: oklch(0.569 0.237 260)   # #0069FF · pressed / blue-600
+primary-heavy: oklch(0.498 0.226 262)    # #0052E0 · heaviest / blue-700
+service-business: oklch(0.388 0.193 263) # #0033A9 · SOCAR Business / blue-900
 
 # Blue ramp (brand axis; named steps used by components)
-blue-50: oklch(0.966 0.017 248)   # #EBF5FF
-blue-100: oklch(0.931 0.035 247)   # #D6EBFF
-blue-200: oklch(0.832 0.089 247)   # #99CEFF · input focus border
-blue-500: oklch(0.599 0.220 258)   # #0078FF · = primary-regular
+blue-50: oklch(0.966 0.017 248)  # #EBF5FF
+blue-100: oklch(0.931 0.035 247) # #D6EBFF
+blue-200: oklch(0.832 0.089 247) # #99CEFF · input focus border
+blue-500: oklch(0.599 0.220 258) # #0078FF · = primary-regular
 
 # Neutral grays (faintly blue-tinted ramp)
 gray-50: oklch(0.983 0.003 286)   # #F9F9FB
-gray-100: oklch(0.965 0.007 277)   # #F2F3F8
-gray-200: oklch(0.931 0.010 267)   # #E5E8EF
-gray-300: oklch(0.859 0.017 263)   # #CBD1DC
-gray-400: oklch(0.792 0.024 267)   # #B4BBCB
-gray-500: oklch(0.708 0.025 264)   # #99A1B1
-gray-600: oklch(0.553 0.028 260)   # #697383
-gray-700: oklch(0.449 0.032 257)   # #4A5667
-gray-800: oklch(0.372 0.035 258)   # #354153
-gray-900: oklch(0.302 0.027 258)   # #262F3C
-gray-1000: oklch(0.217 0.022 261)   # #141A24
+gray-100: oklch(0.965 0.007 277)  # #F2F3F8
+gray-200: oklch(0.931 0.010 267)  # #E5E8EF
+gray-300: oklch(0.859 0.017 263)  # #CBD1DC
+gray-400: oklch(0.792 0.024 267)  # #B4BBCB
+gray-500: oklch(0.708 0.025 264)  # #99A1B1
+gray-600: oklch(0.553 0.028 260)  # #697383
+gray-700: oklch(0.449 0.032 257)  # #4A5667
+gray-800: oklch(0.372 0.035 258)  # #354153
+gray-900: oklch(0.302 0.027 258)  # #262F3C
+gray-1000: oklch(0.217 0.022 261) # #141A24
 
 # Semantic — text
 text-strong: oklch(0.217 0.022 261)    # #141A24 · gray-1000
@@ -108,49 +108,49 @@ text-tertiary: oklch(0.708 0.025 264)  # #99A1B1 · gray-500
 text-disabled: oklch(0.792 0.024 267)  # #B4BBCB · gray-400
 
 # Semantic — surface / structure
-background-regular: oklch(0.965 0.007 277)  # #F2F3F8 · app-surface wash
-border-regular: oklch(0.931 0.010 267)   # #E5E8EF
-border-weak: oklch(0.965 0.007 277)   # #F2F3F8
-divider-regular: oklch(0.931 0.010 267)   # #E5E8EF
-divider-weak: oklch(0.965 0.007 277)   # #F2F3F8
-white: oklch(1.000 0.000 0)                 # #FFFFFF · body background
-black: oklch(0.000 0.000 0)   # #000000
+background-regular: oklch(0.965 0.007 277) # #F2F3F8 · app-surface wash
+border-regular: oklch(0.931 0.010 267)     # #E5E8EF
+border-weak: oklch(0.965 0.007 277)        # #F2F3F8
+divider-regular: oklch(0.931 0.010 267)    # #E5E8EF
+divider-weak: oklch(0.965 0.007 277)       # #F2F3F8
+white: oklch(1.000 0.000 0)                # #FFFFFF · body background
+black: oklch(0.000 0.000 0)                # #000000
 
 # Semantic — overlay (translucent)
-dimmed-regular: oklch(0.217 0.022 261 / 0.44)      # modal/sheet dim · gray-1000의 알파 변형 · 공식 Colors 표에 없음
-pressed-regular: oklch(0.217 0.022 261 / 0.06)     # press-ripple · gray-1000의 알파 변형 · 공식 Colors 표에 없음
-pressed-dark-regular: oklch(0.000 0.000 0 / 0.08)  # press-ripple on dark fill · 공식 Colors 표에 없음
+dimmed-regular: oklch(0.217 0.022 261 / 0.44)     # modal/sheet dim · gray-1000의 알파 변형 · 공식 Colors 표에 없음
+pressed-regular: oklch(0.217 0.022 261 / 0.06)    # press-ripple · gray-1000의 알파 변형 · 공식 Colors 표에 없음
+pressed-dark-regular: oklch(0.000 0.000 0 / 0.08) # press-ripple on dark fill · 공식 Colors 표에 없음
 
 # Semantic — status (weak / regular / strong)
-information-weak: oklch(0.966 0.017 248)   # #EBF5FF · 발행명은 status-information-weak
-information-regular: oklch(0.599 0.220 258)   # #0078FF · 발행명은 status-information-regular
-information-strong: oklch(0.569 0.237 260)   # #0069FF · 발행명은 status-information-strong
-positive-weak: oklch(0.976 0.031 160)   # #E6FEF0 · 발행명은 status-positive-weak
-positive-regular: oklch(0.740 0.171 159)   # #04CA81 · 발행명은 status-positive-regular
-positive-strong: oklch(0.701 0.151 163)   # #00BB83 · 발행명은 status-positive-strong
-caution-weak: oklch(0.980 0.025 89)   # #FFF8E6 · 발행명은 status-caution-weak
-caution-regular: oklch(0.744 0.181 56)   # #FF8800 · 발행명은 status-caution-regular
-caution-strong: oklch(0.714 0.186 51)   # #FA7900 · 발행명은 status-caution-strong
-negative-weak: oklch(0.968 0.017 4)   # #FFF0F3 · 발행명은 status-negative-weak
-negative-regular: oklch(0.659 0.229 18)   # #FF3A5B · 발행명은 status-negative-regular
-negative-strong: oklch(0.618 0.242 21)   # #F51441 · 발행명은 status-negative-strong
-notification-red: oklch(0.659 0.229 18)  # #FF3A5B · badge / notification dot
+information-weak: oklch(0.966 0.017 248)    # #EBF5FF · 발행명은 status-information-weak
+information-regular: oklch(0.599 0.220 258) # #0078FF · 발행명은 status-information-regular
+information-strong: oklch(0.569 0.237 260)  # #0069FF · 발행명은 status-information-strong
+positive-weak: oklch(0.976 0.031 160)       # #E6FEF0 · 발행명은 status-positive-weak
+positive-regular: oklch(0.740 0.171 159)    # #04CA81 · 발행명은 status-positive-regular
+positive-strong: oklch(0.701 0.151 163)     # #00BB83 · 발행명은 status-positive-strong
+caution-weak: oklch(0.980 0.025 89)         # #FFF8E6 · 발행명은 status-caution-weak
+caution-regular: oklch(0.744 0.181 56)      # #FF8800 · 발행명은 status-caution-regular
+caution-strong: oklch(0.714 0.186 51)       # #FA7900 · 발행명은 status-caution-strong
+negative-weak: oklch(0.968 0.017 4)         # #FFF0F3 · 발행명은 status-negative-weak
+negative-regular: oklch(0.659 0.229 18)     # #FF3A5B · 발행명은 status-negative-regular
+negative-strong: oklch(0.618 0.242 21)      # #F51441 · 발행명은 status-negative-strong
+notification-red: oklch(0.659 0.229 18)     # #FF3A5B · badge / notification dot
 
 # Semantic — accent (one representative step per hue)
-accent-red: oklch(0.659 0.229 18)   # #FF3A5B
-accent-orange: oklch(0.744 0.181 56)   # #FF8800
-accent-green: oklch(0.740 0.171 159)   # #04CA81
-accent-lightblue: oklch(0.716 0.165 240)   # #00AEFF
-accent-purple: oklch(0.643 0.210 293)   # #956BFF
-accent-redorange: oklch(0.709 0.194 45)   # #FF7017
-accent-indigo: oklch(0.586 0.225 270)   # #4B68FF
+accent-red: oklch(0.659 0.229 18)        # #FF3A5B
+accent-orange: oklch(0.744 0.181 56)     # #FF8800
+accent-green: oklch(0.740 0.171 159)     # #04CA81
+accent-lightblue: oklch(0.716 0.165 240) # #00AEFF
+accent-purple: oklch(0.643 0.210 293)    # #956BFF
+accent-redorange: oklch(0.709 0.194 45)  # #FF7017
+accent-indigo: oklch(0.586 0.225 270)    # #4B68FF
 accent-magenta: oklch(0.681 0.231 358)   # #FF4397
-accent-lime: oklch(0.793 0.213 131)   # #8AD510
-accent-cyan: oklch(0.762 0.130 204)   # #01C9D7
+accent-lime: oklch(0.793 0.213 131)      # #8AD510
+accent-cyan: oklch(0.762 0.130 204)      # #01C9D7
 
 # Semantic — domain-specific (mobility)
-location-rental: oklch(0.599 0.220 258)  # #0078FF · pickup marker
-location-return: oklch(0.503 0.251 268)  # #2C46F0 · return marker / indigo-700
+location-rental: oklch(0.599 0.220 258) # #0078FF · pickup marker
+location-return: oklch(0.503 0.251 268) # #2C46F0 · return marker / indigo-700
 ```
 
 색상 축은 채도 높은 파랑(`{colors.primary-regular}`)이며, 동일 hue를 strong/heavy로 단계화해 눌림 상태를 표현한다 [src:4]. `{colors.primary-regular}`(blue-500)는 유일한 브랜드 색이고, strong/heavy는 press·강한 CTA 용도일 뿐 장식에 쓰지 않는다 [src:4][src:9]. 회색 램프는 순수 회색이 아니라 푸른 기가 옅게 도는 톤이라 전체 온도가 차갑게 읽힌다 [src:1][src:4]. 상태색은 information / positive / caution / negative를 각각 weak·regular·strong 3단계로 분리하며 — weak는 틴트 표면, regular는 아이콘/텍스트 — 배지·알림 점에는 `{colors.notification-red}`를 사용한다 [src:4][src:1]. accent는 10개의 범주형 램프로 차종·위치·상태를 태깅하는 용도이며, 한 화면에 두 개의 accent가 동시에 나오는 일은 드물다 [src:4]. 모빌리티 도메인 토큰으로 픽업 마커 `{colors.location-rental}`와 반납 마커 `{colors.location-return}`가 별도로 정의되어, 쏘카존 기반 지도 UI를 색으로 구분한다 [src:4][src:2].

--- a/services/socar.tokens.json
+++ b/services/socar.tokens.json
@@ -157,13 +157,13 @@
     },
     {
       "name": "dimmed-regular",
-      "value": "oklch(0.211 0.026 261 / 0.44)",
-      "note": "modal/sheet dim · 공식 Colors 표에 없음"
+      "value": "oklch(0.217 0.022 261 / 0.44)",
+      "note": "modal/sheet dim · gray-1000의 알파 변형 · 공식 Colors 표에 없음"
     },
     {
       "name": "pressed-regular",
-      "value": "oklch(0.211 0.026 261 / 0.06)",
-      "note": "press-ripple · 공식 Colors 표에 없음"
+      "value": "oklch(0.217 0.022 261 / 0.06)",
+      "note": "press-ripple · gray-1000의 알파 변형 · 공식 Colors 표에 없음"
     },
     {
       "name": "pressed-dark-regular",

--- a/services/socar.tokens.json
+++ b/services/socar.tokens.json
@@ -2,140 +2,158 @@
   "colors": [
     {
       "name": "primary-regular",
-      "value": "oklch(0.620 0.219 257)",
-      "note": "service-socar / blue-500"
+      "value": "oklch(0.599 0.220 258)",
+      "note": "#0078FF · service-socar / blue-500"
     },
     {
       "name": "primary-strong",
-      "value": "oklch(0.586 0.236 261)",
-      "note": "pressed / blue-600"
+      "value": "oklch(0.569 0.237 260)",
+      "note": "#0069FF · pressed / blue-600"
     },
     {
       "name": "primary-heavy",
-      "value": "oklch(0.526 0.224 263)",
-      "note": "heaviest / blue-700"
+      "value": "oklch(0.498 0.226 262)",
+      "note": "#0052E0 · heaviest / blue-700"
     },
     {
       "name": "service-business",
-      "value": "oklch(0.395 0.197 266)",
-      "note": "SOCAR Business / blue-900"
+      "value": "oklch(0.388 0.193 263)",
+      "note": "#0033A9 · SOCAR Business / blue-900"
     },
     {
       "name": "blue-50",
-      "value": "oklch(0.962 0.022 248)"
+      "value": "oklch(0.966 0.017 248)",
+      "note": "#EBF5FF"
     },
     {
       "name": "blue-100",
-      "value": "oklch(0.917 0.040 240)"
+      "value": "oklch(0.931 0.035 247)",
+      "note": "#D6EBFF"
     },
     {
       "name": "blue-200",
-      "value": "oklch(0.789 0.111 234)",
-      "note": "input focus border"
+      "value": "oklch(0.832 0.089 247)",
+      "note": "#99CEFF · input focus border"
     },
     {
       "name": "blue-500",
-      "value": "oklch(0.620 0.219 257)",
-      "note": "= primary-regular"
+      "value": "oklch(0.599 0.220 258)",
+      "note": "#0078FF · = primary-regular"
     },
     {
       "name": "gray-50",
-      "value": "oklch(0.984 0.002 286)"
+      "value": "oklch(0.983 0.003 286)",
+      "note": "#F9F9FB"
     },
     {
       "name": "gray-100",
-      "value": "oklch(0.967 0.004 271)"
+      "value": "oklch(0.965 0.007 277)",
+      "note": "#F2F3F8"
     },
     {
       "name": "gray-200",
-      "value": "oklch(0.927 0.009 264)"
+      "value": "oklch(0.931 0.010 267)",
+      "note": "#E5E8EF"
     },
     {
       "name": "gray-300",
-      "value": "oklch(0.851 0.018 264)"
+      "value": "oklch(0.859 0.017 263)",
+      "note": "#CBD1DC"
     },
     {
       "name": "gray-400",
-      "value": "oklch(0.781 0.027 267)"
+      "value": "oklch(0.792 0.024 267)",
+      "note": "#B4BBCB"
     },
     {
       "name": "gray-500",
-      "value": "oklch(0.687 0.035 265)"
+      "value": "oklch(0.708 0.025 264)",
+      "note": "#99A1B1"
     },
     {
       "name": "gray-600",
-      "value": "oklch(0.519 0.039 263)"
+      "value": "oklch(0.553 0.028 260)",
+      "note": "#697383"
     },
     {
       "name": "gray-700",
-      "value": "oklch(0.405 0.036 264)"
+      "value": "oklch(0.449 0.032 257)",
+      "note": "#4A5667"
     },
     {
       "name": "gray-800",
-      "value": "oklch(0.331 0.034 264)"
+      "value": "oklch(0.372 0.035 258)",
+      "note": "#354153"
     },
     {
       "name": "gray-900",
-      "value": "oklch(0.268 0.030 263)"
+      "value": "oklch(0.302 0.027 258)",
+      "note": "#262F3C"
     },
     {
       "name": "gray-1000",
-      "value": "oklch(0.211 0.026 261)"
+      "value": "oklch(0.217 0.022 261)",
+      "note": "#141A24"
     },
     {
       "name": "text-strong",
-      "value": "oklch(0.211 0.026 261)",
-      "note": "gray-1000"
+      "value": "oklch(0.217 0.022 261)",
+      "note": "#141A24 · gray-1000"
     },
     {
       "name": "text-primary",
-      "value": "oklch(0.331 0.034 264)",
-      "note": "gray-800, default body text"
+      "value": "oklch(0.372 0.035 258)",
+      "note": "#354153 · gray-800, default body text"
     },
     {
       "name": "text-secondary",
-      "value": "oklch(0.519 0.039 263)",
-      "note": "gray-600"
+      "value": "oklch(0.553 0.028 260)",
+      "note": "#697383 · gray-600"
     },
     {
       "name": "text-tertiary",
-      "value": "oklch(0.687 0.035 265)",
-      "note": "gray-500"
+      "value": "oklch(0.708 0.025 264)",
+      "note": "#99A1B1 · gray-500"
     },
     {
       "name": "text-disabled",
-      "value": "oklch(0.781 0.027 267)",
-      "note": "gray-400"
+      "value": "oklch(0.792 0.024 267)",
+      "note": "#B4BBCB · gray-400"
     },
     {
       "name": "background-regular",
-      "value": "oklch(0.967 0.004 271)",
-      "note": "app-surface wash"
+      "value": "oklch(0.965 0.007 277)",
+      "note": "#F2F3F8 · app-surface wash"
     },
     {
       "name": "border-regular",
-      "value": "oklch(0.927 0.009 264)"
+      "value": "oklch(0.931 0.010 267)",
+      "note": "#E5E8EF"
     },
     {
       "name": "border-weak",
-      "value": "oklch(0.967 0.004 271)"
+      "value": "oklch(0.965 0.007 277)",
+      "note": "#F2F3F8"
     },
     {
       "name": "divider-regular",
-      "value": "oklch(0.927 0.009 264)"
+      "value": "oklch(0.931 0.010 267)",
+      "note": "#E5E8EF"
     },
     {
       "name": "divider-weak",
-      "value": "oklch(0.967 0.004 271)"
+      "value": "oklch(0.965 0.007 277)",
+      "note": "#F2F3F8"
     },
     {
       "name": "white",
       "value": "oklch(1.000 0.000 0)",
-      "note": "body background"
+      "note": "#FFFFFF · body background"
     },
     {
       "name": "black",
-      "value": "oklch(0.000 0.000 0)"
+      "value": "oklch(0.000 0.000 0)",
+      "note": "#000000"
     },
     {
       "name": "dimmed-regular",
@@ -154,118 +172,128 @@
     },
     {
       "name": "information-weak",
-      "value": "oklch(0.962 0.022 248)",
-      "note": "발행명은 status-information-weak"
+      "value": "oklch(0.966 0.017 248)",
+      "note": "#EBF5FF · 발행명은 status-information-weak"
     },
     {
       "name": "information-regular",
-      "value": "oklch(0.620 0.219 257)",
-      "note": "발행명은 status-information-regular"
+      "value": "oklch(0.599 0.220 258)",
+      "note": "#0078FF · 발행명은 status-information-regular"
     },
     {
       "name": "information-strong",
-      "value": "oklch(0.586 0.236 261)",
-      "note": "발행명은 status-information-strong"
+      "value": "oklch(0.569 0.237 260)",
+      "note": "#0069FF · 발행명은 status-information-strong"
     },
     {
       "name": "positive-weak",
-      "value": "oklch(0.974 0.043 158)",
-      "note": "발행명은 status-positive-weak"
+      "value": "oklch(0.976 0.031 160)",
+      "note": "#E6FEF0 · 발행명은 status-positive-weak"
     },
     {
       "name": "positive-regular",
-      "value": "oklch(0.745 0.176 162)",
-      "note": "발행명은 status-positive-regular"
+      "value": "oklch(0.740 0.171 159)",
+      "note": "#04CA81 · 발행명은 status-positive-regular"
     },
     {
       "name": "positive-strong",
-      "value": "oklch(0.706 0.165 163)",
-      "note": "발행명은 status-positive-strong"
+      "value": "oklch(0.701 0.151 163)",
+      "note": "#00BB83 · 발행명은 status-positive-strong"
     },
     {
       "name": "caution-weak",
-      "value": "oklch(0.978 0.030 92)",
-      "note": "발행명은 status-caution-weak"
+      "value": "oklch(0.980 0.025 89)",
+      "note": "#FFF8E6 · 발행명은 status-caution-weak"
     },
     {
       "name": "caution-regular",
-      "value": "oklch(0.741 0.166 56)",
-      "note": "발행명은 status-caution-regular"
+      "value": "oklch(0.744 0.181 56)",
+      "note": "#FF8800 · 발행명은 status-caution-regular"
     },
     {
       "name": "caution-strong",
-      "value": "oklch(0.712 0.166 53)",
-      "note": "발행명은 status-caution-strong"
+      "value": "oklch(0.714 0.186 51)",
+      "note": "#FA7900 · 발행명은 status-caution-strong"
     },
     {
       "name": "negative-weak",
-      "value": "oklch(0.957 0.025 14)",
-      "note": "발행명은 status-negative-weak"
+      "value": "oklch(0.968 0.017 4)",
+      "note": "#FFF0F3 · 발행명은 status-negative-weak"
     },
     {
       "name": "negative-regular",
-      "value": "oklch(0.649 0.219 19)",
-      "note": "발행명은 status-negative-regular"
+      "value": "oklch(0.659 0.229 18)",
+      "note": "#FF3A5B · 발행명은 status-negative-regular"
     },
     {
       "name": "negative-strong",
-      "value": "oklch(0.594 0.249 21)",
-      "note": "발행명은 status-negative-strong"
+      "value": "oklch(0.618 0.242 21)",
+      "note": "#F51441 · 발행명은 status-negative-strong"
     },
     {
       "name": "notification-red",
-      "value": "oklch(0.649 0.219 19)",
-      "note": "badge / notification dot"
+      "value": "oklch(0.659 0.229 18)",
+      "note": "#FF3A5B · badge / notification dot"
     },
     {
       "name": "accent-red",
-      "value": "oklch(0.649 0.219 19)"
+      "value": "oklch(0.659 0.229 18)",
+      "note": "#FF3A5B"
     },
     {
       "name": "accent-orange",
-      "value": "oklch(0.741 0.166 56)"
+      "value": "oklch(0.744 0.181 56)",
+      "note": "#FF8800"
     },
     {
       "name": "accent-green",
-      "value": "oklch(0.745 0.176 162)"
+      "value": "oklch(0.740 0.171 159)",
+      "note": "#04CA81"
     },
     {
       "name": "accent-lightblue",
-      "value": "oklch(0.681 0.156 232)"
+      "value": "oklch(0.716 0.165 240)",
+      "note": "#00AEFF"
     },
     {
       "name": "accent-purple",
-      "value": "oklch(0.617 0.214 295)"
+      "value": "oklch(0.643 0.210 293)",
+      "note": "#956BFF"
     },
     {
       "name": "accent-redorange",
-      "value": "oklch(0.683 0.205 41)"
+      "value": "oklch(0.709 0.194 45)",
+      "note": "#FF7017"
     },
     {
       "name": "accent-indigo",
-      "value": "oklch(0.572 0.234 268)"
+      "value": "oklch(0.586 0.225 270)",
+      "note": "#4B68FF"
     },
     {
       "name": "accent-magenta",
-      "value": "oklch(0.640 0.245 7)"
+      "value": "oklch(0.681 0.231 358)",
+      "note": "#FF4397"
     },
     {
       "name": "accent-lime",
-      "value": "oklch(0.794 0.214 130)"
+      "value": "oklch(0.793 0.213 131)",
+      "note": "#8AD510"
     },
     {
       "name": "accent-cyan",
-      "value": "oklch(0.733 0.137 207)"
+      "value": "oklch(0.762 0.130 204)",
+      "note": "#01C9D7"
     },
     {
       "name": "location-rental",
-      "value": "oklch(0.620 0.219 257)",
-      "note": "pickup marker"
+      "value": "oklch(0.599 0.220 258)",
+      "note": "#0078FF · pickup marker"
     },
     {
       "name": "location-return",
-      "value": "oklch(0.487 0.260 268)",
-      "note": "return marker / indigo-700"
+      "value": "oklch(0.503 0.251 268)",
+      "note": "#2C46F0 · return marker / indigo-700"
     }
   ],
   "typography": [


### PR DESCRIPTION
큐 4번. socar 59개 토큰이 `audit:oklch` 밖에 있던 문제입니다.

## 이건 정책 판단이 아니라 버그였습니다

문서가 스스로 이렇게 적습니다:

> 아래 값은 **공개된 hex 토큰을** ko-design-md 표준에 맞게 OKLCH로 변환한 것이며…

그런데 이름이 맞는 56개 중 **39개가 게이트 허용 오차(ΔE 0.01)를 넘었습니다**(최대 `accent-magenta` 0.056, `blue-200` 0.054). 다른 팔레트가 아니라 **손계산 변환 잔차**입니다 — 값이 문서 자신의 서술을 따라가지 못한 상태였습니다.

vapor-ui(#195)와 대비됩니다:

| | vapor-ui | socar |
|---|---|---|
| 값 출처 | 비공개 번들 (다른 세대) | **공개 hex를 변환했다고 명시** |
| 편차 | ΔE 최대 **0.218**, hue 이동 | 최대 0.056, hue 거의 동일 |
| 성격 | 출처 불일치 → 정책 판단 | **변환 오차 → 버그** |

## 수치 정정

승인 요청 시 "18개"라고 보고했는데 **39개가 맞습니다.** 제가 제 분석 버킷 경계(0.02)를 게이트 기준인 것처럼 말했고, 실제 `DELTA_E_TOLERANCE`는 **0.01**입니다. 성격은 같아(전부 변환 잔차, 육안 불가) 승인하신 의도대로 진행했습니다.

## 결과

- **56개 전부가 발행 hex의 정확한 변환값**이 됐고 각 줄에 출처 hex를 병기했습니다
- `audit:oklch` 판정 대상 **0 → 56** (카탈로그 전체 **586 → 698**)
- 시맨틱 상태 토큰 12개는 발행명(`status-` 접두사)도 같은 줄에 병기 — 그대로 복사하면 없는 토큰을 부르므로 사이드카 소비자에게도 전달돼야 합니다
- `dimmed-regular`·`pressed-regular`·`pressed-dark-regular` 3개는 Colors 표에 발행값이 없어 병기 대상이 아닙니다

프리뷰 파생 리터럴 46개(light 23 / dark 23)와 사이드카를 동기화했고, **이동한 옛 값 34개가 프리뷰에 남아 있지 않은지 따로 확인**했습니다(0건).

감사 메모는 새 결과로 덮어썼습니다 — 종전 메모가 "값과 이름은 그대로 두고 차이만 명시한다"고 적고 있어 그대로 두면 문서가 자기모순이 됩니다(#200 규칙 "재감사하면 덮어쓴다").

## 검증

typecheck 0 · lint 0 · **326 tests** · `validate:catalog` 17 files 0 blocking / **9 warn** · `validate:previews` 0 blocking · `tokens:check` OK · `audit:oklch` **689/698 judged** / 0 mismatched · `build` OK.