### PR TITLE
feat(ci): DCO 서명 게이트 — 포크 PR 한정

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,10 @@ name: DCO
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review 가 필요하다. 아래 draft 스킵과 짝이다 — 이게 없으면 드래프트로
+    # 열었다가 ready 로 바꾸는 PR 은 그 사이 push 가 없을 경우 검사가 한 번도 돌지
+    # 않아 게이트를 우회한다.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # 같은 PR에 새 커밋이 푸시되면 진행 중이던 이전 검사는 취소
 # (claude-code-review.yml 과 같은 관례)
@@ -25,9 +28,13 @@ jobs:
     # 맞으므로 검사를 도는 게 옳다 — null 분기를 앞에 명시해 그 판단이 조건식의
     # 부수 효과가 아니라 의도임을 남긴다(null != 'owner/repo' 도 true 로 평가되어
     # 동작 자체는 같다).
+    #
+    # 드래프트는 건너뛴다(claude-code-review.yml 과 같은 관례). ready 로 전환하는
+    # 순간 위 ready_for_review 트리거가 검사를 돌리므로 우회 경로는 생기지 않는다.
     if: >-
-      github.event.pull_request.head.repo == null ||
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event.pull_request.draft == false &&
+      (github.event.pull_request.head.repo == null ||
+      github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,6 +61,10 @@ jobs:
           # 그래서 `^Signed-off-by:` 는 트레일러가 있어도 항상 false 다 — 개행을
           # 명시한 `(^|\n)` 를 쓴다. 줄 시작을 요구하는 이유는 산문 중간에 이
           # 문구를 언급만 한 커밋이 통과하지 않게 하기 위함이다.
+          #
+          # 대소문자는 구분하지 않는다("i"). `git commit -s` 는 항상 표준 표기로
+          # 붙이지만, 공식 DCO 앱이 대소문자 무관으로 인정하므로 이 게이트만 더
+          # 엄격해서 외부 기여자를 막는 일이 없게 맞춘다.
           # 조회 실패는 통과가 아니라 실패로 끝낸다. 삭제된 포크처럼 드문 상황에서
           # 원인 없는 종료 코드만 남지 않도록 메시지를 붙인다.
           if ! gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate --jq '
@@ -61,7 +72,7 @@ jobs:
             | select((.parents | length) < 2)
             | [
                 .sha[0:8],
-                (if (.commit.message | test("(^|\n)Signed-off-by: .+ <.+@.+>")) then "signed" else "MISSING" end),
+                (if (.commit.message | test("(^|\n)Signed-off-by: .+ <.+@.+>"; "i")) then "signed" else "MISSING" end),
                 (.commit.message | split("\n")[0])
               ]
             | @tsv
@@ -83,7 +94,7 @@ jobs:
             echo "| \`$sha\` | $state | $subject |" >> "$GITHUB_STEP_SUMMARY"
           done < commits.tsv
 
-          missing=$(awk -F'\t' '$2 == "MISSING"' commits.tsv || true)
+          missing=$(awk -F'\t' '$2 == "MISSING"' commits.tsv)
           if [ -z "$missing" ]; then
             echo "모든 커밋에 Signed-off-by 트레일러가 있습니다."
             exit 0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,93 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dco:
+    # DCO 는 저작권자 본인이 자기에게 하는 선언이 아니라, *외부* 기여자로부터
+    # 원작·라이선스 적격 증명을 받는 장치다(CONTRIBUTING §5 — CLA 대신 채택).
+    # 그래서 포크에서 올라온 PR 에서만 돈다.
+    #
+    # 같은 repo 브랜치는 대상이 아니다:
+    #   - 메인테이너 커밋 — 저작권자 본인이라 증명받을 상대가 없다.
+    #   - Dependabot — 같은 repo 브랜치라 이 조건에서 자동 제외된다. 강제할 실익도
+    #     없다: 도입 시점까지 dependabot 커밋 28건이 전부 서명돼 있었다.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check Signed-off-by on every commit
+        # 포크 코드를 체크아웃하지 않고 API 로만 읽는다 — 검사에 필요한 건 커밋
+        # 메시지뿐이고, 신뢰할 수 없는 코드를 러너에 내려받을 이유가 없다.
+        #
+        # ci.yml 과 같은 이유로 값은 `env:` 로 넘긴다: 정적 스캐너가 run 블록 안의
+        # `${{ }}` 를 표현식 주입으로 표시하고, 이 간접화는 나중에 자유 텍스트
+        # 컨텍스트를 읽게 되더라도 안전하게 유지된다.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # 머지 커밋(부모 2개 이상)은 제외한다. 기여자가 base 를 자기 브랜치로
+          # 머지해 생기는 커밋은 본인이 작성한 변경이 아니라 서명 대상이 아니다.
+          #
+          # jq 의 Oniguruma 에서 `^` 는 줄 시작이 아니라 *문자열* 시작에만 걸린다.
+          # 그래서 `^Signed-off-by:` 는 트레일러가 있어도 항상 false 다 — 개행을
+          # 명시한 `(^|\n)` 를 쓴다. 줄 시작을 요구하는 이유는 산문 중간에 이
+          # 문구를 언급만 한 커밋이 통과하지 않게 하기 위함이다.
+          gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate --jq '
+            .[]
+            | select((.parents | length) < 2)
+            | [
+                .sha[0:8],
+                (if (.commit.message | test("(^|\n)Signed-off-by: .+ <.+@.+>")) then "signed" else "MISSING" end),
+                (.commit.message | split("\n")[0])
+              ]
+            | @tsv
+          ' > commits.tsv
+
+          if [ ! -s commits.tsv ]; then
+            echo "검사할 non-merge 커밋이 없습니다."
+            exit 0
+          fi
+
+          echo "## DCO" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 커밋 | 서명 | 제목 |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+          while IFS=$'\t' read -r sha state subject; do
+            echo "| \`$sha\` | $state | $subject |" >> "$GITHUB_STEP_SUMMARY"
+          done < commits.tsv
+
+          missing=$(awk -F'\t' '$2 == "MISSING"' commits.tsv || true)
+          if [ -z "$missing" ]; then
+            echo "모든 커밋에 Signed-off-by 트레일러가 있습니다."
+            exit 0
+          fi
+
+          echo "$missing" | while IFS=$'\t' read -r sha _ subject; do
+            echo "::error::$sha 에 Signed-off-by 트레일러가 없습니다 — $subject"
+          done
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<'GUIDE'
+
+          서명이 없는 커밋이 있습니다. 이 프로젝트는 CLA 대신
+          [DCO](https://developercertificate.org/)를 사용합니다 (CONTRIBUTING §5).
+
+          기존 커밋에 서명을 추가하려면:
+
+          ```bash
+          git rebase --signoff origin/main   # 브랜치 전체
+          git push --force-with-lease
+          ```
+
+          앞으로는 `git commit -s` 로 커밋하면 트레일러가 자동으로 붙습니다.
+          GUIDE
+
+          exit 1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -91,7 +91,10 @@ jobs:
           echo "| 커밋 | 서명 | 제목 |" >> "$GITHUB_STEP_SUMMARY"
           echo "| --- | --- | --- |" >> "$GITHUB_STEP_SUMMARY"
           while IFS=$'\t' read -r sha state subject; do
-            echo "| \`$sha\` | $state | $subject |" >> "$GITHUB_STEP_SUMMARY"
+            # subject 는 기여자가 온전히 통제하는 커밋 첫 줄이다. `|` 가 들어 있으면
+            # 표 셀이 쪼개져 요약이 깨지므로 이스케이프한다(표시 문제이고 주입은
+            # 아니다 — 첫 줄만 취해 개행이 없고, 큰따옴표 안 확장은 재평가되지 않는다).
+            echo "| \`$sha\` | $state | ${subject//|/\\|} |" >> "$GITHUB_STEP_SUMMARY"
           done < commits.tsv
 
           missing=$(awk -F'\t' '$2 == "MISSING"' commits.tsv)

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# 같은 PR에 새 커밋이 푸시되면 진행 중이던 이전 검사는 취소
+# (claude-code-review.yml 과 같은 관례)
+concurrency:
+  group: dco-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dco:
     # DCO 는 저작권자 본인이 자기에게 하는 선언이 아니라, *외부* 기여자로부터
@@ -14,7 +20,14 @@ jobs:
     #   - 메인테이너 커밋 — 저작권자 본인이라 증명받을 상대가 없다.
     #   - Dependabot — 같은 repo 브랜치라 이 조건에서 자동 제외된다. 강제할 실익도
     #     없다: 도입 시점까지 dependabot 커밋 28건이 전부 서명돼 있었다.
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    #
+    # head.repo 는 PR 오픈 후 포크가 삭제되면 null 이 된다. 그 경우도 포크 PR 이
+    # 맞으므로 검사를 도는 게 옳다 — null 분기를 앞에 명시해 그 판단이 조건식의
+    # 부수 효과가 아니라 의도임을 남긴다(null != 'owner/repo' 도 true 로 평가되어
+    # 동작 자체는 같다).
+    if: >-
+      github.event.pull_request.head.repo == null ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,7 +54,9 @@ jobs:
           # 그래서 `^Signed-off-by:` 는 트레일러가 있어도 항상 false 다 — 개행을
           # 명시한 `(^|\n)` 를 쓴다. 줄 시작을 요구하는 이유는 산문 중간에 이
           # 문구를 언급만 한 커밋이 통과하지 않게 하기 위함이다.
-          gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate --jq '
+          # 조회 실패는 통과가 아니라 실패로 끝낸다. 삭제된 포크처럼 드문 상황에서
+          # 원인 없는 종료 코드만 남지 않도록 메시지를 붙인다.
+          if ! gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate --jq '
             .[]
             | select((.parents | length) < 2)
             | [
@@ -50,7 +65,10 @@ jobs:
                 (.commit.message | split("\n")[0])
               ]
             | @tsv
-          ' > commits.tsv
+          ' > commits.tsv; then
+            echo "::error::PR 커밋 목록을 가져오지 못했습니다. 포크가 삭제된 PR 이라면 기여자에게 브랜치 복구 후 재오픈을 요청하세요."
+            exit 1
+          fi
 
           if [ ! -s commits.tsv ]; then
             echo "검사할 non-merge 커밋이 없습니다."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,15 @@ git commit -s -m "feat(catalog): add 토스"
 # Signed-off-by: Your Name <you@example.com>
 ```
 
+**포크에서 올린 PR은 CI(`.github/workflows/dco.yml`)가 커밋마다 이 트레일러를 검사하며, 없으면 실패합니다.** DCO는 저작권자 본인이 아니라 외부 기여자의 원작·라이선스 적격을 증명받는 장치이므로, 이 저장소 안의 브랜치(메인테이너·Dependabot)와 base를 끌어온 머지 커밋에는 적용되지 않습니다.
+
+서명을 빠뜨린 채 커밋했다면 브랜치 전체에 소급할 수 있습니다.
+
+```bash
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
 ---
 
 ## 6. 사이트 코드/스킬 자체 기여


### PR DESCRIPTION
## 변경 요약

CONTRIBUTING §5 · PR 템플릿 · CLAUDE.md가 DCO 서명을 요구하는데 **이를 강제하는 게이트가 없었습니다**(`.github/workflows/` 전수 grep 0건). PR #217의 코드 리뷰가 "머지 전 CI의 DCO 체크로 재확인"을 권했는데 그 체크가 실재하지 않아 드러났습니다.

`.github/workflows/dco.yml`을 신설하되 **포크에서 올라온 PR에만** 겁니다.

## 왜 전면이 아니라 포크 한정인가

DCO는 저작권자 본인이 자기에게 하는 선언이 아니라, **외부 기여자로부터 원작·라이선스 적격 증명을 받는 장치**입니다. 같은 repo 브랜치는 그 대상이 아닙니다.

| 대상 | 게이트 | 이유 |
|---|---|---|
| 포크 PR | **block** | DCO가 실제 법적 기능을 하는 유일한 지점 |
| 메인테이너 브랜치 | 미적용 | 저작권자 본인 — 증명받을 상대가 없음 |
| Dependabot | 미적용(조건상 자동 제외) | 같은 repo 브랜치. 실익도 없음 — 도입 시점까지 **28건 전부 서명** |
| 머지 커밋 | 제외 | base를 자기 브랜치로 끌어온 커밋은 본인 작성분이 아님 |

포크에서 온 PR은 전체 214건 중 **0건**입니다(작성자: CaesiumY 147 · dependabot 65 · vercel 2). 지금은 no-op이지만, 신규 항목 이슈 템플릿으로 외부 기여를 유치하는 repo라 실제 기여가 들어오는 시점에 값이 생깁니다.

## ⚠️ 기존 히스토리 통계 정정

main 233커밋 중 116건(49.8%)에 서명 트레일러가 없습니다. 조사 초기에 이를 "작성 단계 미서명"으로 읽었는데 **틀렸습니다.**

실제로는 **PR 브랜치 커밋의 서명률이 100%**입니다 — 최근 머지 15개 PR의 non-merge 커밋 105건 전수, 초기 PR 14건 표본이 모두 서명돼 있습니다.

main의 미서명분은 **squash 머지가 트레일러를 떨어뜨린 산물**입니다. 예를 들어 PR #197의 브랜치 커밋 6건은 전부 서명돼 있지만 main의 squash 커밋 `0ef7891`에는 없습니다.

repo 설정은 이미 `squash_merge_commit_message=COMMIT_MESSAGES`라 **설정 문제가 아니고**, 머지 시점에 본문을 손으로 고쳐 쓰면서 트레일러가 빠진 것입니다. 이 게이트는 squash 이전의 PR 커밋을 보므로 그 경로와는 독립적입니다.

> 이 정정 때문에 "전면 강제하면 메인테이너 습관을 즉시 차단한다"는 초기 판단도 근거가 약해집니다. 다만 저작권자 본인 커밋에 DCO를 요구하는 것이 법적 기능이 없다는 이유는 그대로 유효해, 포크 한정 결론은 유지합니다.

## 구현 노트

- **포크 코드를 체크아웃하지 않습니다.** 검사에 필요한 건 커밋 메시지뿐이라 API로만 읽습니다 — 신뢰할 수 없는 코드를 러너에 내려받을 이유가 없습니다.
- **jq의 `^` 함정.** Oniguruma에서 `^`는 줄 시작이 아니라 *문자열* 시작에만 걸립니다. 그래서 `^Signed-off-by:`는 트레일러가 있어도 항상 false이고, 실제로 첫 구현에서 **서명된 커밋을 미서명으로 오판했습니다.** 개행을 명시한 `(^|\n)`을 씁니다. 줄 시작을 요구하는 건 산문 중간에 문구를 언급만 한 커밋이 통과하지 않게 하기 위함입니다.
- 값은 `ci.yml`과 같은 이유로 `env:`를 거쳐 넘깁니다(run 블록 내 `${{ }}` 회피).

## 검증

포크 PR을 만들 수 없어, **형태가 동일한 커밋 API 응답**으로 양쪽 경로를 실측했습니다.

| 케이스 | 대상 | 결과 |
|---|---|---|
| 미서명 판정 | `0ef78914` (squash 산물) | `MISSING` ✅ |
| 서명 판정 | `2d0fca75` | `signed` ✅ |
| 머지 커밋 제외 | `09418ad6` (부모 2개) | select 후 출력 없음 ✅ |

후처리 로직 3케이스:

| 입력 | 동작 |
|---|---|
| 전부 서명 | exit 0 |
| 일부 미서명 | `::error::` 어노테이션 후 exit 1 |
| 검사 대상 없음 | exit 0 |

워크플로 YAML 파싱과 step summary 마크다운 형태(표 · 펜스 블록 · 선행 공백 없음)도 확인했습니다.

## 문서

CONTRIBUTING §5에 게이트 존재와 소급 서명 방법(`git rebase --signoff`)을 적었습니다. `CONTRIBUTING.md`는 이 편집 전부터 prettier 비준수였고 마크다운은 CI 포맷 게이트(`**/*.{ts,tsx,js,jsx}`) 대상이 아니라 재포맷하지 않았습니다.

## 범위

열린 PR #217(의존성 배치) · #218(nitro 핀)과 독립적이며 `origin/main`에서 분기했습니다.
