### PR TITLE
feat(tokens): 색상 스와치를 클릭하면 OKLCH 값이 복사되도록

### DIFF
--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -209,9 +209,12 @@ export function ServiceDetailLayout({
               checks the outer's width.
 
               The right slot is tab-aware: Live Preview gets the
-              light/dark toggle (relevant), Tokens gets a "Copy JSON"
+              light/dark toggle (relevant), Tokens gets a "JSON 복사"
               shortcut (the full sidecar for AI prompts / Tailwind themes),
-              and DESIGN.md gets a "Copy MD" shortcut for the raw source. */}
+              and DESIGN.md gets a "MD 복사" shortcut for the raw source.
+              These labels are Korean because the buttons confirm in Korean
+              ("복사됨") — an English idle label would switch languages
+              mid-interaction. */}
           <div className="@container">
             <div className="flex flex-col items-start gap-3 @sm:flex-row @sm:items-center">
               <DetailTabsList>
@@ -232,7 +235,7 @@ export function ServiceDetailLayout({
                 <InlineCopyButton
                   raw={tokensJson}
                   filename={`${doc.frontmatter.slug}.tokens.json`}
-                  label="Copy JSON"
+                  label="JSON 복사"
                   className="@sm:ml-auto"
                 />
               )}
@@ -240,7 +243,7 @@ export function ServiceDetailLayout({
                 <InlineCopyButton
                   raw={doc.raw}
                   filename={filename}
-                  label="Copy MD"
+                  label="MD 복사"
                   className="@sm:ml-auto"
                 />
               )}

--- a/src/routes/services/-components/copy-button.test.tsx
+++ b/src/routes/services/-components/copy-button.test.tsx
@@ -23,6 +23,32 @@ describe("CopyButton", () => {
     expect(screen.getByRole("button").textContent).toContain("복사됨")
   })
 
+  // This button used to rely on its own label flipping to "복사됨" to convey the
+  // copy, since its accessible name comes from its content. Whether a screen
+  // reader re-announces a focused control whose name changed varies by AT, so
+  // the name is now pinned and the confirmation rides a live region — the same
+  // mechanism the swatch cards and the inline button already use.
+  it("announces the copy without letting its accessible name change", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<CopyButton raw="# design.md" />)
+    const nameBefore = screen.getByRole("button").getAttribute("aria-label")
+    expect(screen.getByRole("status").textContent).toBe("")
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole("status").textContent).toBe("design.md 복사됨")
+    expect(screen.getByRole("button").getAttribute("aria-label")).toBe(
+      nameBefore
+    )
+  })
+
   // Matches the swatch cards and the inline button: a second click has to own a
   // full confirmation window rather than inheriting the first one's deadline.
   it("restarts the confirmation window when clicked again", async () => {

--- a/src/routes/services/-components/copy-button.test.tsx
+++ b/src/routes/services/-components/copy-button.test.tsx
@@ -49,6 +49,22 @@ describe("CopyButton", () => {
     )
   })
 
+  // A button makes every descendant presentational, so a nested live region
+  // never announces. It has to sit beside the control.
+  it("keeps the live region outside the button", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    const { container } = render(<CopyButton raw="# design.md" />)
+
+    expect(container.querySelector('[role="status"]')).toBeTruthy()
+    expect(
+      screen.getByRole("button").querySelector('[role="status"]')
+    ).toBeNull()
+  })
+
   // Matches the swatch cards and the inline button: a second click has to own a
   // full confirmation window rather than inheriting the first one's deadline.
   it("restarts the confirmation window when clicked again", async () => {

--- a/src/routes/services/-components/copy-button.test.tsx
+++ b/src/routes/services/-components/copy-button.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { CopyButton } from "./copy-button"
+
+afterEach(cleanup)
+
+describe("CopyButton", () => {
+  // Its idle label is already Korean ("design.md 전체 복사"); the confirmation
+  // has to match rather than switching languages mid-interaction.
+  it("confirms the copy in Korean", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<CopyButton raw="# design.md" />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole("button").textContent).toContain("복사됨")
+  })
+})

--- a/src/routes/services/-components/copy-button.test.tsx
+++ b/src/routes/services/-components/copy-button.test.tsx
@@ -22,4 +22,34 @@ describe("CopyButton", () => {
 
     expect(screen.getByRole("button").textContent).toContain("복사됨")
   })
+
+  // Matches the swatch cards and the inline button: a second click has to own a
+  // full confirmation window rather than inheriting the first one's deadline.
+  it("restarts the confirmation window when clicked again", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<CopyButton raw="# design.md" />)
+    const click = async () => {
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"))
+        await Promise.resolve()
+      })
+    }
+
+    await click()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    await click()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(screen.getByRole("button").textContent).toContain("복사됨")
+    vi.useRealTimers()
+  })
 })

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -41,6 +41,13 @@ function CheckIcon({ className }: { className?: string }) {
   )
 }
 
+// Pinned as the accessible name so it survives the swap to "복사됨". This
+// button's name used to come from its own text, which meant the confirmation
+// depended on a screen reader re-announcing a focused control whose name
+// changed — behaviour that varies by AT. The live region below carries it
+// instead, matching InlineCopyButton and SwatchCard.
+const IDLE_LABEL = "design.md 전체 복사"
+
 export function CopyButton({ raw }: Props) {
   const [copied, setCopied] = useState(false)
   const revertTimer = useRef<number | undefined>(undefined)
@@ -66,6 +73,7 @@ export function CopyButton({ raw }: Props) {
     <Button
       onClick={onCopy}
       size="lg"
+      aria-label={IDLE_LABEL}
       className="group/copy w-full justify-between font-bold tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]"
     >
       <span className="inline-flex items-center gap-2.5">
@@ -83,10 +91,13 @@ export function CopyButton({ raw }: Props) {
             )}
           />
         </span>
-        <span>{copied ? "복사됨" : "design.md 전체 복사"}</span>
+        <span>{copied ? "복사됨" : IDLE_LABEL}</span>
       </span>
       <span aria-hidden className="text-base">
         →
+      </span>
+      <span role="status" className="sr-only">
+        {copied ? "design.md 복사됨" : ""}
       </span>
     </Button>
   )

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -77,7 +77,7 @@ export function CopyButton({ raw }: Props) {
             )}
           />
         </span>
-        <span>{copied ? "Copied" : "design.md 전체 복사"}</span>
+        <span>{copied ? "복사됨" : "design.md 전체 복사"}</span>
       </span>
       <span aria-hidden className="text-base">
         →

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
@@ -43,12 +43,18 @@ function CheckIcon({ className }: { className?: string }) {
 
 export function CopyButton({ raw }: Props) {
   const [copied, setCopied] = useState(false)
+  const revertTimer = useRef<number | undefined>(undefined)
+
+  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
 
   async function onCopy() {
     try {
       await navigator.clipboard.writeText(raw)
       setCopied(true)
-      setTimeout(() => setCopied(false), 1800)
+      // Cancel the pending revert so a second click gets a full dwell instead
+      // of inheriting the first click's deadline.
+      window.clearTimeout(revertTimer.current)
+      revertTimer.current = window.setTimeout(() => setCopied(false), 1800)
     } catch {
       // Clipboard rejection is rare in practice (requires denied permission
       // or a non-secure context); fall through silently. The button just

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -44,8 +44,8 @@ function CheckIcon({ className }: { className?: string }) {
 // Pinned as the accessible name so it survives the swap to "복사됨". This
 // button's name used to come from its own text, which meant the confirmation
 // depended on a screen reader re-announcing a focused control whose name
-// changed — behaviour that varies by AT. The live region below carries it
-// instead, matching InlineCopyButton and SwatchCard.
+// changed — behaviour that varies by AT. The live region beside the button
+// carries it instead, matching InlineCopyButton and SwatchCard.
 const IDLE_LABEL = "design.md 전체 복사"
 
 export function CopyButton({ raw }: Props) {
@@ -70,35 +70,39 @@ export function CopyButton({ raw }: Props) {
   }
 
   return (
-    <Button
-      onClick={onCopy}
-      size="lg"
-      aria-label={IDLE_LABEL}
-      className="group/copy w-full justify-between font-bold tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]"
-    >
-      <span className="inline-flex items-center gap-2.5">
-        <span className="relative inline-flex size-4 items-center justify-center">
-          <CopyIcon
-            className={cn(
-              "absolute size-4 transition-all duration-200",
-              copied ? "scale-0 opacity-0" : "scale-100 opacity-100"
-            )}
-          />
-          <CheckIcon
-            className={cn(
-              "absolute size-4 transition-all duration-200",
-              copied ? "scale-100 opacity-100" : "scale-0 opacity-0"
-            )}
-          />
+    <>
+      <Button
+        onClick={onCopy}
+        size="lg"
+        aria-label={IDLE_LABEL}
+        className="group/copy w-full justify-between font-bold tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]"
+      >
+        <span className="inline-flex items-center gap-2.5">
+          <span className="relative inline-flex size-4 items-center justify-center">
+            <CopyIcon
+              className={cn(
+                "absolute size-4 transition-all duration-200",
+                copied ? "scale-0 opacity-0" : "scale-100 opacity-100"
+              )}
+            />
+            <CheckIcon
+              className={cn(
+                "absolute size-4 transition-all duration-200",
+                copied ? "scale-100 opacity-100" : "scale-0 opacity-0"
+              )}
+            />
+          </span>
+          <span>{copied ? "복사됨" : IDLE_LABEL}</span>
         </span>
-        <span>{copied ? "복사됨" : IDLE_LABEL}</span>
-      </span>
-      <span aria-hidden className="text-base">
-        →
-      </span>
+        <span aria-hidden className="text-base">
+          →
+        </span>
+      </Button>
+      {/* Sibling, not child: a button makes its descendants presentational,
+          which would strip role="status" and silence this. */}
       <span role="status" className="sr-only">
         {copied ? "design.md 복사됨" : ""}
       </span>
-    </Button>
+    </>
   )
 }

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { InlineCopyButton } from "./inline-copy-button"
+
+afterEach(cleanup)
+
+describe("InlineCopyButton", () => {
+  // The detail page mixes this button with the click-to-copy swatch cards, so
+  // both have to confirm in the same language.
+  it("confirms the copy in Korean", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<InlineCopyButton raw="{}" filename="toss.tokens.json" />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole("button").textContent).toContain("복사됨")
+  })
+})

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -64,6 +64,24 @@ describe("InlineCopyButton", () => {
     expect(screen.getByRole("button").textContent).not.toMatch(/Copy/i)
   })
 
+  // A button makes every descendant presentational, so a nested live region
+  // never announces. It has to sit beside the control.
+  it("keeps the live region outside the button", () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    const { container } = render(
+      <InlineCopyButton raw="{}" filename="toss.tokens.json" />
+    )
+
+    expect(container.querySelector('[role="status"]')).toBeTruthy()
+    expect(
+      screen.getByRole("button").querySelector('[role="status"]')
+    ).toBeNull()
+  })
+
   // WCAG 2.5.3 (Label in Name): voice-control users say what they see, so the
   // visible label has to appear inside the accessible name. The filename is
   // extra context, not a replacement for it.

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -22,4 +22,42 @@ describe("InlineCopyButton", () => {
 
     expect(screen.getByRole("button").textContent).toContain("복사됨")
   })
+
+  // WCAG 2.5.3 (Label in Name): voice-control users say what they see, so the
+  // visible label has to appear inside the accessible name. The filename is
+  // extra context, not a replacement for it.
+  it("keeps the visible label inside the accessible name", () => {
+    render(
+      <InlineCopyButton
+        raw="{}"
+        filename="toss.tokens.json"
+        label="JSON 복사"
+      />
+    )
+
+    expect(screen.getByRole("button").getAttribute("aria-label")).toBe(
+      "JSON 복사 — toss.tokens.json"
+    )
+  })
+
+  // The accessible name never changes, so the visible 복사됨 swap is invisible
+  // to assistive tech without a live region of its own.
+  it("announces the copy through a live region", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<InlineCopyButton raw="{}" filename="toss.tokens.json" />)
+    expect(screen.getByRole("status").textContent).toBe("")
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole("status").textContent).toBe(
+      "toss.tokens.json 복사됨"
+    )
+  })
 })

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -23,6 +23,37 @@ describe("InlineCopyButton", () => {
     expect(screen.getByRole("button").textContent).toContain("복사됨")
   })
 
+  // Same defect as the swatch cards: without cancelling the pending revert, a
+  // second click inherits the first one's deadline and its confirmation is cut
+  // short. All three copy affordances share this page, so they share the fix.
+  it("restarts the confirmation window when clicked again", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+
+    render(<InlineCopyButton raw="{}" filename="toss.tokens.json" />)
+    const click = async () => {
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"))
+        await Promise.resolve()
+      })
+    }
+
+    await click()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    await click()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(screen.getByRole("button").textContent).toContain("복사됨")
+    vi.useRealTimers()
+  })
+
   // The confirmation text is hardcoded Korean, so the idle default has to be
   // Korean too — an English default would put a caller that omits `label` right
   // back into the mid-interaction language switch this component just fixed.

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -23,6 +23,16 @@ describe("InlineCopyButton", () => {
     expect(screen.getByRole("button").textContent).toContain("복사됨")
   })
 
+  // The confirmation text is hardcoded Korean, so the idle default has to be
+  // Korean too — an English default would put a caller that omits `label` right
+  // back into the mid-interaction language switch this component just fixed.
+  it("falls back to a Korean idle label so the pair never mixes languages", () => {
+    render(<InlineCopyButton raw="{}" filename="toss.tokens.json" />)
+
+    expect(screen.getByRole("button").textContent).toContain("복사")
+    expect(screen.getByRole("button").textContent).not.toMatch(/Copy/i)
+  })
+
   // WCAG 2.5.3 (Label in Name): voice-control users say what they see, so the
   // visible label has to appear inside the accessible name. The filename is
   // extra context, not a replacement for it.

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -5,7 +5,14 @@ import { cn } from "@/lib/utils"
 interface Props {
   raw: string
   filename: string
-  /** Idle-state button text. Defaults to "Copy". */
+  /**
+   * Idle-state button text. Defaults to "복사".
+   *
+   * Keep it Korean: the confirmation below is a hardcoded "복사됨", so an
+   * English label would switch languages mid-interaction — the exact bug this
+   * component was fixed for. Types cannot enforce that, so the default is the
+   * guard for callers that do not pass one.
+   */
   label?: string
   className?: string
 }
@@ -48,7 +55,7 @@ function CheckIcon({ className }: { className?: string }) {
 export function InlineCopyButton({
   raw,
   filename,
-  label = "Copy",
+  label = "복사",
   className,
 }: Props) {
   const [copied, setCopied] = useState(false)

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -59,6 +59,9 @@ export function InlineCopyButton({
   className,
 }: Props) {
   const [copied, setCopied] = useState(false)
+  const revertTimer = useRef<number | undefined>(undefined)
+
+  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
 
   // Visible label first so it is contained in the accessible name — voice
   // control users say what they see (WCAG 2.5.3); the filename trails as extra
@@ -70,7 +73,10 @@ export function InlineCopyButton({
     try {
       await navigator.clipboard.writeText(raw)
       setCopied(true)
-      window.setTimeout(() => setCopied(false), 1800)
+      // Cancel the pending revert so a second click gets a full dwell instead
+      // of inheriting the first click's deadline.
+      window.clearTimeout(revertTimer.current)
+      revertTimer.current = window.setTimeout(() => setCopied(false), 1800)
     } catch {
       // Clipboard rejection is rare; fall through silently and let the
       // button stay in its idle state instead of surfacing an error toast.

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -84,26 +84,30 @@ export function InlineCopyButton({
   }
 
   return (
-    <button
-      type="button"
-      onClick={onCopy}
-      aria-label={accessibleName}
-      className={cn(
-        "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",
-        "hover:bg-foreground hover:text-background",
-        copied && "bg-foreground text-background",
-        className
-      )}
-    >
-      {copied ? (
-        <CheckIcon className="size-3.5" />
-      ) : (
-        <CopyIcon className="size-3.5" />
-      )}
-      <span>{copied ? "복사됨" : label}</span>
+    <>
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label={accessibleName}
+        className={cn(
+          "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",
+          "hover:bg-foreground hover:text-background",
+          copied && "bg-foreground text-background",
+          className
+        )}
+      >
+        {copied ? (
+          <CheckIcon className="size-3.5" />
+        ) : (
+          <CopyIcon className="size-3.5" />
+        )}
+        <span>{copied ? "복사됨" : label}</span>
+      </button>
+      {/* Sibling, not child: a button makes its descendants presentational,
+          which would strip role="status" and silence this. */}
       <span role="status" className="sr-only">
         {copied ? `${filename} 복사됨` : ""}
       </span>
-    </button>
+    </>
   )
 }

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -81,7 +81,7 @@ export function InlineCopyButton({
       ) : (
         <CopyIcon className="size-3.5" />
       )}
-      <span>{copied ? "Copied" : label}</span>
+      <span>{copied ? "복사됨" : label}</span>
     </button>
   )
 }

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -53,6 +53,12 @@ export function InlineCopyButton({
 }: Props) {
   const [copied, setCopied] = useState(false)
 
+  // Visible label first so it is contained in the accessible name — voice
+  // control users say what they see (WCAG 2.5.3); the filename trails as extra
+  // context. Keep it stable across the copy so a focused button is not renamed
+  // mid-interaction; the live region below carries the confirmation instead.
+  const accessibleName = `${label} — ${filename}`
+
   async function onCopy() {
     try {
       await navigator.clipboard.writeText(raw)
@@ -68,7 +74,7 @@ export function InlineCopyButton({
     <button
       type="button"
       onClick={onCopy}
-      aria-label={`Copy ${filename}`}
+      aria-label={accessibleName}
       className={cn(
         "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",
         "hover:bg-foreground hover:text-background",
@@ -82,6 +88,9 @@ export function InlineCopyButton({
         <CopyIcon className="size-3.5" />
       )}
       <span>{copied ? "복사됨" : label}</span>
+      <span role="status" className="sr-only">
+        {copied ? `${filename} 복사됨` : ""}
+      </span>
     </button>
   )
 }

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -9,6 +9,11 @@ const TOKEN = {
   group: "Brand",
 }
 
+const NOTED = {
+  ...TOKEN,
+  note: "카노니컬 Toss Blue, 화면당 하나의 primary CTA",
+}
+
 // jsdom ships no clipboard implementation, so every test installs its own and
 // asserts on what the component asked it to write.
 function stubClipboard(writeText: () => Promise<void>) {
@@ -106,11 +111,10 @@ describe("SwatchCard", () => {
     expect(screen.getByRole("status").textContent).toBe("")
   })
 
-  // The 1.8s revert timer is deliberately not cancelled on unmount. React 18
-  // dropped the "state update on an unmounted component" warning (it flagged
-  // correct code), so leaving a card mid-confirmation costs one short-lived
-  // closure and nothing else. This pins that: if a future React reinstates the
-  // warning, the cheap pattern stops being cheap and we should know.
+  // The revert timer is now cleared on unmount — the ref that the re-click fix
+  // needed made that free. This guards the result rather than the mechanism: a
+  // card left mid-confirmation must neither warn nor throw, whether the timer
+  // was cancelled or simply fired into a dead component.
   it("leaves quietly when unmounted inside the confirmation window", async () => {
     stubClipboard(vi.fn().mockResolvedValue(undefined))
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
@@ -124,6 +128,52 @@ describe("SwatchCard", () => {
 
     expect(consoleError).not.toHaveBeenCalled()
     consoleError.mockRestore()
+  })
+
+  // As a <div> the note was plain text and got read in browse mode. Promoting
+  // the card to a <button> with an aria-label replaced the accessible name
+  // outright, and a button is announced atomically — so the usage note went
+  // silent. It rides aria-describedby rather than the label because the label
+  // doubles as the voice-control target (WCAG 2.5.3) and must stay short.
+  it("keeps the usage note reachable after the card became a button", () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={NOTED} />)
+    const describedBy = screen
+      .getByRole("button")
+      .getAttribute("aria-describedby")
+
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)?.textContent).toBe(NOTED.note)
+  })
+
+  it("adds no description when the token carries no note", () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+
+    expect(
+      screen.getByRole("button").getAttribute("aria-describedby")
+    ).toBeNull()
+  })
+
+  // Each click has to own a full confirmation window. Without cancelling the
+  // pending timer, the first click's timer fires on schedule and cuts the
+  // second click's "복사됨" short.
+  it("restarts the confirmation window when the card is clicked again", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    await clickCard()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(screen.getByText("복사됨")).toBeTruthy()
   })
 
   it("names the token and its value for screen readers", () => {

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -76,6 +76,36 @@ describe("SwatchCard", () => {
     expect(screen.getByText(TOKEN.value)).toBeTruthy()
   })
 
+  // The button's accessible name is deliberately static, so a screen reader
+  // hears nothing when the visible line flips to 복사됨. A separate live region
+  // carries the confirmation — and names the token, since 88 cards share the
+  // page and a bare "복사됨" would not say which one landed.
+  it("announces which token was copied without renaming the button", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+    expect(screen.getByRole("status").textContent).toBe("")
+
+    await clickCard()
+
+    expect(screen.getByRole("status").textContent).toBe("blue-500 복사됨")
+    expect(screen.getByRole("button").getAttribute("aria-label")).toBe(
+      "blue-500 복사 — oklch(0.624 0.176 254)"
+    )
+  })
+
+  it("clears the announcement when the confirmation window closes", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1800)
+    })
+
+    expect(screen.getByRole("status").textContent).toBe("")
+  })
+
   it("names the token and its value for screen readers", () => {
     stubClipboard(vi.fn().mockResolvedValue(undefined))
 

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -106,6 +106,26 @@ describe("SwatchCard", () => {
     expect(screen.getByRole("status").textContent).toBe("")
   })
 
+  // The 1.8s revert timer is deliberately not cancelled on unmount. React 18
+  // dropped the "state update on an unmounted component" warning (it flagged
+  // correct code), so leaving a card mid-confirmation costs one short-lived
+  // closure and nothing else. This pins that: if a future React reinstates the
+  // warning, the cheap pattern stops being cheap and we should know.
+  it("leaves quietly when unmounted inside the confirmation window", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const view = render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+    view.unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1800)
+    })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
   it("names the token and its value for screen readers", () => {
     stubClipboard(vi.fn().mockResolvedValue(undefined))
 

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -99,6 +99,20 @@ describe("SwatchCard", () => {
     )
   })
 
+  // Browsers apply role="presentation" to every descendant of a button, so a
+  // live region nested inside one is stripped of its semantics and never
+  // announces. The region has to be a sibling of the control, not a child.
+  it("keeps the live region outside the button so it is not made presentational", () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    const { container } = render(<SwatchCard token={TOKEN} />)
+
+    expect(container.querySelector('[role="status"]')).toBeTruthy()
+    expect(
+      screen.getByRole("button").querySelector('[role="status"]')
+    ).toBeNull()
+  })
+
   it("clears the announcement when the confirmation window closes", async () => {
     stubClipboard(vi.fn().mockResolvedValue(undefined))
 

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { SwatchCard } from "./swatch-card"
+
+const TOKEN = {
+  name: "blue-500",
+  value: "oklch(0.624 0.176 254)",
+  group: "Brand",
+}
+
+// jsdom ships no clipboard implementation, so every test installs its own and
+// asserts on what the component asked it to write.
+function stubClipboard(writeText: () => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  })
+}
+
+// The click handler awaits the clipboard before setting state, so the click has
+// to be flushed inside act() for React to have committed by the assertions.
+async function clickCard() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button"))
+    // Settle the clipboard promise inside the same act() scope so the state
+    // update it schedules is flushed before the assertions run.
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("SwatchCard", () => {
+  it("writes the token's displayed value to the clipboard when clicked", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+
+    render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+
+    expect(writeText).toHaveBeenCalledWith("oklch(0.624 0.176 254)")
+  })
+
+  it("confirms the copy in Korean, then returns to showing the value", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+
+    expect(screen.getByText("복사됨")).toBeTruthy()
+    expect(screen.queryByText(TOKEN.value)).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1800)
+    })
+
+    expect(screen.queryByText("복사됨")).toBeNull()
+    expect(screen.getByText(TOKEN.value)).toBeTruthy()
+  })
+
+  it("stays in its idle state when the clipboard rejects", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")))
+
+    render(<SwatchCard token={TOKEN} />)
+    await clickCard()
+
+    expect(screen.queryByText("복사됨")).toBeNull()
+    expect(screen.getByText(TOKEN.value)).toBeTruthy()
+  })
+
+  it("names the token and its value for screen readers", () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<SwatchCard token={TOKEN} />)
+
+    expect(screen.getByRole("button").getAttribute("aria-label")).toBe(
+      "blue-500 복사 — oklch(0.624 0.176 254)"
+    )
+  })
+})

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -63,50 +63,53 @@ export function SwatchCard({ token }: { token: ColorToken }) {
   }
 
   return (
-    <button
-      type="button"
-      onClick={onCopy}
-      aria-label={`${token.name} 복사 — ${token.value}`}
-      aria-describedby={token.note ? noteId : undefined}
-      className={CARD_CLASS}
-    >
-      <span
-        className="block h-16 w-full border-b"
-        style={{ background: token.value }}
-        aria-hidden
-      />
-      <span className="block px-2.5 py-2">
-        <span className="block text-[13px] leading-tight font-bold text-foreground">
-          {token.name}
-        </span>
-        <span className="mt-1 flex items-center gap-1 font-mono text-[10px] break-all text-muted-foreground">
-          {copied ? (
-            <>
-              <CheckIcon />
-              <span>복사됨</span>
-            </>
-          ) : (
-            token.value
+    <>
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label={`${token.name} 복사 — ${token.value}`}
+        aria-describedby={token.note ? noteId : undefined}
+        className={CARD_CLASS}
+      >
+        <span
+          className="block h-16 w-full border-b"
+          style={{ background: token.value }}
+          aria-hidden
+        />
+        <span className="block px-2.5 py-2">
+          <span className="block text-[13px] leading-tight font-bold text-foreground">
+            {token.name}
+          </span>
+          <span className="mt-1 flex items-center gap-1 font-mono text-[10px] break-all text-muted-foreground">
+            {copied ? (
+              <>
+                <CheckIcon />
+                <span>복사됨</span>
+              </>
+            ) : (
+              token.value
+            )}
+          </span>
+          {token.note && (
+            <span
+              id={noteId}
+              className="mt-1.5 block text-[11px] leading-snug text-muted-foreground"
+            >
+              {token.note}
+            </span>
           )}
         </span>
-        {token.note && (
-          <span
-            id={noteId}
-            className="mt-1.5 block text-[11px] leading-snug text-muted-foreground"
-          >
-            {token.note}
-          </span>
-        )}
-        {/* The aria-label is deliberately static — renaming a focused button
-            mid-interaction makes screen readers re-announce the whole control.
-            So the confirmation rides a live region instead, and it names the
-            token: 88 cards share this page and a bare "복사됨" would not say
-            which one landed. Empty while idle so nothing is announced on the
-            way back. */}
-        <span role="status" className="sr-only">
-          {copied ? `${token.name} 복사됨` : ""}
-        </span>
+      </button>
+      {/* Outside the button on purpose: browsers mark every descendant of a
+          button presentational, which strips role="status" and silences the
+          announcement. It stays sr-only (position:absolute) so adding it as a
+          second grid item does not create a track or shift the cards. It names
+          the token because 88 cards share this page and a bare "복사됨" would
+          not say which one landed, and it empties on revert so nothing is
+          announced on the way back. */}
+      <span role="status" className="sr-only">
+        {copied ? `${token.name} 복사됨` : ""}
       </span>
-    </button>
+    </>
   )
 }

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react"
+import type { ColorToken } from "@/lib/content-types"
+
+// Matches the dwell time of the other copy affordances on this page
+// (CopyButton, InlineCopyButton) so the whole detail view confirms alike.
+const COPIED_MS = 1800
+
+// `flex flex-col` is load-bearing, not a style preference. Grid rows stretch
+// every card to the tallest note in the row, and a <button> lays its contents
+// out in an anonymous box that CENTERS that slack — splitting it above and
+// below, which tears the colour band off the card's top edge. `display: block`
+// does not opt out of it and neither does `align-items`; declaring a formatting
+// context on the button does. A <div> never had the problem, so this only
+// matters for as long as the card is a button.
+const CARD_CLASS =
+  "flex w-full cursor-pointer flex-col border text-left transition-colors outline-none hover:border-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-3 shrink-0"
+      aria-hidden
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  )
+}
+
+// The whole card is the copy target: the swatches sit in a dense 2–5 column
+// grid, so a per-card icon would crowd them and a hover-only affordance would
+// be invisible on touch. Everything inside is a <span> because <p> is not
+// allowed in button content.
+export function SwatchCard({ token }: { token: ColorToken }) {
+  const [copied, setCopied] = useState(false)
+
+  async function onCopy() {
+    try {
+      await navigator.clipboard.writeText(token.value)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), COPIED_MS)
+    } catch {
+      // Clipboard rejection is rare (denied permission / non-secure context);
+      // stay idle rather than surfacing an error, as the other copy buttons do.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      aria-label={`${token.name} 복사 — ${token.value}`}
+      className={CARD_CLASS}
+    >
+      <span
+        className="block h-16 w-full border-b"
+        style={{ background: token.value }}
+        aria-hidden
+      />
+      <span className="block px-2.5 py-2">
+        <span className="block text-[13px] leading-tight font-bold text-foreground">
+          {token.name}
+        </span>
+        <span className="mt-1 flex items-center gap-1 font-mono text-[10px] break-all text-muted-foreground">
+          {copied ? (
+            <>
+              <CheckIcon />
+              <span>복사됨</span>
+            </>
+          ) : (
+            token.value
+          )}
+        </span>
+        {token.note && (
+          <span className="mt-1.5 block text-[11px] leading-snug text-muted-foreground">
+            {token.note}
+          </span>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import type { ColorToken } from "@/lib/content-types"
 
 // Matches the dwell time of the other copy affordances on this page
@@ -38,12 +38,24 @@ function CheckIcon() {
 // allowed in button content.
 export function SwatchCard({ token }: { token: ColorToken }) {
   const [copied, setCopied] = useState(false)
+  const revertTimer = useRef<number | undefined>(undefined)
+  // The note rides aria-describedby, not aria-label: a button is announced
+  // atomically, so once the card became one the usage note stopped being heard
+  // at all. Keeping it out of the label also keeps that string short enough to
+  // be a usable voice-control target (WCAG 2.5.3).
+  const noteId = useId()
+
+  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
 
   async function onCopy() {
     try {
       await navigator.clipboard.writeText(token.value)
       setCopied(true)
-      window.setTimeout(() => setCopied(false), COPIED_MS)
+      // Cancel the pending revert first: without this a second click inside the
+      // window inherits the first click's deadline, so its "복사됨" is cut
+      // short instead of getting a full dwell of its own.
+      window.clearTimeout(revertTimer.current)
+      revertTimer.current = window.setTimeout(() => setCopied(false), COPIED_MS)
     } catch {
       // Clipboard rejection is rare (denied permission / non-secure context);
       // stay idle rather than surfacing an error, as the other copy buttons do.
@@ -55,6 +67,7 @@ export function SwatchCard({ token }: { token: ColorToken }) {
       type="button"
       onClick={onCopy}
       aria-label={`${token.name} 복사 — ${token.value}`}
+      aria-describedby={token.note ? noteId : undefined}
       className={CARD_CLASS}
     >
       <span
@@ -77,7 +90,10 @@ export function SwatchCard({ token }: { token: ColorToken }) {
           )}
         </span>
         {token.note && (
-          <span className="mt-1.5 block text-[11px] leading-snug text-muted-foreground">
+          <span
+            id={noteId}
+            className="mt-1.5 block text-[11px] leading-snug text-muted-foreground"
+          >
             {token.note}
           </span>
         )}

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -81,6 +81,15 @@ export function SwatchCard({ token }: { token: ColorToken }) {
             {token.note}
           </span>
         )}
+        {/* The aria-label is deliberately static — renaming a focused button
+            mid-interaction makes screen readers re-announce the whole control.
+            So the confirmation rides a live region instead, and it names the
+            token: 88 cards share this page and a bare "복사됨" would not say
+            which one landed. Empty while idle so nothing is announced on the
+            way back. */}
+        <span role="status" className="sr-only">
+          {copied ? `${token.name} 복사됨` : ""}
+        </span>
       </span>
     </button>
   )

--- a/src/routes/services/-components/token-card-section.test.tsx
+++ b/src/routes/services/-components/token-card-section.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import { TokenCardSection } from "./token-card-section"
+import type { ServiceTokens } from "@/lib/content-types"
+
+function tokens(overrides: Partial<ServiceTokens> = {}): ServiceTokens {
+  return {
+    colors: [],
+    typography: [],
+    spacing: [],
+    radius: [],
+    ...overrides,
+  }
+}
+
+afterEach(cleanup)
+
+describe("TokenCardSection", () => {
+  // Click-to-copy has no per-card icon, so touch users get no hover cue. A
+  // standing hint next to the Colors label is the only affordance they see.
+  it("tells the reader the colour swatches are click-to-copy", () => {
+    render(
+      <TokenCardSection
+        tokens={tokens({
+          colors: [{ name: "blue-500", value: "oklch(0.624 0.176 254)" }],
+        })}
+      />
+    )
+
+    expect(screen.getByText("클릭하면 복사")).toBeTruthy()
+  })
+
+  it("omits the copy hint when the entry has no colours to click", () => {
+    render(
+      <TokenCardSection
+        tokens={tokens({ radius: [{ name: "r-md", value: "8px", px: 8 }] })}
+      />
+    )
+
+    expect(screen.queryByText("클릭하면 복사")).toBeNull()
+  })
+})

--- a/src/routes/services/-components/token-card-section.tsx
+++ b/src/routes/services/-components/token-card-section.tsx
@@ -1,3 +1,4 @@
+import { SwatchCard } from "./swatch-card"
 import type { ReactNode } from "react"
 import type {
   ColorToken,
@@ -79,8 +80,21 @@ export function TokenCardSection({ tokens }: { tokens?: ServiceTokens }) {
   )
 }
 
-function SubLabel({ children }: { children: string }) {
-  return <p className="text-meta-caps text-muted-foreground">{children}</p>
+// `hint` carries a standing affordance note (currently only the swatch
+// click-to-copy). It has to be always-on rather than hover-revealed: the cards
+// carry no copy icon, so on touch there is nothing else to discover it from.
+function SubLabel({ children, hint }: { children: string; hint?: string }) {
+  return (
+    <p className="text-meta-caps text-muted-foreground">
+      {children}
+      {hint && (
+        <>
+          <span className="opacity-40"> · </span>
+          <span>{hint}</span>
+        </>
+      )}
+    </p>
+  )
 }
 
 // Native disclosure for the collapsed tail of a long section. Styled as an
@@ -164,7 +178,7 @@ function ColorBlock({ colors }: { colors: Array<ColorToken> }) {
 
   return (
     <div className="mt-8">
-      <SubLabel>Colors</SubLabel>
+      <SubLabel hint="클릭하면 복사">Colors</SubLabel>
       <div className="mt-4 space-y-6">
         {visibleGroups.map(renderColorGroup)}
       </div>
@@ -192,31 +206,6 @@ function renderColorGroup([group, items]: [
         {items.map((c) => (
           <SwatchCard key={c.name} token={c} />
         ))}
-      </div>
-    </div>
-  )
-}
-
-function SwatchCard({ token }: { token: ColorToken }) {
-  return (
-    <div className="border">
-      <div
-        className="h-16 w-full border-b"
-        style={{ background: token.value }}
-        aria-hidden
-      />
-      <div className="px-2.5 py-2">
-        <p className="text-[13px] leading-tight font-bold text-foreground">
-          {token.name}
-        </p>
-        <p className="mt-1 font-mono text-[10px] break-all text-muted-foreground">
-          {token.value}
-        </p>
-        {token.note && (
-          <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
-            {token.note}
-          </p>
-        )}
       </div>
     </div>
   )

--- a/src/routes/services/-components/token-card-section.tsx
+++ b/src/routes/services/-components/token-card-section.tsx
@@ -1,3 +1,7 @@
+// Value imports precede type imports here because that is what this repo's
+// `import/order` rule enforces — moving `./swatch-card` below the `react` type
+// import fails `pnpm lint`. It reads backwards next to files that have no type
+// imports, so it keeps getting flagged in review; it is not a style choice.
 import { SwatchCard } from "./swatch-card"
 import type { ReactNode } from "react"
 import type {

--- a/src/routes/services/-service-detail-layout.test.tsx
+++ b/src/routes/services/-service-detail-layout.test.tsx
@@ -33,7 +33,7 @@ vi.mock("./-components/detail-tabs", () => ({
 }))
 
 vi.mock("./-components/inline-copy-button", () => ({
-  InlineCopyButton: () => <button type="button">Copy</button>,
+  InlineCopyButton: () => <button type="button">복사</button>,
 }))
 
 vi.mock("./-components/preview-frame", () => ({


### PR DESCRIPTION
## 변경 요약

토큰 카드 뷰의 색상 스와치를 클릭하면 표시된 OKLCH 값이 클립보드에 복사된다. 지금까지는 값을 쓰려면 10px 모노 텍스트를 드래그로 긁어야 했다. 카드 전체가 복사 버튼이 되고, 확인은 값 텍스트 줄이 1.8초간 "복사됨"으로 바뀌는 방식이다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 설계 결정과 근거

리뷰에서 되물을 만한 지점을 먼저 적는다.

**복사값은 OKLCH 그대로, hex 변환 없음.** 사이드카에는 OKLCH만 있어 hex를 주려면 변환이 필요한데, 왕복 반올림으로 계산한 hex는 브랜드 공식 hex와 마지막 자리가 어긋날 수 있다(시각적으로는 동일 — `audit:oklch`가 ΔE ≤ 0.01, 채널당 2/255 이내를 강제한다). 값 충실도가 이 카탈로그의 존재 이유라 "보이는 것이 복사된다"를 지켰다. 공식 hex는 md의 `# #RRGGBB` 트레일링 주석에 이미 있으므로, 수요가 확인되면 사이드카에 `hex` 필드로 실어 보내는 **별도 PR**로 정확하게 추가할 수 있다.

**대상은 색상만.** 타이포 토큰은 size·weight·lineHeight·tracking 묶음이라 "무엇을 복사하나"를 따로 정의해야 하고, spacing/radius는 `8px`처럼 손으로 치는 게 빠르다. 클릭 어포던스를 붙일 값이 단일 문자열인 곳으로 한정했다.

**카드 전체가 버튼.** 스와치는 2~5열로 빽빽해 카드마다 복사 아이콘을 넣으면 붐비고, 호버로만 드러내면 터치에서 발견되지 않는다. 네이티브 `<button>`이라 키보드 포커스·Enter 활성화·스크린리더 라벨(`"blue-500 복사 — oklch(...)"`)이 따라온다.

**"클릭하면 복사" 힌트는 상시 노출.** 카드에 아이콘이 없으니 모바일에는 이것 말고 단서가 없다. Colors 서브라벨 옆 한 줄이라 카드 88개에 아이콘을 뿌리는 것보다 밀도 대비 효율이 좋다.

**기존 두 복사 버튼의 "Copied"도 "복사됨"으로.** 같은 화면에서 복사 확인 어휘가 영·한으로 갈리지 않게 하기 위한 것으로, 이 PR이 건드리는 마이크로카피는 복사 피드백 문구뿐이다("Show less" 등 다른 영문 라벨은 그대로).

## 리뷰어가 알면 좋은 함정 2개

버튼으로 바꾸면서 딸려온 제약이라, 나중에 되돌리면 조용히 재발한다.

1. **내부가 전부 `<span>`인 이유** — `<p>`는 button 콘텐츠 모델에 들어갈 수 없다(하이드레이션 불일치).
2. **컨테이너가 `flex flex-col`인 이유** — 그리드가 카드를 행 최대 높이로 늘리는데, `<button>`은 남는 공간을 익명 정렬 상자에서 위아래로 나눠 색 면을 카드 상단 테두리에서 떼어놓는다. `display: block`으로도 `align-items`로도 빠져나갈 수 없어 서식 문맥 선언이 필요했다. 실제로 코드잇 88개 중 5개에서 상단 16px 여백으로 나타났던 회귀이고, 코드에 주석으로 근거를 남겼다.

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] `pnpm test` 435개 통과 (신규 테스트 7개 포함)
- [x] `pnpm tokens:check` · `pnpm check:last-updated` 통과 (`services/` 무변경)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

`pnpm format:check`는 `.claude/skills/docs-crawler/` 하위 14개 파일을 잡지만 CLAUDE.md에 기록된 Windows CRLF 오탐이고, 이 PR이 건드린 파일은 전부 통과한다.

## 검증

TDD로 진행해 모든 테스트가 구현 전에 올바른 이유로 실패하는 것을 확인했다(button role 부재 / `'Copied' vs '복사됨'`).

로컬 dev 서버 실측 (코드잇 항목, 88개 카드 전수):

| 확인 | 결과 |
| --- | --- |
| 클립보드 수신값 | 표시값과 동일 (`oklch(0.561 0.216 20)`), 프로미스 resolve |
| 피드백 전환 | `복사됨` → 1.8초 후 원래 값 복귀 |
| 상단 여백 | 0 (수정 전 5개 카드에서 16px) |
| 색 면 높이 | 88개 전부 64px |
| 375 / 976 / 1280px | 가로 오버플로우 없음 |
| 콘솔 | 에러·하이드레이션 경고 0건 |

키보드 Enter 활성화는 하니스의 합성 키 이벤트가 네이티브 버튼 활성화를 일으키지 못해 **실측하지 못했다.** 이 PR과 무관한 기존 "Copy toss.tokens.json" 버튼으로 대조한 결과 동일하게 `keydown`만 도달하고 click이 없었으므로 하니스 한계로 판단했다. 네이티브 `<button>`이라 실제 브라우저에서는 보장되지만, 리뷰 시 한 번 눌러봐 주면 좋겠다.

## 관련 이슈

<!-- 없음 -->
