### PR TITLE
fix(drift): 주석이 검사를 끄는 경로를 막고 커버리지를 단언한다 (#187)

### DIFF
--- a/public/preview/line-design-system/dark.html
+++ b/public/preview/line-design-system/dark.html
@@ -53,7 +53,7 @@
 
       /* Dark-mode 표현용 보강색 — primary는 +6 명도 보강 */
       --ldsg-linegreen-dark: oklch(0.79 0.205 149);
-      --ldsg-role-link-dark: oklch(0.70 0.18 258);
+      --ldsg-role-link-dark: oklch(0.70 0.197 258);
       --ldsg-role-negative-dark: oklch(0.66 0.217 28);
 
       /* Dark 셸용 보조 회색 — 표면용으로 명도를 뒤집은 표현값(토큰값 아님).

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -1,0 +1,151 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { findPreviewDrift, readDefinitions } from "./oklch-drift"
+
+// `oklch-drift.test.ts` proves the algorithm on synthetic strings. Nothing
+// proved it still reaches the catalogue — and it barely does. Measured over the
+// shipped previews, the gate compares 22 declarations out of the 650 it looks
+// at, and 14 of 17 slugs contribute nothing, because previews prefix their
+// custom properties (`--tds-blue-500`) while the md keys are bare (`blue-500`).
+// A regression in `readDefinitions` could take that 22 to 0 and every existing
+// test would stay green.
+//
+// `scripts/audit-oklch.ts` already worries about this in prose: its drift loop
+// stops the run when a preview file is missing, because otherwise the loop
+// "exits 0 with no output — the gate is green but nothing was checked". That
+// guard only covers a missing FILE. This file covers the other way to check
+// nothing: the file is there and no declaration reaches the comparison.
+//
+// So the assertions here are about COVERAGE, not correctness. Correctness is
+// the unit file's job; drift being zero is the catalogue's job (and CI runs
+// `pnpm audit:oklch` for that). What is pinned here is that the gate still has
+// something to say.
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url))
+const PREVIEW = join(ROOT, "public", "preview")
+const SERVICES = join(ROOT, "services")
+
+// Any value that cannot be a normalised `oklch(...)` string, so every name that
+// reaches the comparison is reported as a finding. That turns `findPreviewDrift`
+// into a counter without reimplementing its scope rules — the count then comes
+// from the real code path, which is the only kind of count worth asserting.
+const SENTINEL = "SENTINEL_NEVER_EQUAL"
+
+/** Declarations that survived the scope rules, whatever their name. */
+function consideredCount(html: string): number {
+  const names = new Map<string, string>()
+  for (const m of html.matchAll(/--([\w-]+):\s*(?=oklch\()/g)) {
+    names.set(m[1], SENTINEL)
+  }
+  return findPreviewDrift(html, names).length
+}
+
+/** Declarations that survived the scope rules AND matched an md token name. */
+function matchedCount(html: string, defs: Map<string, string>): number {
+  const names = new Map<string, string>()
+  for (const key of defs.keys()) names.set(key, SENTINEL)
+  return findPreviewDrift(html, names).length
+}
+
+function slugs(): Array<string> {
+  if (!existsSync(PREVIEW)) return []
+  return readdirSync(PREVIEW, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith("_"))
+    .map((d) => d.name)
+    .filter(
+      (s) =>
+        existsSync(join(PREVIEW, s, "light.html")) &&
+        existsSync(join(SERVICES, `${s}.md`))
+    )
+    .sort()
+}
+
+// The floor, not the exact number. Previews change for legitimate reasons and
+// the count moves with them; what must never happen is the total collapsing.
+// Measured 22 on 2026-08-06 (11st 19, class101 2, seed-design 1).
+const MATCH_FLOOR = 22
+
+// Slugs whose preview names cannot reach their md names today, with the reason.
+// Being listed here is not approval — it is the coverage gap written down where
+// the next person will see it. A slug LEAVING this list is an improvement and
+// does not fail; a slug JOINING it is a regression the total-floor check above
+// catches.
+const NO_MATCH_TODAY: Record<string, string> = {
+  baemin: "preview `--bm-*`, md bare",
+  bezier: "preview declares no oklch at all — it is hex",
+  codeit: "preview `--ci-*`, md `codeit-*`",
+  gmarket: "preview semantic + `--gds-*`, md palette names",
+  greeting: "preview `--g-gray-0`, md `gray0` — prefix and hyphen both differ",
+  krds: "preview `--krds-*`, md bare",
+  kyobobook: "preview `--kds-*`, md bare",
+  "line-design-system": "preview `--ldsg-linegreen`, md `ldsg-color-linegreen`",
+  socar: "preview `--sf-*`, md bare",
+  teamsparta: "preview `--sp-red`, md `brand-red`",
+  toss: "preview `--tds-*`, md bare",
+  "vapor-ui": "preview `--vp-*`, md bare",
+  wanted: "preview `--w-*`, md bare",
+  yeogi: "preview `--yg-*`, md `yeogi-*`",
+}
+
+describe("oklch-drift — catalogue coverage", () => {
+  const all = slugs()
+
+  it("finds previews to check", () => {
+    expect(all.length).toBeGreaterThan(0)
+  })
+
+  it("still compares at least as many declarations as it did when measured", () => {
+    let total = 0
+    const perSlug: Array<string> = []
+    for (const slug of all) {
+      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const defs = readDefinitions(
+        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
+      )
+      const n = matchedCount(html, defs)
+      total += n
+      if (n > 0) perSlug.push(`${slug} ${n}`)
+    }
+    expect(
+      total,
+      `the drift gate now compares ${total} declarations, below the ${MATCH_FLOOR} measured on 2026-08-06 (${perSlug.join(", ")}). Something stopped matching — check readDefinitions' regex and the scope rules in findPreviewDrift before lowering this floor.`
+    ).toBeGreaterThanOrEqual(MATCH_FLOOR)
+  })
+
+  it("reads a nonzero number of declarations out of every preview that has them", () => {
+    // Distinct from the check above: a slug can legitimately match no md name,
+    // but a preview full of oklch declarations that the scanner sees NONE of is
+    // always a scanner bug. codeit was exactly that — a `[data-theme="dark"]`
+    // string inside a banner comment closed the light scope over all 91.
+    for (const slug of all) {
+      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const declared = [...html.matchAll(/--[\w-]+:\s*oklch\(/g)].length
+      if (declared === 0) continue
+      expect(
+        consideredCount(html),
+        `${slug}/light.html declares ${declared} oklch custom properties and the scanner considered none of them — the whole file is silently unchecked`
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  it("documents which slugs match no md token name, and why", () => {
+    const measured: Array<string> = []
+    for (const slug of all) {
+      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const defs = readDefinitions(
+        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
+      )
+      if (matchedCount(html, defs) === 0) measured.push(slug)
+    }
+    // Only one direction is a failure. A slug that starts matching has been
+    // fixed, so drop it from the map; a slug that stops matching is caught by
+    // the floor assertion, not here.
+    const unexplained = measured.filter((s) => !(s in NO_MATCH_TODAY))
+    expect(
+      unexplained,
+      `these slugs now match no md token name and are not in NO_MATCH_TODAY — the drift gate is not checking them at all: ${unexplained.join(", ")}`
+    ).toEqual([])
+  })
+})

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -94,14 +94,24 @@ describe("findPreviewDrift", () => {
   })
 
   it("does not let braces inside a comment shift the nesting depth", () => {
-    // Stripping a comment by deleting it would also delete its braces and pull
-    // the depth counter off by one; the fix has to preserve length.
     const found = findPreviewDrift(
       `:root { --gray-06: oklch(0.68 0 0); /* } [data-theme="dark"] { */ }
        :root { --gray-07: oklch(0.99 0 0); }`,
       readDefinitions(md)
     )
     expect(found.map((f) => f.name)).toEqual(["gray-06", "gray-07"])
+  })
+
+  it("treats a comment as a token separator, not as nothing", () => {
+    // In CSS a comment separates tokens, so `--gray-0<comment>6` is not the
+    // property `--gray-06`. Blanking the comment to spaces keeps the halves
+    // apart; deleting it would splice them and invent a declaration that the
+    // stylesheet does not contain — and then compare it against the md.
+    const found = findPreviewDrift(
+      ":root { --gray-0/**/6: oklch(0.68 0 0); }",
+      readDefinitions(md)
+    )
+    expect(found).toEqual([])
   })
 
   it("still honours a real dark block that follows a comment mentioning one", () => {

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -79,4 +79,50 @@ describe("findPreviewDrift", () => {
     )
     expect(found).toEqual([])
   })
+
+  // The scanner reads raw CSS, so anything a comment happens to contain is read
+  // as if it were code. That is not hypothetical: codeit's preview documents its
+  // own theme layering in a banner comment, and the sentence disabled the check
+  // for that whole file. A comment describing the rule must not switch it off.
+  it("does not let a dark selector inside a comment close the light scope", () => {
+    const found = findPreviewDrift(
+      `/* THEME-VARIANT (re-declared under [data-theme="dark"]): gray ramp */
+       :root { --gray-06: oklch(0.68 0 0); }`,
+      readDefinitions(md)
+    )
+    expect(found.map((f) => f.name)).toEqual(["gray-06"])
+  })
+
+  it("does not let braces inside a comment shift the nesting depth", () => {
+    // Stripping a comment by deleting it would also delete its braces and pull
+    // the depth counter off by one; the fix has to preserve length.
+    const found = findPreviewDrift(
+      `:root { --gray-06: oklch(0.68 0 0); /* } [data-theme="dark"] { */ }
+       :root { --gray-07: oklch(0.99 0 0); }`,
+      readDefinitions(md)
+    )
+    expect(found.map((f) => f.name)).toEqual(["gray-06", "gray-07"])
+  })
+
+  it("still honours a real dark block that follows a comment mentioning one", () => {
+    // Removing comment text must not make the scanner blind to the real thing.
+    const found = findPreviewDrift(
+      `/* tokens below are re-declared under [data-theme="dark"] */
+       :root { --gray-06: oklch(0.67 0 0); }
+       [data-theme="dark"] { --gray-07: oklch(0.30 0 0); }`,
+      readDefinitions(md)
+    )
+    expect(found).toEqual([])
+  })
+
+  it("does not treat an unterminated comment as code", () => {
+    // A truncated file must fail closed — reading the rest as CSS would let a
+    // half-written comment invent declarations.
+    const found = findPreviewDrift(
+      `:root { --gray-06: oklch(0.68 0 0); }
+       /* trailing comment that never closes --gray-07: oklch(0.99 0 0);`,
+      readDefinitions(md)
+    )
+    expect(found.map((f) => f.name)).toEqual(["gray-06"])
+  })
 })

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -21,6 +21,35 @@ const normalise = (value: string): string =>
     .replace(/\s\)/g, ")")
     .trim()
 
+/**
+ * Blank out CSS block comments so the scanner cannot read prose as CSS.
+ *
+ * This is not tidiness. The scanner decides scope from the raw text, so a
+ * comment that merely *names* the dark selector switches the check off:
+ * `public/preview/codeit/light.html` documents its own theme layering with
+ * "THEME-VARIANT (re-declared under [data-theme="dark"])" in a banner comment,
+ * which armed `pendingDark`, made the next `:root {` look like a dark block,
+ * and dropped every one of that file's 91 declarations — 56 of which belong in
+ * the light scope (the other 35 are inside a genuine dark block and are meant
+ * to be skipped). A comment describing the rule must not disable it.
+ *
+ * Replaced with spaces rather than removed, because in CSS a comment SEPARATES
+ * tokens. Put an empty comment in the middle of a property name — between the
+ * `0` and the `6` of `--gray-06` — and deleting it splices the halves into a
+ * declaration the stylesheet does not contain, which the scanner would then
+ * compare. A space keeps the halves apart, which is what a CSS parser sees.
+ *
+ * (Brace depth is NOT the reason, though it looks like it. The scan counts
+ * braces in the stripped text, so a comment's braces are gone either way.)
+ *
+ * An unterminated comment runs to the end. That is what a CSS parser does, and
+ * it fails closed — the alternative reads a half-written comment as markup and
+ * invents declarations out of a truncated file.
+ */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, (m) => m.replace(/[^\n]/g, " "))
+}
+
 /** `name: oklch(…)` definitions in a design.md, normalised for comparison. */
 export function readDefinitions(markdown: string): Map<string, string> {
   const out = new Map<string, string>()
@@ -54,7 +83,7 @@ export function findPreviewDrift(
   ].map((m) => m[1])
   // With no <style> at all the input is already a stylesheet — every catalogue
   // preview has one, so this only matters when checking raw CSS directly.
-  const css = blocks.length > 0 ? blocks.join("\n") : previewHtml
+  const css = stripComments(blocks.length > 0 ? blocks.join("\n") : previewHtml)
 
   // Walk braces and declarations in document order. Deciding scope per LINE is
   // not enough: a block that opens and closes on one line would have already


### PR DESCRIPTION
Closes #187.

#187 이 제안한 **"다크 파생 토큰의 C·H 일치 검사"는 코퍼스 실측 결과 세울 수 없다.** 대신 조사 과정에서 진짜 결함 둘과 게이트 자체의 구멍이 나왔고, 이 PR 은 그것을 처리한다.

## 왜 제안된 규칙을 기각하는가

이슈는 다크 파생색이 "L 만 다르고 C·H 는 같아야" 한다고 전제한다. 저장소 산문도 그렇게 말한다 — `preview-html-author.md:161` 과 `rubric-preview.md:66` 이 "primary **lightness** +5–10". 그런데 **코퍼스는 그 규약을 지키지 않는다.**

라이트↔다크 동명 토큰 671쌍(16/17 슬러그):

| 버킷 | 수 |
|---|---:|
| 트리플 완전 동일 | 355 |
| C·H 같고 L 만 다름 (규약 준수) | **93 (14%)** |
| **C 또는 H 가 다름 → 규칙을 걸면 적발** | **223** |

223건은 거의 전부 **의도된 설계**이고 대개 주석에 명시돼 있다 — 11st 웜틴트 중립 램프(`/* warm tint begins */`), codeit 램프 반전, kyobobook 4–10° 재색조, toss 극성 뒤집기, gmarket 녹색 틴트 중립 23개. 구조적으로 오탐이 보장되는 것만 64건이다(중립→틴트 38 · 틴트→중립 10 · 반올림 16). 규약을 지키는 슬러그는 `greeting` 하나뿐이다.

전체 트리플 비교 316건 → C·H 로 좁혀 223건, **노이즈를 29% 밖에 못 줄인다.**

다른 형태도 전부 막힌다:

- **`-dark` 접미사 규칙** — 코퍼스는 접미 형제를 쓰지 않는다(동명 재정의가 지배적). 해소 가능한 쌍이 **4개**뿐이고 그중 진짜 1 · 오탐 1. `-dark-` 포함으로 넓히면 seed-design 의 독립 팔레트 6개를 잘못 빨아들인다.
- **다크 스코프 md 이름 일치** — 20건 대조에 적발 7건, **7건 전부 오탐**.
- **"다크 블록 안"을 키로 쓰는 규칙** — 다크 토큰 814개 중 **211개(26%)** 만 보인다. 10개 슬러그는 `dark.html` 의 `:root` 에 다크 팔레트를 둔다.
- **md 를 대조 상대로 삼기** — 이슈가 든 예 자체가 안 잡힌다. md 는 `ldsg-color-linegreen` 인데 프리뷰는 `--ldsg-linegreen-dark` 로 **`color-` 마디가 없다.** 접미사를 떼도 닿지 않는다.

즉 이슈의 방향 3("현행 유지 + 문서화")이 옳다. 방향 1·2 는 가설이 아니라 **측정으로 기각**된다.

## 대신 고친 것

### 1. 주석이 검사를 꺼버리는 버그 — codeit 이 통째로 미검사였다

`findPreviewDrift` 는 스코프를 원문 텍스트로 판단하는데 CSS 주석을 모른다. `public/preview/codeit/light.html:17` 은 배너 주석 **안**에서 자기 테마 레이어링을 설명한다:

```
   THEME-VARIANT (re-declared under [data-theme="dark"]):
```

이 문장이 `pendingDark` 를 켜고, 바로 다음 `:root {` 가 다크 블록으로 기록되어 **codeit 의 oklch 선언 91개 전부가 검사 대상에서 빠져 있었다.** 어떤 토큰이 테마 가변인지 **설명하는 주석이 검사를 꺼버린 것**이다.

수정 후 실측 — codeit 고려 대상 **0 → 56**(나머지 35개는 진짜 다크 블록이라 계속 스킵되는 게 맞다), 카탈로그 전체 **650 → 706**.

지우지 않고 **공백으로 치환**한다. CSS 에서 주석은 토큰 구분자라, 속성 이름 가운데 빈 주석을 넣으면 삭제 방식은 양쪽을 이어붙여 스타일시트에 없는 선언을 만들고 그걸 md 와 대조한다. 픽스처를 삭제 방식으로 **변이시켜 그 오적발을 실제로 확인**했다.

> 처음엔 "중괄호 깊이 때문에 길이 보존이 필요하다"고 적었는데 **틀렸다.** 중괄호는 제거된 텍스트에서 세므로 삭제해도 똑같이 사라진다. 변이 테스트가 통과해 버려서 근거가 틀렸음이 드러났고, 진짜 이유를 찾아 주석과 픽스처를 다시 썼다.

### 2. 진짜 색 결함 — `--ldsg-role-link-dark`

`public/preview/line-design-system/dark.html:54-57` 은 한 주석 그룹이다.

```
/* Dark-mode 표현용 보강색 — primary는 +6 명도 보강 */
--ldsg-linegreen-dark:     oklch(0.79 0.205 149)   형제 0.72 0.205 149  → L 만 +0.07  ✓
--ldsg-role-link-dark:     oklch(0.70 0.18  258)   형제 0.61 0.197 258  → C 가 함께 바뀜 ✗
--ldsg-role-negative-dark: oklch(0.66 0.217 28)    형제 0.61 0.217 28   → L 만 +0.05  ✓
```

주석은 **명도만** 보강한다고 선언하는데 가운데 줄만 채도를 `0.197 → 0.18` 로 바꾼다. md `line-design-system.md:106` 도 `0.197` 이다. 커밋 `ee9d21b` 가 같은 그룹의 나머지 둘을 고치면서 이것을 빠뜨렸다. `0.18 → 0.197` 로 정정한다. 값이 등장하는 곳은 이 한 줄뿐이라(프리뷰 전체 grep) 사용자 노출 본문 사본이 없고, `services/` 를 건드리지 않으므로 `last_updated` 대상이 아니다.

### 3. 커버리지 단언 — 이 PR 의 핵심 산출물

조사하다 발견한 것: **게이트는 650개 중 22개만 대조하고, 17개 슬러그 중 14개가 0이다.**

| | 값 |
|---|---|
| md 정의 총계 | 1242 |
| 게이트가 대조하는 선언 | 650 |
| **그중 md 이름과 정확 일치** | **22** (11st 19 · class101 2 · seed-design 1) |
| 적발된 드리프트 | 0 |

원인은 프리뷰가 `--tds-blue-500` 처럼 접두를 붙이는데 md 는 `blue-500` 인 이름 불일치다. 즉 이 게이트는 오늘 사실상 **11st 전용 회귀 테스트**이고, `readDefinitions` 의 정규식이 퇴화해 22 가 0 이 되어도 스위트는 초록으로 남는다.

`audit-oklch.ts:330` 의 주석은 이미 이 위험을 산문으로 적어뒀다 — "게이트는 초록인데 검사는 안 됨". 그런데 그 가드는 **파일 부재만** 막는다. `src/lib/oklch-drift-corpus.test.ts` 가 나머지 경로를 막는다:

- 총 일치 수가 **22 미만이면 실패**(바닥만 고정 — 프리뷰가 정당하게 바뀌면 수는 움직인다).
- oklch 선언이 있는데 **고려 대상이 0인 파일이 있으면 실패** — codeit 이 정확히 그 상태였다.
- 현재 0 인 14개 슬러그를 **이유와 함께 명시**. 목록을 벗어나는 것은 개선이라 실패시키지 않고, 새로 들어오는 것은 바닥 검사가 잡는다.

수는 실제 export 를 sentinel 맵으로 호출해 얻는다 — 재구현한 계수는 실제 코드와 조용히 갈라질 수 있다.

## 리뷰 순서

`f5b3128` 은 **검증기를 건드리지 않고 테스트만** 올린다. 그 시점에서 3건이 실패했고(주석 안 다크 셀렉터 · 미종료 주석 · codeit 코퍼스), `git show f5b3128` 로 옛 동작을 재현할 수 있다. `9f53fcd` 가 통과시킨다.

## 하지 않은 것

- **이름 불일치(22/650) 해소** — 슬러그별 접두 선언으로 22 → 약 370(57%)까지 갈 수 있으나, 접두를 어디에 선언할지 설계 결정이 필요하고 새로 드러날 드리프트를 전수 분류해야 한다. 후속 이슈로 연다.
- **bezier** 는 프리뷰가 oklch 를 아예 안 쓰고 hex 라 어떤 이름 규칙으로도 닿지 않는다.
- **`--fix`/`--sync` 모드에서 드리프트가 무시되는 것**(`audit-oklch.ts:365` 의 `!fix` 가드). 하필 `--sync` 가 `dark.html` 에 쓰는 그 모드다. 여기서 고치면 `--sync` 실행이 새로 실패하기 시작해 결함 수정과 섞인다.

## 검증

`pnpm typecheck` · `lint` · `test`(464) · `audit:oklch` · `validate:previews` · `validate:catalog` · `tokens:check` 전부 통과. `format:check` 로컬 실패 14건은 전부 `.claude/skills/docs-crawler/` CRLF 오탐(CLAUDE.md 기재)이며 이 PR 이 건드린 파일은 없다.
