### PR TITLE
feat(skill): 고지 스트립을 파이프라인에 배선하고 block 으로 승격 (묶음 D-2)

### DIFF
--- a/.claude/agents/preview-html-author.md
+++ b/.claude/agents/preview-html-author.md
@@ -42,15 +42,66 @@ Both must include:
   </style>
 </head>
 <body>
+<div class="catalog-disclaimer" role="note"><b>ko/design.md 카탈로그 프리뷰</b> — 이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다. 이 화면은 공식 배포본이 아닌 공개 자료 기반 비공식 재현이며, 표시된 상품·가격·평점·거래·채용 정보는 레이아웃 시연용 더미 데이터입니다.</div>
   ...
 </body>
 </html>
 ```
 
+## Catalog disclosure strip (required, verbatim, first child of `<body>`)
+
+Copy the `<div class="catalog-disclaimer">` line above **byte for byte** into both
+files, unindented, as the very first child of `<body>`. Do not reword it, do not
+translate it, do not interpolate the brand name into it, and do not style it —
+`.catalog-disclaimer` already exists in `/preview/_runtime/tokens.css`, along with
+0-chroma `--catalog-note-*` tokens that keep the strip out of the brand's hue.
+
+Three things make this non-negotiable:
+
+- **It cannot be injected at runtime.** `/preview/_runtime/iframe.js` returns early
+  when `window.parent === window`, so a standalone open, a screenshot, and a CC BY
+  redistributed copy all get nothing. Only static markup reaches those readers.
+- **Position is load-bearing.** The strip has to land in the first screen and in the
+  hero crop a screenshot usually takes. Anywhere else satisfies the letter of the
+  rule and none of its purpose.
+- **The two sentences carry different jobs.** The first (`제휴·후원 관계가 없습니다`)
+  is the non-affiliation claim and is the same sentence the site footer uses — a
+  contract test pins both. The second (`더미 데이터`) is what makes the fabricated
+  values on screen not a statement of fact. Neither substitutes for the other.
+
+Brand names are deliberately NOT interpolated: naming the mark again inside a
+notice works against the non-affiliation point, and `<title>{Brand} preview` plus
+the hero lockup already sit on the same screen.
+
+## Fabricated data must be labelled
+
+Every block that shows invented values attached to a **real, named third party**
+gets a `<p class="catalog-dummy">` immediately before it, inside the same
+container. A real `<table>` gets a `<caption class="catalog-dummy">` as its first
+child instead, so the label travels with the table when someone extracts it —
+**unless the table sits inside a horizontal scroll container**, because a caption
+box takes the *table's* width, not the scroller's, and the sentence then runs off
+by exactly the amount the scroller exists to absorb. Those get the `<p>` before the
+wrapper.
+
+Never put the label inside a phone mockup's `.screen`. It is the catalog speaking,
+not the mocked app.
+
+**Enumerate the claims, not just the numbers.** Prices and ratings are the easy
+half. Badges, certifications, rankings, and identifiers are fabricated claims too,
+and they are what gets missed: `공식` (seller verification), `베스트` (bestseller
+rank), `국비지원` (government-funded course), an invoice number attached to a real
+courier, a merchant name on a transaction row. If the screen asserts a
+qualification about a named company or product, the caption must say that
+assertion is demonstration data. Write the caption by reading the block's rendered
+text, not by recalling what you put there.
+
 ## Required body composition
 
 In this order:
 
+0. **Catalog disclosure strip** — the verbatim `<div class="catalog-disclaimer">`
+   line, first child of `<body>`, before the hero. See the section above.
 1. **Hero section** — brand name, tagline, primary CTA. Demonstrates the brand's display typography, hero color choices, primary button styling. If `logo_src_path` is not `none`, render the logo visibly in the hero or top brand lockup using `<img src="{logo_src_path}">` (the site-relative form) in both light.html and dark.html. The hero is the "card" most users will see first.
 2. **Component showcase grid** below the hero, demonstrating:
    - **Component variants** — every signature component named in design.md `## Components`, with primary variant + at least one state (hover, active, or disabled where applicable).
@@ -121,6 +172,8 @@ Second class of failure that shipped (bezier/채널톡 + krds, now fixed): the b
 - If the design.md `## Typography` defines a `font-display-src`, both files load it via a `<link>` in `<head>` and apply `var(--{prefix}-font-display)` to the hero headline (`.hero h1`); `body` stays on the sans face. (See Typography & display face.)
 - All sub-files referenced (tokens.css, iframe.js) use absolute paths starting with `/preview/`, NOT relative paths.
 - If a logo path is present, both light.html and dark.html contain the exact `/logos/...` site-relative string (NOT the absolute URL form) and render it in a visible brand/hero position.
+- Both files carry the catalog disclosure strip verbatim, as the **first child of `<body>`** — including both sentences (`제휴·후원 관계가 없습니다` and `더미 데이터`). A strip below the hero, or with one sentence dropped, does not count.
+- Every block showing invented values against a real named third party carries a `catalog-dummy` label, and that label names the fabricated **claims** (badges, certifications, rankings, identifiers) as well as the numbers.
 - No horizontal overflow at 375px, at the ~976px embed width, OR at each multi-column layout's narrowest state: every multi-column grid has a mobile collapse rule, content-bearing tracks use `minmax(0, 1fr)` (not bare `1fr`), flex/grid items wrapping fixed-width children (mocks, images, nowrap labels) carry `min-width: 0`, and atomic control groups (segmented/toggle/button) carry `max-width: 100%` + `min-width: 0` with shrinkable children. (See the Responsive & mobile-overflow guard.)
 
 ## What you must NOT do
@@ -130,6 +183,8 @@ Second class of failure that shipped (bezier/채널톡 + krds, now fixed): the b
 - Convert OKLCH values to hex/rgba "for browser compatibility" — modern browsers support OKLCH fine and the design.md token values must match exactly.
 - Move files into `public/preview/` yourself. Staging only — the skill body handles the move after the preview review loop completes.
 - Drop a provided logo from one theme because the other theme already shows it. Logo presence is required in both files when a path is available.
+- Reword, translate, shorten, or restyle the catalog disclosure strip, or move it below the hero "so it doesn't spoil the first impression". The aesthetic cost is known and accepted; the strip is 11px and 0-chroma precisely so it reads as a document header rather than a warning.
+- Label a mockup's fabricated values by writing prose *inside* the mocked app's UI. The label is the catalog's voice and belongs outside the `.screen`.
 - Copy a demo's hero verbatim. Demos exist for structural reference, not as templates to fill in.
 - Ship a multi-column grid with no mobile collapse rule, a bare `1fr` content track, a fixed-width-child item missing `min-width: 0`, an atomic `inline-flex` control group (segmented/toggle) whose nowrap children can't shrink (no `max-width: 100%` / `min-width: 0`), or a generic class name (`.brand`, `.card`, `.item`) reused across two unrelated components — each causes horizontal overflow at phone, intermediate multi-column, or ~976px embed widths. See the Responsive & mobile-overflow guard.
 

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -416,11 +416,15 @@ for THEME in light dark; do
   rg -q -F 'class="catalog-disclaimer"' "$F" || echo "DISCLAIMER_MISSING_${THEME}"
   rg -q -F '제휴·후원 관계가 없습니다' "$F" || echo "DISCLAIMER_NO_NONAFFILIATION_${THEME}"
   rg -q -F '더미 데이터' "$F" || echo "DISCLAIMER_NO_DUMMYDATA_${THEME}"
-  rg -qU '<body>\s*<div class="catalog-disclaimer"' "$F" || echo "DISCLAIMER_MISPLACED_${THEME}"
+  rg -qU '<body>(\s|<!--[\s\S]*?-->)*<div class="catalog-disclaimer"' "$F" || echo "DISCLAIMER_MISPLACED_${THEME}"
 done
 ```
 
-`-U` (multiline) is required for the placement check — the strip sits on the line *after* `<body>`, so a line-scoped match never sees both. The two phrase sentinels are literal (`-F`) because the wording is fixed: the non-affiliation sentence is shared verbatim with `src/components/site/footer.tsx` and pinned by `src/lib/license-notice-consistency.test.ts`.
+`-U` (multiline) is required for the placement check — the strip sits on the line *after* `<body>`, so a line-scoped match never sees both. The comment alternation matches `DISCLAIMER_FIRST_CHILD` in `src/lib/preview-validator.ts`: a comment between `<body>` and the strip is still a strip-first document, and flagging it here would send Stage 9a back to fix markup that 9a2 already passed.
+
+**These sentinels are deliberately stricter than the validator on one axis: quoting.** `preview-validator.ts` accepts `class='catalog-disclaimer'` because it also validates hand-edited and pre-existing files. Stage 10 re-checks *pipeline output*, where `.claude/agents/preview-html-author.md` prescribes the strip **byte for byte** with double quotes — so `-F` on the verbatim form is the point, not an oversight. A single-quoted strip reaching here means the author deviated from a verbatim instruction, which is worth a Stage 9a round. Do not "fix" this by loosening it to match the validator.
+
+The two phrase sentinels are literal (`-F`) for the same reason: the non-affiliation sentence is shared verbatim with `src/components/site/footer.tsx` and pinned by `src/lib/license-notice-consistency.test.ts`.
 
 If any `DISCLAIMER_*` sentinel prints, do not proceed to Stage 11. Re-run Stage 9a with a blocking prior-preview issue quoting the verbatim strip from `.claude/agents/preview-html-author.md` and stating it must be the first child of `<body>` in both files.
 

--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -339,7 +339,7 @@ cd "${repo_root}" && pnpm validate:previews \
   --iteration {M} --json-out "${repo_root}/.claude/cache/design-md/{slug}/preview-review-machine-{M}.json"
 ```
 
-It hard-checks the structural rubric items (data-theme/lang, absolute runtime paths, foreign scripts, file size, hero logo src) and emits warn-level responsive heuristics plus an `oklch coverage` metric (`matched/total` per theme) in `metrics`.
+It hard-checks the structural rubric items (data-theme/lang, absolute runtime paths, foreign scripts, file size, hero logo src, catalog disclosure strip) and emits warn-level responsive heuristics plus an `oklch coverage` metric (`matched/total` per theme) in `metrics`.
 
 - **Exit 0** → proceed to 9b, passing the machine report path.
 - **Exit 1** → do NOT dispatch the reviewer. Re-dispatch 9a with `prior_review_path` = the `preview-review-machine-{M}.json`. Machine retries use a sub-counter **K (max 2) and do not increment M**.
@@ -405,6 +405,24 @@ rg -q -F "src=\"${HERO_SRC}\"" "${repo_root}/public/preview/{slug}/dark.html" ||
 ```
 
 If any sentinel prints, do not proceed to Stage 11. If the markdown is missing the logo, re-run Stage 6a with a blocking prior-review issue that says `logo_url` must appear as frontmatter `logo` (the exact fully-qualified URL — not a site-relative shortcut). If either preview is missing the hero logo, re-run Stage 9a with a blocking prior-preview issue that says the exact `HERO_SRC` (site-relative form — wordmark when defined, else symbol) must render as an `<img src>` in both files.
+
+### Catalog disclosure deterministic check
+
+`validate:previews` already blocks on this at 9a2, so reaching here with a missing strip means the file changed after the gate. Re-check the placed files:
+
+```bash
+for THEME in light dark; do
+  F="${repo_root}/public/preview/{slug}/${THEME}.html"
+  rg -q -F 'class="catalog-disclaimer"' "$F" || echo "DISCLAIMER_MISSING_${THEME}"
+  rg -q -F '제휴·후원 관계가 없습니다' "$F" || echo "DISCLAIMER_NO_NONAFFILIATION_${THEME}"
+  rg -q -F '더미 데이터' "$F" || echo "DISCLAIMER_NO_DUMMYDATA_${THEME}"
+  rg -qU '<body>\s*<div class="catalog-disclaimer"' "$F" || echo "DISCLAIMER_MISPLACED_${THEME}"
+done
+```
+
+`-U` (multiline) is required for the placement check — the strip sits on the line *after* `<body>`, so a line-scoped match never sees both. The two phrase sentinels are literal (`-F`) because the wording is fixed: the non-affiliation sentence is shared verbatim with `src/components/site/footer.tsx` and pinned by `src/lib/license-notice-consistency.test.ts`.
+
+If any `DISCLAIMER_*` sentinel prints, do not proceed to Stage 11. Re-run Stage 9a with a blocking prior-preview issue quoting the verbatim strip from `.claude/agents/preview-html-author.md` and stating it must be the first child of `<body>` in both files.
 
 ## Stage 11 — Build OG image
 

--- a/.claude/skills/design-md/references/rubric-preview.md
+++ b/.claude/skills/design-md/references/rubric-preview.md
@@ -13,10 +13,11 @@ Both HTML files exist and conform:
 - No external JS frameworks (no React, no jQuery — these are static HTML pages).
 - File size < 100KB each.
 - If the orchestrator passes `expected_logo_src_path` (or design.md frontmatter includes `logo`), both HTML files must contain a `<img src="{expected_logo_src_path}">` rendered in a visible brand/hero position. The required form is **site-relative** (e.g. `/logos/toss.png`) — NOT the absolute URL (`https://getdesign.kr/logos/toss.png`) that design.md frontmatter stores. Preview HTML lives inside the catalog site's iframe, so site-relative is correct; the absolute URL exists only in frontmatter so that copied design.md files stay meaningful outside the site.
+- Both files carry the catalog disclosure strip — `<div class="catalog-disclaimer" role="note">` as the **first child of `<body>`**, verbatim, carrying both `제휴·후원 관계가 없습니다` and `더미 데이터`. It cannot be injected at runtime (`iframe.js` returns early when `window.parent === window`), so a standalone open or a redistributed copy sees only what is in the file. Position counts: the strip has to land in the first screen and in the hero crop a screenshot takes.
 
 **Pass**: 2 pts if all checks pass. 0 pts if any structural element missing or wrong path. No partial credit.
 
-**Failure modes**: writing `tokens.css` as a relative path; creating a per-slug `_runtime/` folder (the runtime is shared); adding `<script src="https://cdn.../react.js">`; frontmatter says `logo: https://getdesign.kr/logos/toss.png` but light.html or dark.html omits the `<img src="/logos/toss.png">` site-relative form (or worse, embeds the absolute URL itself in `<img src>`).
+**Failure modes**: writing `tokens.css` as a relative path; creating a per-slug `_runtime/` folder (the runtime is shared); adding `<script src="https://cdn.../react.js">`; frontmatter says `logo: https://getdesign.kr/logos/toss.png` but light.html or dark.html omits the `<img src="/logos/toss.png">` site-relative form (or worse, embeds the absolute URL itself in `<img src>`); the disclosure strip is absent, reworded, moved below the hero, or reduced to one of its two sentences.
 
 ## Item 2 — Color fidelity (2 pts)
 
@@ -80,6 +81,36 @@ The reviewer reads CSS only and cannot render, so this is a STATIC scan of the i
 - **Generic class-name collision.** The same single-word class (`.brand`, `.card`, `.item`) used both as a standalone selector and in a compound selector (e.g. `.brand` AND `.swatch.brand`) — the standalone rule's `display`/`white-space`/`gap` leak onto the compound element.
 
 Emit each as e.g. `{"severity":"warn","section":"footer grid","fix":"`.brand-footer` declares 4 columns with no mobile collapse; add a `@media (max-width:720px)` override to 1–2 columns + `min-width:0` on items."}`. These are **non-blocking** (the whole preview review is non-blocking), but compounding — a preview that overflows at 375px reads as broken on the device most catalog users browse from, so surface them even when the 10-point score passes.
+
+## Dummy-data labelling (advisory content check — emits `warn` issues, does NOT change the 10-point score)
+
+The disclosure strip itself is Item 1 (structural, machine-checked). This block is
+the part a machine cannot check: **whether each caption actually enumerates what
+its block fabricates.** `validate:previews` verifies the label literals exist; only
+a reader can tell whether the label is complete. Adds **no points** — append one
+`warn` per gap.
+
+For every block that shows invented values attached to a real, named third party
+(a brand, a company, a product, a person, a public body), check:
+
+- **Is there a label at all?** A `catalog-dummy` `<p>` immediately before the block
+  in the same container, or a `<caption>` as the table's first child. A table inside
+  an `overflow-x` wrapper must use the `<p>` form — a caption box takes the table's
+  width, not the scroller's, so the sentence runs off screen at phone widths.
+- **Is the label outside the mocked UI?** It must not sit inside a phone mockup's
+  `.screen`. It is the catalog's voice, not the mocked app's.
+- **Does the enumeration cover the claims, not just the numbers?** This is the one
+  that gets missed. Prices, ratings, and counts are the easy half; badges,
+  certifications, rankings, and identifiers are fabricated claims too — `공식`
+  (seller verification), `베스트` (bestseller rank), `국비지원` (government-funded
+  course), an invoice number attached to a real courier, a merchant name on a
+  transaction row. Read the block's rendered text and compare item by item.
+- **Does the label read as an observation, not a norm?** "…는 레이아웃 시연용 더미
+  데이터입니다" describes the screen. A caption that instead asserts what the brand
+  *does* is an unsourced claim about a real company and belongs in design.md with a
+  `[src:N]`, not here.
+
+Emit each as e.g. `{"severity":"warn","section":"kyobobook — device mock","fix":"The caption lists prices and delivery badges but the screen also shows a `베스트` rank badge and a 9.6 rating with 2,481 reviews; add those to the enumeration."}`.
 
 ## Output JSON shape
 

--- a/src/lib/design-md-preview-disclaimer.test.ts
+++ b/src/lib/design-md-preview-disclaimer.test.ts
@@ -128,14 +128,19 @@ describe("/design-md catalog disclosure wiring", () => {
   // identifiers — not the numbers. Those are what regressed: the first pass
   // enumerated prices and ratings and silently dropped 베스트, 국비지원, the
   // fabricated invoice number, and the merchant names (PR #210 erratum).
+  //
+  // Badge literals are quoted (`'베스트'`, not `베스트`) on purpose. The captions
+  // mention some of these twice — once as the badge, once in the closing "…이
+  // 아닙니다" clause — so the bare token stays satisfied after the badge is
+  // dropped from the enumeration. Mutation-testing caught exactly that.
   const FABRICATED_DATA_SITES: Record<string, Array<string>> = {
     // 원티드랩·토스·당근 with invented 채용보상금 figures.
     wanted: ["채용보상금", "근무지", "경력 조건"],
     // Course cards claiming a government-funded designation.
-    teamsparta: ["국비지원", "평점", "수강생 수"],
+    teamsparta: ["'국비지원'", "평점", "수강생 수"],
     // Real books (룰루 밀러 『물고기는 존재하지 않는다』, 곰출판) with invented
     // prices, a bestseller rank, and a rating.
-    kyobobook: ["베스트", "리뷰 수", "할인율"],
+    kyobobook: ["'베스트'", "베스트 순위", "리뷰 수", "할인율"],
     // 나이키·소니·스타벅스 with invented prices and an "공식" seller badge, plus
     // a mock order screen carrying an invoice number against a real courier.
     gmarket: ["'공식' 배지", "쿠폰·사은품", "송장번호", "택배사명"],

--- a/src/lib/design-md-preview-disclaimer.test.ts
+++ b/src/lib/design-md-preview-disclaimer.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+
+// The non-affiliation sentence is shared verbatim between the preview strip and
+// the site footer. Keeping one literal here (rather than one per surface) is the
+// point: it is what makes the two surfaces impossible to drift apart silently.
+const NON_AFFILIATION = "제휴·후원 관계가 없습니다"
+const DUMMY_DATA = "더미 데이터"
+const DISCLAIMER_CLASS = "catalog-disclaimer"
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8")
+}
+
+function previewFiles(): Array<string> {
+  return readdirSync(join(ROOT, "public/preview"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "_runtime")
+    .flatMap((entry) =>
+      ["light", "dark"].map(
+        (theme) => `public/preview/${entry.name}/${theme}.html`
+      )
+    )
+}
+
+describe("/design-md catalog disclosure wiring", () => {
+  it("teaches the strip everywhere the pipeline could drop it", () => {
+    const previewAuthor = readRepoFile(".claude/agents/preview-html-author.md")
+    const previewRubric = readRepoFile(
+      ".claude/skills/design-md/references/rubric-preview.md"
+    )
+    const skill = readRepoFile(".claude/skills/design-md/SKILL.md")
+    const validator = readRepoFile("src/lib/preview-validator.ts")
+    const tokensCss = readRepoFile("public/preview/_runtime/tokens.css")
+
+    // Author: the verbatim strip, both sentences, and the reason it cannot be
+    // injected at runtime (an author that does not know this "helpfully" moves
+    // it into iframe.js).
+    expect(previewAuthor).toContain(`class="${DISCLAIMER_CLASS}"`)
+    expect(previewAuthor).toContain(NON_AFFILIATION)
+    expect(previewAuthor).toContain(DUMMY_DATA)
+    expect(previewAuthor).toContain("window.parent === window")
+    expect(previewAuthor).toContain("catalog-dummy")
+
+    // Rubric: structural check in Item 1, labelling as a score-neutral advisory.
+    expect(previewRubric).toContain(DISCLAIMER_CLASS)
+    expect(previewRubric).toContain("first child of `<body>`")
+    expect(previewRubric).toContain("Dummy-data labelling")
+    expect(previewRubric).toContain("does NOT change the 10-point score")
+
+    // Skill: the Stage 10 sentinels, including the multiline placement check.
+    expect(skill).toContain("Catalog disclosure deterministic check")
+    expect(skill).toContain("DISCLAIMER_MISSING_")
+    expect(skill).toContain("DISCLAIMER_MISPLACED_")
+    expect(skill).toContain("catalog disclosure strip")
+
+    // Validator: both rule names reachable from the skill's 9a2 gate.
+    expect(validator).toContain("missing-disclaimer-banner")
+    expect(validator).toContain("disclaimer-banner-misplaced")
+
+    // Runtime CSS: dedicated 0-chroma tokens. Reusing --muted-foreground would
+    // let 13 of 17 previews tint the strip with their own brand hue, because a
+    // preview's inline <style> loads after this file.
+    expect(tokensCss).toContain(`.${DISCLAIMER_CLASS}`)
+    expect(tokensCss).toContain("--catalog-note-fg")
+    expect(tokensCss).toContain("--catalog-note-bg")
+  })
+
+  it("keeps the strip present, complete, and first in every preview", () => {
+    const files = previewFiles()
+    expect(files.length).toBeGreaterThan(0)
+
+    for (const path of files) {
+      const html = readRepoFile(path)
+
+      // Placement, not just presence: the strip has to land in the first screen
+      // and in the hero crop a screenshot takes.
+      expect(
+        html,
+        `${path} must open <body> with the disclosure strip`
+      ).toMatch(
+        new RegExp(
+          `<body\\b[^>]*>\\s*<[a-z][a-z0-9]*\\b[^>]*${DISCLAIMER_CLASS}`
+        )
+      )
+
+      // Scoped to the strip itself — five previews carry .catalog-dummy captions
+      // that also say "더미 데이터", so a document-wide search would keep passing
+      // after the sentence is deleted from the strip.
+      const strip = html.match(
+        new RegExp(
+          `<([a-z][a-z0-9]*)\\b[^>]*${DISCLAIMER_CLASS}[^>]*>([\\s\\S]*?)</\\1>`
+        )
+      )?.[2]
+
+      expect(strip, `${path} disclosure strip must parse`).toBeTruthy()
+      expect(
+        strip,
+        `${path} strip must carry the non-affiliation sentence`
+      ).toContain(NON_AFFILIATION)
+      expect(
+        strip,
+        `${path} strip must carry the dummy-data sentence`
+      ).toContain(DUMMY_DATA)
+    }
+  })
+
+  it("keeps the preview strip and the site footer on one non-affiliation sentence", () => {
+    const footer = readRepoFile("src/components/site/footer.tsx")
+    expect(footer).toContain(NON_AFFILIATION)
+
+    // Both surfaces answer the same 부정경쟁방지법 제2조 제1호 나목 question. If
+    // one is reworded and the other is not, a reader comparing them learns the
+    // claim is casual. src/lib/license-notice-consistency.test.ts pins the
+    // footer side; this pins that the preview side did not drift away from it.
+    for (const path of previewFiles()) {
+      expect(
+        readRepoFile(path),
+        `${path} must reuse the footer's non-affiliation sentence verbatim`
+      ).toContain(NON_AFFILIATION)
+    }
+  })
+
+  // Every entry below is a screen showing invented values against a real, named
+  // third party. The literals are the *claims* — badges, certifications, rankings,
+  // identifiers — not the numbers. Those are what regressed: the first pass
+  // enumerated prices and ratings and silently dropped 베스트, 국비지원, the
+  // fabricated invoice number, and the merchant names (PR #210 erratum).
+  const FABRICATED_DATA_SITES: Record<string, Array<string>> = {
+    // 원티드랩·토스·당근 with invented 채용보상금 figures.
+    wanted: ["채용보상금", "근무지", "경력 조건"],
+    // Course cards claiming a government-funded designation.
+    teamsparta: ["국비지원", "평점", "수강생 수"],
+    // Real books (룰루 밀러 『물고기는 존재하지 않는다』, 곰출판) with invented
+    // prices, a bestseller rank, and a rating.
+    kyobobook: ["베스트", "리뷰 수", "할인율"],
+    // 나이키·소니·스타벅스 with invented prices and an "공식" seller badge, plus
+    // a mock order screen carrying an invoice number against a real courier.
+    gmarket: ["'공식' 배지", "쿠폰·사은품", "송장번호", "택배사명"],
+    // 삼성전자·SK하이닉스 quotes, and a transaction list naming 카카오T·쿠팡.
+    toss: ["종목명", "가맹점명"],
+    // The KRDS government-identification banner rendered inside a catalog page.
+    krds: ["표시 예시"],
+  }
+
+  it("labels the fabricated claims, not only the fabricated numbers", () => {
+    for (const [slug, required] of Object.entries(FABRICATED_DATA_SITES)) {
+      for (const theme of ["light", "dark"]) {
+        const path = `public/preview/${slug}/${theme}.html`
+        const html = readRepoFile(path)
+
+        const captions = [
+          ...html.matchAll(/class="catalog-dummy"[^>]*>([\s\S]*?)</g),
+        ]
+          .map((match) => match[1])
+          .join("\n")
+
+        expect(
+          captions,
+          `${path} must carry catalog-dummy captions`
+        ).toBeTruthy()
+
+        for (const phrase of required) {
+          expect(
+            captions,
+            `${path} caption must name the fabricated claim "${phrase}"`
+          ).toContain(phrase)
+        }
+      }
+    }
+  })
+
+  it("keeps captions out of the mocked app's own screen", () => {
+    // The label is the catalog speaking. Inside a phone mockup it reads as the
+    // mocked product disclaiming its own data, which is a different (and false)
+    // statement about a real brand.
+    for (const path of previewFiles()) {
+      const html = readRepoFile(path)
+      const screens = [
+        ...html.matchAll(
+          /<div class="screen"[^>]*>([\s\S]*?)<\/div>\s*<\/div>/g
+        ),
+      ]
+      for (const screen of screens) {
+        expect(
+          screen[1],
+          `${path} must not place a catalog-dummy caption inside a .screen mock`
+        ).not.toContain("catalog-dummy")
+      }
+    }
+  })
+})

--- a/src/lib/design-md-preview-disclaimer.test.ts
+++ b/src/lib/design-md-preview-disclaimer.test.ts
@@ -15,6 +15,29 @@ function readRepoFile(path: string): string {
   return readFileSync(join(ROOT, path), "utf8")
 }
 
+/**
+ * Content of the `<div class="screen">` that opens at `openIndex`, found by
+ * counting tag depth to its real closing tag.
+ *
+ * A non-greedy `([\s\S]*?)</div>\s*</div>` regex looks equivalent and is not: it
+ * stops at the first *adjacent* pair of closing divs, which inside a phone mock
+ * is some nested field wrapper, not the screen. Measured against depth counting
+ * it covered 14% of 11st's screen, 16% of socar's, and 43% of codeit's — so the
+ * back of every mock went unchecked and this guard would have passed a caption
+ * placed there.
+ */
+function screenContent(html: string, openIndex: number): string {
+  let depth = 0
+  for (const tag of html
+    .slice(openIndex)
+    .matchAll(/<(\/?)div\b[^>]*?(\/?)>/g)) {
+    if (tag[2] === "/") continue // self-closing, no depth change
+    depth += tag[1] ? -1 : 1
+    if (depth === 0) return html.slice(openIndex, openIndex + tag.index)
+  }
+  return html.slice(openIndex)
+}
+
 function previewFiles(): Array<string> {
   return readdirSync(join(ROOT, "public/preview"), { withFileTypes: true })
     .filter((entry) => entry.isDirectory() && entry.name !== "_runtime")
@@ -56,9 +79,12 @@ describe("/design-md catalog disclosure wiring", () => {
     expect(skill).toContain("DISCLAIMER_MISPLACED_")
     expect(skill).toContain("catalog disclosure strip")
 
-    // Validator: both rule names reachable from the skill's 9a2 gate.
+    // Validator: all three rule names reachable from the skill's 9a2 gate.
+    // They are separate because the fixes are: add the strip / move it / restore
+    // a sentence.
     expect(validator).toContain("missing-disclaimer-banner")
     expect(validator).toContain("disclaimer-banner-misplaced")
+    expect(validator).toContain("disclaimer-banner-incomplete")
 
     // Runtime CSS: dedicated 0-chroma tokens. Reusing --muted-foreground would
     // let 13 of 17 previews tint the strip with their own brand hue, because a
@@ -183,14 +209,9 @@ describe("/design-md catalog disclosure wiring", () => {
     // statement about a real brand.
     for (const path of previewFiles()) {
       const html = readRepoFile(path)
-      const screens = [
-        ...html.matchAll(
-          /<div class="screen"[^>]*>([\s\S]*?)<\/div>\s*<\/div>/g
-        ),
-      ]
-      for (const screen of screens) {
+      for (const open of html.matchAll(/<div class="screen"[^>]*>/g)) {
         expect(
-          screen[1],
+          screenContent(html, open.index),
           `${path} must not place a catalog-dummy caption inside a .screen mock`
         ).not.toContain("catalog-dummy")
       }

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { validatePreviewPair } from "./preview-validator"
 import type { PreviewValidationInput } from "./preview-validator"
@@ -243,7 +245,7 @@ describe("validatePreviewPair — disclosure banner", () => {
     })
 
   it("flags a preview with no disclosure strip at all", () => {
-    expect(rulesOf(bothThemes(""), "warn")).toContain(
+    expect(rulesOf(bothThemes(""), "block")).toContain(
       "missing-disclaimer-banner"
     )
   })
@@ -251,7 +253,7 @@ describe("validatePreviewPair — disclosure banner", () => {
   it("flags a strip that dropped the non-affiliation sentence", () => {
     const partial =
       '<div class="catalog-disclaimer" role="note">표시된 정보는 레이아웃 시연용 더미 데이터입니다.</div>'
-    expect(rulesOf(bothThemes(partial), "warn")).toContain(
+    expect(rulesOf(bothThemes(partial), "block")).toContain(
       "missing-disclaimer-banner"
     )
   })
@@ -259,7 +261,7 @@ describe("validatePreviewPair — disclosure banner", () => {
   it("flags a strip that dropped the dummy-data sentence", () => {
     const partial =
       '<div class="catalog-disclaimer" role="note">이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다.</div>'
-    expect(rulesOf(bothThemes(partial), "warn")).toContain(
+    expect(rulesOf(bothThemes(partial), "block")).toContain(
       "missing-disclaimer-banner"
     )
   })
@@ -283,7 +285,7 @@ describe("validatePreviewPair — disclosure banner", () => {
         body: `${captionBelow}<main class="hero"><h1>데모</h1></main>`,
       }),
     })
-    expect(rulesOf(input, "warn")).toContain("missing-disclaimer-banner")
+    expect(rulesOf(input, "block")).toContain("missing-disclaimer-banner")
   })
 
   // The mirror case: a class name that merely ends in the token must not count
@@ -291,7 +293,7 @@ describe("validatePreviewPair — disclosure banner", () => {
   it("does not accept a class that only ends with the disclosure token", () => {
     const lookalike =
       '<div class="page-catalog-disclaimer">이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다. 더미 데이터입니다.</div>'
-    expect(rulesOf(bothThemes(lookalike), "warn")).toContain(
+    expect(rulesOf(bothThemes(lookalike), "block")).toContain(
       "missing-disclaimer-banner"
     )
   })
@@ -326,19 +328,31 @@ describe("validatePreviewPair — disclosure banner", () => {
         `${FULL_DISCLAIMER}</body>`
       ),
     })
-    const rules = rulesOf(buried, "warn")
+    const rules = rulesOf(buried, "block")
     expect(rules).toContain("disclaimer-banner-misplaced")
     // Present and complete — only its position is wrong.
     expect(rules).not.toContain("missing-disclaimer-banner")
   })
 
-  // D-1 ships these at `warn` on purpose: promoting them to `block` before
-  // preview-html-author.md teaches the strip would make the pipeline unable to
-  // satisfy its own Stage 9a2 gate. D-2 flips them with the skill files.
-  it("is a warn, not a block, until the author skill teaches the strip", () => {
-    expect(rulesOf(bothThemes(""), "block")).not.toContain(
+  // Promoted to `block` in D-2, together with the skill files that teach the
+  // strip. The dependency is asserted, not just commented: a `block` rule landing
+  // before preview-html-author.md knows about the strip leaves the pipeline unable
+  // to satisfy its own Stage 9a2 gate — the author cannot fix what it was never
+  // told about, K=2 exhausts, Stage 9c ships anyway, and main fails. If someone
+  // ever strips the guidance back out of the author, this fails loudly here rather
+  // than silently on the next onboarding.
+  it("blocks, and the author prompt it depends on teaches the strip", () => {
+    expect(rulesOf(bothThemes(""), "block")).toContain(
       "missing-disclaimer-banner"
     )
+
+    const author = readFileSync(
+      join(process.cwd(), ".claude/agents/preview-html-author.md"),
+      "utf8"
+    )
+    expect(author).toContain('class="catalog-disclaimer"')
+    expect(author).toContain("제휴·후원 관계가 없습니다")
+    expect(author).toContain("더미 데이터")
   })
 })
 
@@ -442,7 +456,9 @@ describe("validatePreviewPair — review hardening", () => {
           theme === "dark" ? "oklch(0.22 0.01 250)" : "oklch(0.98 0.005 250)"
         }; }</style>`,
         "</head>",
-        "<body><main><img src='/logos/demo.png' alt=''><h1>데모</h1></main></body>",
+        // Single-quoted here too — this is the suite's only single-quote fixture,
+        // so it is also what covers the disclosure regexes' `["']` handling.
+        "<body><div class='catalog-disclaimer' role='note'>이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다. 표시된 정보는 레이아웃 시연용 더미 데이터입니다.</div><main><img src='/logos/demo.png' alt=''><h1>데모</h1></main></body>",
         "</html>",
       ].join("\n")
     const input = makeInput({

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -254,7 +254,7 @@ describe("validatePreviewPair — disclosure banner", () => {
     const partial =
       '<div class="catalog-disclaimer" role="note">표시된 정보는 레이아웃 시연용 더미 데이터입니다.</div>'
     expect(rulesOf(bothThemes(partial), "block")).toContain(
-      "missing-disclaimer-banner"
+      "disclaimer-banner-incomplete"
     )
   })
 
@@ -262,7 +262,7 @@ describe("validatePreviewPair — disclosure banner", () => {
     const partial =
       '<div class="catalog-disclaimer" role="note">이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다.</div>'
     expect(rulesOf(bothThemes(partial), "block")).toContain(
-      "missing-disclaimer-banner"
+      "disclaimer-banner-incomplete"
     )
   })
 
@@ -285,7 +285,7 @@ describe("validatePreviewPair — disclosure banner", () => {
         body: `${captionBelow}<main class="hero"><h1>데모</h1></main>`,
       }),
     })
-    expect(rulesOf(input, "block")).toContain("missing-disclaimer-banner")
+    expect(rulesOf(input, "block")).toContain("disclaimer-banner-incomplete")
   })
 
   // The mirror case: a class name that merely ends in the token must not count
@@ -306,13 +306,14 @@ describe("validatePreviewPair — disclosure banner", () => {
       darkRaw: makeHtml({ theme: "dark", disclaimer: english, lang: "en" }),
       designMdRaw: makeDesignMd().replace("lang: ko", "lang: en"),
     })
-    expect(rulesOf(input)).not.toContain("missing-disclaimer-banner")
+    expect(rulesOf(input)).not.toContain("disclaimer-banner-incomplete")
   })
 
   it("accepts a complete strip", () => {
     const rules = rulesOf(makeInput())
     expect(rules).not.toContain("missing-disclaimer-banner")
     expect(rules).not.toContain("disclaimer-banner-misplaced")
+    expect(rules).not.toContain("disclaimer-banner-incomplete")
   })
 
   // A strip below the fold satisfies the letter of the rule and none of its

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -412,9 +412,15 @@ function checkFile(
     )
   }
 
+  // `block`, matching the sibling structural rules (missing-tokens-css,
+  // missing-iframe-js, hero-logo-missing). D-1 shipped these at `warn` only as a
+  // transition: promoting before .claude/agents/preview-html-author.md taught the
+  // strip would have left the pipeline unable to satisfy its own Stage 9a2 gate.
+  // That file now carries the verbatim strip and its halt conditions, so the
+  // false-positive rate is zero and the fix is mechanical.
   if (!DISCLAIMER_PRESENT.test(html)) {
     issues.push(
-      warn(
+      block(
         "missing-disclaimer-banner",
         name,
         `${name} must open <body> with <div class="${DISCLAIMER_CLASS}" role="note">…</div> — iframe.js cannot inject it into a standalone or redistributed copy.`
@@ -423,7 +429,7 @@ function checkFile(
   } else {
     if (!DISCLAIMER_FIRST_CHILD.test(html)) {
       issues.push(
-        warn(
+        block(
           "disclaimer-banner-misplaced",
           name,
           `${name} has a .${DISCLAIMER_CLASS} strip but it is not the first child of <body> — move it there so it lands in the first screen and in the hero crop a screenshot takes.`
@@ -440,7 +446,7 @@ function checkFile(
       ].filter((phrase) => !strip.includes(phrase))
       if (missing.length > 0) {
         issues.push(
-          warn(
+          block(
             "missing-disclaimer-banner",
             name,
             `${name} has a .${DISCLAIMER_CLASS} strip but is missing ${missing.map((p) => `"${p}"`).join(" and ")} — the non-affiliation and dummy-data sentences each carry a separate claim and both must survive edits.`

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -53,8 +53,11 @@ const DISCLAIMER_PRESENT = new RegExp(DISCLAIMER_CLASS_ATTR, "i")
 // screen and in the hero crop that screenshots usually take. A strip anywhere
 // else satisfies the letter of the rule and none of its purpose, so presence
 // and placement are separate findings with separate fixes.
+// `(?:\s|<!--[\s\S]*?-->)*` rather than `\s*`: an HTML comment between <body>
+// and the strip is still a strip-first document, and flagging it as misplaced
+// would be a false positive on markup that is doing nothing wrong.
 const DISCLAIMER_FIRST_CHILD = new RegExp(
-  `<body\\b[^>]*>\\s*<[a-z][a-z0-9]*\\b[^>]*${DISCLAIMER_CLASS_ATTR}`,
+  `<body\\b[^>]*>(?:\\s|<!--[\\s\\S]*?-->)*<[a-z][a-z0-9]*\\b[^>]*${DISCLAIMER_CLASS_ATTR}`,
   "i"
 )
 // Captures the strip's own inner HTML (group 2) so the wording below is checked
@@ -445,9 +448,14 @@ function checkFile(
         DISCLAIMER_DUMMY_DATA,
       ].filter((phrase) => !strip.includes(phrase))
       if (missing.length > 0) {
+        // Separate rule from `missing-disclaimer-banner`, for the same reason
+        // `disclaimer-banner-misplaced` is separate: "there is no strip" and
+        // "the strip lost a sentence" are different fixes, and a consumer
+        // filtering by rule name should not have to parse the message to tell
+        // them apart.
         issues.push(
           block(
-            "missing-disclaimer-banner",
+            "disclaimer-banner-incomplete",
             name,
             `${name} has a .${DISCLAIMER_CLASS} strip but is missing ${missing.map((p) => `"${p}"`).join(" and ")} — the non-affiliation and dummy-data sentences each carry a separate claim and both must survive edits.`
           )


### PR DESCRIPTION
Closes #211 — 스킬 파일 변경 사전 합의 이슈.

[PR #210](https://github.com/CaesiumY/ko-design-md/pull/210)(D-1)이 34개 프리뷰에 고지 스트립을 넣고 검증기 룰을 **`warn`** 으로 추가했습니다. D-2가 파이프라인이 그 룰을 만족할 수 있게 만들고 **`block`** 으로 올립니다.

설계 문서: `docs/superpowers/specs/2026-08-03-preview-disclosure-banner-design.md`

## 왜 두 PR로 나눴나

D-1 착지 시점의 파이프라인은 비대칭이었습니다 — **검증기는 스트립을 알지만 작성자 에이전트는 몰랐습니다.** 새 브랜드를 온보딩하면 배너 없는 프리뷰가 나오고 warn만 뜬 채 출하됩니다.

`block`을 작성자 프롬프트보다 먼저 올리면 더 나쁩니다: 배너 없는 프리뷰 → Stage 9a2 block → 작성자가 배너를 모르니 못 고침 → K=2 소진 → Stage 9c가 비블로킹이라 출하 → main에서 CI 실패. **파이프라인이 자기 게이트를 구조적으로 만족 못 하는 상태**가 됩니다.

## 커밋

| 커밋 | 내용 |
|---|---|
| `6b90a56` | 작성자·루브릭·SKILL.md 배선 + 계약 테스트 신설 |
| `c0749dc` | `warn` → `block` 승격 |

## 무엇이 들어갔나

**`.claude/agents/preview-html-author.md`** — `<body>` 스켈레톤에 정본 1줄, 전용 절 2개 신설("Catalog disclosure strip", "Fabricated data must be labelled"), Required body composition 0번 항목, Halt conditions 2개, 금지 항목 2개.

**라벨링 절이 "자격 주장"을 명시하는 건 PR #210 정오표 때문입니다.** 캡션 9곳 중 6곳이 허구 항목을 빠뜨렸는데 빠진 것 대부분이 배지·인증·순위였습니다 — gmarket `공식`은 계획에서 다뤘으면서 같은 부류인 `베스트`·`국비지원`, 실존 택배사에 붙은 송장번호, 거래 행의 가맹점명은 놓쳤습니다. **허구 데이터를 수치로만 생각하면 값이 아닌 주장을 놓칩니다.**

**`rubric-preview.md`** — Item 1(하드)에 구조 불릿 + failure mode, "Mobile overflow" 뒤에 더미 데이터 라벨링 advisory 블록 신설(warn 방출, **점수 불변**). 새 채점 항목을 만들지 않았습니다 — 10점 총합 재배분과 JSON 예시 전면 수정을 유발합니다. 기계가 못 하는 부분(열거의 완전성)만 리뷰어에게 맡깁니다.

**`SKILL.md`** — Stage 9a2 설명에 스트립 추가, Stage 10에 로고 센티넬을 본뜬 `DISCLAIMER_*` 4종. 배치 검사는 **`rg -qU` 멀티라인이어야 합니다** — 스트립이 `<body>` 다음 줄이라 줄 단위 매칭은 둘을 함께 못 봅니다. 실제로 돌려 정상 파일 0건, 배너를 하단으로 옮긴 사본에서 `DISCLAIMER_MISPLACED`만 발화하는 것을 확인했습니다.

**`src/lib/design-md-preview-disclaimer.test.ts`** (신규, 5개 테스트) — 배선 리터럴 5파일 / 34개 순회(존재 + `<body>` 첫 자식 + **스트립 내부**에 두 문장) / 프리뷰와 사이트 푸터의 비제휴 문장 공유 / 허구 데이터 6개 slug의 자격 주장 인벤토리 / 캡션이 폰 목업 `.screen` 안에 없을 것.

## 검증

- **종단 실측** — `validate:previews`가 정상 사본에 **exit 0**, 배너를 지운 스크래치 사본에 **exit 1** (`BLOCK [missing-disclaimer-banner]`)
- **변이 검증 11종 전부 통과** — 스트립 제거 / 하단 이동 / 더미 문장만 삭제(캡션이 가리는 경우) / 푸터 문구 변경 / 작성자 배선 제거, 그리고 인벤토리 5종 개별 변이
- `test` 366 → **371** (29파일), 카탈로그 17개 전수 **0 blocking**
- `typecheck`·`lint`·`format:check`·`validate:catalog`·`tokens:check`·`audit:oklch`·`build` 통과

## 리뷰가 봐야 할 것

1. **작성자 프롬프트 문구.** 기계 검사는 리터럴 존재까지만 하고, 캡션 열거의 완전성은 이 프롬프트와 루브릭 advisory에 달려 있습니다.
2. **승격 타이밍.** 순서 의존을 주석이 아니라 **단언**으로 고정했습니다 — block 테스트가 작성자 프롬프트의 스트립 리터럴 3종을 함께 확인하므로, 누군가 작성자 쪽 안내만 걷어내면 다음 온보딩에서 조용히 터지는 대신 여기서 실패합니다.
3. **기존 테스트 1건 수정.** 승격이 "accepts single-quoted attributes" 픽스처를 드러냈습니다(자체 인라인 HTML에 스트립이 없어 block). 이 픽스처는 스위트에서 작은따옴표를 쓰는 유일한 곳이라 스트립도 작은따옴표로 넣어, 원래 의도를 지키면서 새 룰의 `["']` 처리까지 덮게 했습니다.

## 자체 발견 (변이 검증이 잡은 것)

계약 테스트가 **통과하는데도 공허한 단언**이 하나 있었습니다. kyobobook 캡션은 `베스트 순위`와 `'베스트' 배지`로 `베스트`가 두 번 나와, 인벤토리가 bare 토큰만 요구하면 배지 쪽을 지워도 통과했습니다(teamsparta `국비지원`도 동일). 배지 리터럴을 따옴표째 고정해 각 항목이 독립적으로 잡히도록 고쳤습니다.

## 범위

- 잔여 묶음 **C**(로고 리사이즈) · **E**(KRDS 주민등록번호 필드·정부24 문구·인증실패 오류) · **F** · **G**(`public/logos/SOURCES.json`) · **H**(프리뷰 산문 전수 감사, 서술문 196개)는 범위 밖입니다.
- **seed-design은 묶음 C~H 전체의 범위 밖**([PR #209](https://github.com/CaesiumY/ko-design-md/pull/209)). 이 PR은 프리뷰 파일을 전혀 건드리지 않습니다.
