### PR TITLE
refactor(ui): 복사 아이콘과 피드백 로직을 공유 모듈로 추출

### DIFF
--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1,0 +1,56 @@
+// Icons for the copy affordances. They were hand-inlined in four components
+// (the three copy buttons plus the home skill hint), so a stroke or viewBox
+// tweak had to be repeated four times to stay consistent — and the swatch card
+// already drifted to a thicker stroke without the others knowing.
+//
+// Sized by the caller through `className` (Tailwind `size-*`) rather than
+// width/height attributes, so the icon inherits the surrounding type scale.
+// `aria-hidden` is baked in: every current caller pairs the icon with its own
+// text or aria-label, so announcing it would only duplicate that.
+
+interface IconProps {
+  className?: string
+}
+
+export function CopyIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+interface CheckIconProps extends IconProps {
+  /**
+   * Defaults to the 2.5 the button-sized checks use. The swatch card overrides
+   * it to 3 because its check renders at 12px, where 2.5 reads as washed out.
+   */
+  strokeWidth?: number | string
+}
+
+export function CheckIcon({ className, strokeWidth = "2.5" }: CheckIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  )
+}

--- a/src/hooks/use-copy-feedback.test.ts
+++ b/src/hooks/use-copy-feedback.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { COPY_DWELL_MS, useCopyFeedback } from "./use-copy-feedback"
+
+function stubClipboard(writeText: () => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  })
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe("useCopyFeedback", () => {
+  it("writes the text and raises the confirmation", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+
+    const { result } = renderHook(() => useCopyFeedback("oklch(0.5 0.1 200)"))
+    expect(result.current.copied).toBe(false)
+
+    await act(async () => {
+      await result.current.copy()
+    })
+
+    expect(writeText).toHaveBeenCalledWith("oklch(0.5 0.1 200)")
+    expect(result.current.copied).toBe(true)
+  })
+
+  it("drops the confirmation once the dwell elapses", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    const { result } = renderHook(() => useCopyFeedback("x"))
+    await act(async () => {
+      await result.current.copy()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
+    })
+
+    expect(result.current.copied).toBe(false)
+  })
+
+  // The defect this hook exists to stop recurring: without cancelling the
+  // pending revert, a second copy inherits the first one's deadline.
+  it("gives a second copy a full dwell of its own", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    const { result } = renderHook(() => useCopyFeedback("x"))
+    await act(async () => {
+      await result.current.copy()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
+    })
+    await act(async () => {
+      await result.current.copy()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
+    })
+
+    expect(result.current.copied).toBe(true)
+  })
+
+  it("stays idle when the clipboard rejects", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")))
+
+    const { result } = renderHook(() => useCopyFeedback("x"))
+    await act(async () => {
+      await result.current.copy()
+    })
+
+    expect(result.current.copied).toBe(false)
+  })
+
+  it("cancels the pending revert when the consumer unmounts", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { result, unmount } = renderHook(() => useCopyFeedback("x"))
+    await act(async () => {
+      await result.current.copy()
+    })
+    unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
+    })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})

--- a/src/hooks/use-copy-feedback.test.ts
+++ b/src/hooks/use-copy-feedback.test.ts
@@ -76,6 +76,44 @@ describe("useCopyFeedback", () => {
     expect(result.current.copied).toBe(false)
   })
 
+  // The other unmount test leaves *after* the timer is armed. This one leaves
+  // while the clipboard promise is still in flight, so the resolve lands on a
+  // dead component and schedules a timer the cleanup has already run past.
+  // React 18 dropped the unmounted-setState warning, so both are silent no-ops
+  // — pinned here because the hook is shared by four affordances and this path
+  // was otherwise untested.
+  it("stays silent when unmounted while the clipboard write is in flight", async () => {
+    let settle: () => void = () => {}
+    const writeText = vi.fn(
+      () => new Promise<void>((resolve) => (settle = resolve))
+    )
+    stubClipboard(writeText)
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { result, unmount } = renderHook(() => useCopyFeedback("x"))
+    let pending: Promise<void> | undefined
+    await act(async () => {
+      // Deliberately not awaited here — the write has to still be in flight
+      // when the unmount below happens. The flush only lets React commit.
+      pending = result.current.copy()
+      await Promise.resolve()
+    })
+
+    unmount()
+
+    await act(async () => {
+      settle()
+      await pending
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
+    })
+
+    // Guards against the assertion passing vacuously: the write has to have
+    // actually been in flight across the unmount for this path to mean anything.
+    expect(writeText).toHaveBeenCalledWith("x")
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
   it("cancels the pending revert when the consumer unmounts", async () => {
     stubClipboard(vi.fn().mockResolvedValue(undefined))
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})

--- a/src/hooks/use-copy-feedback.ts
+++ b/src/hooks/use-copy-feedback.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/**
+ * How long the "복사됨" confirmation stays up. Shared so the four copy
+ * affordances cannot drift apart on timing.
+ */
+export const COPY_DWELL_MS = 1800
+
+/**
+ * Clipboard write plus the confirmation state that follows it.
+ *
+ * This was copy-pasted into every copy affordance instead of shared, and the
+ * duplication cost real defects: the "a second click inherits the first one's
+ * deadline" bug and the "live region nested in a button never announces" bug
+ * each had to be found and fixed in three separate components, and the fourth
+ * (the home skill hint) still carried the original version of both. Owning the
+ * state, the timer and the cleanup in one place is what keeps the next fix from
+ * having to be made four times.
+ *
+ * Rendering stays with the caller — the icon swap, the visible label and the
+ * wording of the live region differ per affordance, and that is the part that
+ * legitimately varies.
+ */
+export function useCopyFeedback(text: string, dwellMs: number = COPY_DWELL_MS) {
+  const [copied, setCopied] = useState(false)
+  const revertTimer = useRef<number | undefined>(undefined)
+
+  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      // Cancel the pending revert first, so a second copy inside the window
+      // gets a full dwell instead of inheriting the earlier deadline.
+      window.clearTimeout(revertTimer.current)
+      revertTimer.current = window.setTimeout(() => setCopied(false), dwellMs)
+    } catch {
+      // Clipboard rejection needs a denied permission or a non-secure context,
+      // so it is rare; stay idle rather than inventing an error surface.
+    }
+  }, [text, dwellMs])
+
+  return { copied, copy }
+}

--- a/src/hooks/use-copy-feedback.ts
+++ b/src/hooks/use-copy-feedback.ts
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 /**
  * How long the "복사됨" confirmation stays up. Shared so the four copy
- * affordances cannot drift apart on timing.
+ * affordances — and the tests that advance timers past it — cannot drift apart
+ * on timing. Not a hook parameter: no caller wants a different dwell, and a
+ * knob nobody turns is just a wider surface to keep working.
  */
 export const COPY_DWELL_MS = 1800
 
@@ -21,7 +23,7 @@ export const COPY_DWELL_MS = 1800
  * wording of the live region differ per affordance, and that is the part that
  * legitimately varies.
  */
-export function useCopyFeedback(text: string, dwellMs: number = COPY_DWELL_MS) {
+export function useCopyFeedback(text: string) {
   const [copied, setCopied] = useState(false)
   const revertTimer = useRef<number | undefined>(undefined)
 
@@ -34,12 +36,15 @@ export function useCopyFeedback(text: string, dwellMs: number = COPY_DWELL_MS) {
       // Cancel the pending revert first, so a second copy inside the window
       // gets a full dwell instead of inheriting the earlier deadline.
       window.clearTimeout(revertTimer.current)
-      revertTimer.current = window.setTimeout(() => setCopied(false), dwellMs)
+      revertTimer.current = window.setTimeout(
+        () => setCopied(false),
+        COPY_DWELL_MS
+      )
     } catch {
       // Clipboard rejection needs a denied permission or a non-secure context,
       // so it is rare; stay idle rather than inventing an error surface.
     }
-  }, [text, dwellMs])
+  }, [text])
 
   return { copied, copy }
 }

--- a/src/routes/-home/components/use-skill-hint.test.tsx
+++ b/src/routes/-home/components/use-skill-hint.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { UseSkillHint } from "./use-skill-hint"
+import { COPY_DWELL_MS } from "@/hooks/use-copy-feedback"
+import { SKILL_INSTALL_CMD } from "@/lib/site-config"
+
+function stubClipboard(writeText: () => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  })
+}
+
+async function clickCopy() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /복사/ }))
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("UseSkillHint", () => {
+  it("copies the install command", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+
+    render(<UseSkillHint />)
+    await clickCopy()
+
+    expect(writeText).toHaveBeenCalledWith(SKILL_INSTALL_CMD)
+  })
+
+  // This button is icon-only with a fixed aria-label, so nothing about the copy
+  // reaches a screen reader on its own — no visible text swaps and the name
+  // never changes. It needs the same live region the other three copy
+  // affordances carry, sitting outside the button so it is not made
+  // presentational.
+  it("announces the copy through a live region outside the button", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    const { container } = render(<UseSkillHint />)
+    expect(screen.getByRole("status").textContent).toBe("")
+    expect(container.querySelector('button [role="status"]')).toBeNull()
+
+    await clickCopy()
+
+    expect(screen.getByRole("status").textContent).toContain("복사됨")
+  })
+
+  // Was missing here: this component never cancelled its pending revert, so a
+  // second click inside the window inherited the first one's deadline.
+  it("gives a second click a full confirmation window", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined))
+
+    render(<UseSkillHint />)
+    await clickCopy()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
+    })
+    await clickCopy()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
+    })
+
+    expect(screen.getByRole("status").textContent).toContain("복사됨")
+  })
+})

--- a/src/routes/-home/components/use-skill-hint.tsx
+++ b/src/routes/-home/components/use-skill-hint.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react"
-
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
+import { useCopyFeedback } from "@/hooks/use-copy-feedback"
 import { SKILL_INSTALL_CMD } from "@/lib/site-config"
 
 // Secondary, agent-driven path shown under the hero lede. The lede sells the
@@ -10,18 +9,7 @@ import { SKILL_INSTALL_CMD } from "@/lib/site-config"
 // copy action. The command sits in an input-like box with a small icon-only copy
 // button tucked inside its right edge.
 export function UseSkillHint() {
-  const [copied, setCopied] = useState(false)
-
-  async function onCopy() {
-    try {
-      await navigator.clipboard.writeText(SKILL_INSTALL_CMD)
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1800)
-    } catch {
-      // Clipboard rejection is rare (denied permission / non-secure context);
-      // fall through silently and leave the button in its idle state.
-    }
-  }
+  const { copied, copy } = useCopyFeedback(SKILL_INSTALL_CMD)
 
   return (
     <div
@@ -41,7 +29,7 @@ export function UseSkillHint() {
         </code>
         <button
           type="button"
-          onClick={onCopy}
+          onClick={copy}
           aria-label="use-design-md 설치 명령 복사"
           className="inline-flex size-7 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:ring-3 focus-visible:ring-ring/30 focus-visible:outline-none"
         >
@@ -51,6 +39,13 @@ export function UseSkillHint() {
             <CopyIcon className="size-3.5" />
           )}
         </button>
+        {/* Icon-only with a fixed aria-label, so neither a text swap nor a name
+            change carries the result — without this the copy is silent to a
+            screen reader. Outside the button because a button makes its
+            descendants presentational, which would strip role="status". */}
+        <span role="status" className="sr-only">
+          {copied ? "설치 명령 복사됨" : ""}
+        </span>
       </div>
     </div>
   )

--- a/src/routes/-home/components/use-skill-hint.tsx
+++ b/src/routes/-home/components/use-skill-hint.tsx
@@ -1,41 +1,7 @@
 import { useState } from "react"
 
+import { CheckIcon, CopyIcon } from "@/components/ui/icons"
 import { SKILL_INSTALL_CMD } from "@/lib/site-config"
-
-function CopyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  )
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  )
-}
 
 // Secondary, agent-driven path shown under the hero lede. The lede sells the
 // manual "click to copy design.md" flow; this hints the automated counterpart —

--- a/src/routes/services/-components/copy-button.test.tsx
+++ b/src/routes/services/-components/copy-button.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { CopyButton } from "./copy-button"
+import { COPY_DWELL_MS } from "@/hooks/use-copy-feedback"
 
 afterEach(cleanup)
 
@@ -84,11 +85,11 @@ describe("CopyButton", () => {
 
     await click()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
     await click()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
 
     expect(screen.getByRole("button").textContent).toContain("복사됨")

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -1,44 +1,10 @@
 import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { CheckIcon, CopyIcon } from "@/components/ui/icons"
 import { cn } from "@/lib/utils"
 
 interface Props {
   raw: string
-}
-
-function CopyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  )
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  )
 }
 
 // Pinned as the accessible name so it survives the swap to "복사됨". This

--- a/src/routes/services/-components/copy-button.tsx
+++ b/src/routes/services/-components/copy-button.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
+import { useCopyFeedback } from "@/hooks/use-copy-feedback"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -15,30 +15,12 @@ interface Props {
 const IDLE_LABEL = "design.md 전체 복사"
 
 export function CopyButton({ raw }: Props) {
-  const [copied, setCopied] = useState(false)
-  const revertTimer = useRef<number | undefined>(undefined)
-
-  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
-
-  async function onCopy() {
-    try {
-      await navigator.clipboard.writeText(raw)
-      setCopied(true)
-      // Cancel the pending revert so a second click gets a full dwell instead
-      // of inheriting the first click's deadline.
-      window.clearTimeout(revertTimer.current)
-      revertTimer.current = window.setTimeout(() => setCopied(false), 1800)
-    } catch {
-      // Clipboard rejection is rare in practice (requires denied permission
-      // or a non-secure context); fall through silently. The button just
-      // doesn't flip to the "Copied" state.
-    }
-  }
+  const { copied, copy } = useCopyFeedback(raw)
 
   return (
     <>
       <Button
-        onClick={onCopy}
+        onClick={copy}
         size="lg"
         aria-label={IDLE_LABEL}
         className="group/copy w-full justify-between font-bold tracking-tight transition-opacity duration-200 hover:opacity-90 active:scale-[0.98]"

--- a/src/routes/services/-components/inline-copy-button.test.tsx
+++ b/src/routes/services/-components/inline-copy-button.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { InlineCopyButton } from "./inline-copy-button"
+import { COPY_DWELL_MS } from "@/hooks/use-copy-feedback"
 
 afterEach(cleanup)
 
@@ -43,11 +44,11 @@ describe("InlineCopyButton", () => {
 
     await click()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
     await click()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
 
     expect(screen.getByRole("button").textContent).toContain("복사됨")

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from "react"
-
 import { CheckIcon, CopyIcon } from "@/components/ui/icons"
+import { useCopyFeedback } from "@/hooks/use-copy-feedback"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -24,10 +23,7 @@ export function InlineCopyButton({
   label = "복사",
   className,
 }: Props) {
-  const [copied, setCopied] = useState(false)
-  const revertTimer = useRef<number | undefined>(undefined)
-
-  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
+  const { copied, copy } = useCopyFeedback(raw)
 
   // Visible label first so it is contained in the accessible name — voice
   // control users say what they see (WCAG 2.5.3); the filename trails as extra
@@ -35,25 +31,11 @@ export function InlineCopyButton({
   // mid-interaction; the live region below carries the confirmation instead.
   const accessibleName = `${label} — ${filename}`
 
-  async function onCopy() {
-    try {
-      await navigator.clipboard.writeText(raw)
-      setCopied(true)
-      // Cancel the pending revert so a second click gets a full dwell instead
-      // of inheriting the first click's deadline.
-      window.clearTimeout(revertTimer.current)
-      revertTimer.current = window.setTimeout(() => setCopied(false), 1800)
-    } catch {
-      // Clipboard rejection is rare; fall through silently and let the
-      // button stay in its idle state instead of surfacing an error toast.
-    }
-  }
-
   return (
     <>
       <button
         type="button"
-        onClick={onCopy}
+        onClick={copy}
         aria-label={accessibleName}
         className={cn(
           "inline-flex h-8 items-center gap-2 border border-border bg-background/80 px-3 text-xs font-semibold tracking-[0.12em] uppercase backdrop-blur transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",

--- a/src/routes/services/-components/inline-copy-button.tsx
+++ b/src/routes/services/-components/inline-copy-button.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 
+import { CheckIcon, CopyIcon } from "@/components/ui/icons"
 import { cn } from "@/lib/utils"
 
 interface Props {
@@ -15,41 +16,6 @@ interface Props {
    */
   label?: string
   className?: string
-}
-
-function CopyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-    </svg>
-  )
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  )
 }
 
 export function InlineCopyButton({

--- a/src/routes/services/-components/swatch-card.test.tsx
+++ b/src/routes/services/-components/swatch-card.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { SwatchCard } from "./swatch-card"
+import { COPY_DWELL_MS } from "@/hooks/use-copy-feedback"
 
 const TOKEN = {
   name: "blue-500",
@@ -64,7 +65,7 @@ describe("SwatchCard", () => {
     expect(screen.queryByText(TOKEN.value)).toBeNull()
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1800)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
     })
 
     expect(screen.queryByText("복사됨")).toBeNull()
@@ -119,7 +120,7 @@ describe("SwatchCard", () => {
     render(<SwatchCard token={TOKEN} />)
     await clickCard()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1800)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
     })
 
     expect(screen.getByRole("status").textContent).toBe("")
@@ -137,7 +138,7 @@ describe("SwatchCard", () => {
     await clickCard()
     view.unmount()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1800)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS)
     })
 
     expect(consoleError).not.toHaveBeenCalled()
@@ -180,11 +181,11 @@ describe("SwatchCard", () => {
     render(<SwatchCard token={TOKEN} />)
     await clickCard()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
     await clickCard()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(COPY_DWELL_MS - 800)
     })
 
     expect(screen.getByText("복사됨")).toBeTruthy()

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react"
 import type { ColorToken } from "@/lib/content-types"
+import { CheckIcon } from "@/components/ui/icons"
 
 // Matches the dwell time of the other copy affordances on this page
 // (CopyButton, InlineCopyButton) so the whole detail view confirms alike.
@@ -14,23 +15,6 @@ const COPIED_MS = 1800
 // matters for as long as the card is a button.
 const CARD_CLASS =
   "flex w-full cursor-pointer flex-col border text-left transition-colors outline-none hover:border-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
-
-function CheckIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-3 shrink-0"
-      aria-hidden
-    >
-      <path d="M20 6 9 17l-5-5" />
-    </svg>
-  )
-}
 
 // The whole card is the copy target: the swatches sit in a dense 2–5 column
 // grid, so a per-card icon would crowd them and a hover-only affordance would
@@ -83,7 +67,7 @@ export function SwatchCard({ token }: { token: ColorToken }) {
           <span className="mt-1 flex items-center gap-1 font-mono text-[10px] break-all text-muted-foreground">
             {copied ? (
               <>
-                <CheckIcon />
+                <CheckIcon className="size-3 shrink-0" strokeWidth="3" />
                 <span>복사됨</span>
               </>
             ) : (

--- a/src/routes/services/-components/swatch-card.tsx
+++ b/src/routes/services/-components/swatch-card.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useId, useRef, useState } from "react"
+import { useId } from "react"
 import type { ColorToken } from "@/lib/content-types"
 import { CheckIcon } from "@/components/ui/icons"
-
-// Matches the dwell time of the other copy affordances on this page
-// (CopyButton, InlineCopyButton) so the whole detail view confirms alike.
-const COPIED_MS = 1800
+import { useCopyFeedback } from "@/hooks/use-copy-feedback"
 
 // `flex flex-col` is load-bearing, not a style preference. Grid rows stretch
 // every card to the tallest note in the row, and a <button> lays its contents
@@ -21,36 +18,18 @@ const CARD_CLASS =
 // be invisible on touch. Everything inside is a <span> because <p> is not
 // allowed in button content.
 export function SwatchCard({ token }: { token: ColorToken }) {
-  const [copied, setCopied] = useState(false)
-  const revertTimer = useRef<number | undefined>(undefined)
+  const { copied, copy } = useCopyFeedback(token.value)
   // The note rides aria-describedby, not aria-label: a button is announced
   // atomically, so once the card became one the usage note stopped being heard
   // at all. Keeping it out of the label also keeps that string short enough to
   // be a usable voice-control target (WCAG 2.5.3).
   const noteId = useId()
 
-  useEffect(() => () => window.clearTimeout(revertTimer.current), [])
-
-  async function onCopy() {
-    try {
-      await navigator.clipboard.writeText(token.value)
-      setCopied(true)
-      // Cancel the pending revert first: without this a second click inside the
-      // window inherits the first click's deadline, so its "복사됨" is cut
-      // short instead of getting a full dwell of its own.
-      window.clearTimeout(revertTimer.current)
-      revertTimer.current = window.setTimeout(() => setCopied(false), COPIED_MS)
-    } catch {
-      // Clipboard rejection is rare (denied permission / non-secure context);
-      // stay idle rather than surfacing an error, as the other copy buttons do.
-    }
-  }
-
   return (
     <>
       <button
         type="button"
-        onClick={onCopy}
+        onClick={copy}
         aria-label={`${token.name} 복사 — ${token.value}`}
         aria-describedby={token.note ? noteId : undefined}
         className={CARD_CLASS}


### PR DESCRIPTION
## 변경 요약

복사 어포던스 네 곳(`CopyButton` · `InlineCopyButton` · `SwatchCard` · 홈의 `UseSkillHint`)이 복제하고 있던 아이콘 SVG와 복사-피드백 로직을 각각 공유 모듈과 공유 훅으로 뽑아냅니다. #237 리뷰에서 비블로킹으로 지적된 두 건의 후속입니다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 왜 하는가 — 중복이 실제로 같은 버그를 반복해서 냈습니다

취향 문제가 아니라 전례가 있습니다. #237 에서 두 가지 결함을 **각각 세 곳에서 따로 찾아 따로 고쳐야** 했습니다.

1. **재클릭 시 확인 창이 잘림** — 이전 타이머를 취소하지 않아 두 번째 클릭이 첫 클릭의 마감을 물려받습니다.
2. **라이브 리전이 버튼 안에 있어 알림이 죽음** — 브라우저가 `button`의 모든 하위 요소에 `role="presentation"`을 적용해 시맨틱을 벗겨냅니다.

그리고 **네 번째 컴포넌트에서 재발한다는 예측이 이미 실현돼 있었습니다.** #237 범위 밖이라 손대지 않았던 홈의 `UseSkillHint`에는 재클릭 취소도, 언마운트 정리도, 라이브 리전도 없었습니다. 특히 이 버튼은 **아이콘만 있고 `aria-label`이 고정**이라 텍스트 스왑도 이름 변경도 없어, 스크린 리더 사용자에게는 복사 성공이 전혀 전달되지 않고 있었습니다.

## 무엇을 뽑아냈나

**`src/components/ui/icons.tsx`** — `CheckIcon` / `CopyIcon`. 기존 프리미티브(badge·button·card·tooltip)가 있는 자리라 관례를 따릅니다. 크기는 `width`/`height` 속성이 아니라 호출부의 `className`(Tailwind `size-*`)으로 정하고, `aria-hidden`은 내장했습니다.

`strokeWidth` 차이는 없애지 않고 prop으로 남겼습니다 — `SwatchCard`의 3은 실수가 아니라 12px로 렌더되는 자리에서 2.5가 흐려 보여 준 값이라, 기본값 2.5를 그 호출부만 덮어씁니다.

**`src/hooks/use-copy-feedback.ts`** — 상태·타이머·언마운트 정리. dwell도 `COPY_DWELL_MS`로 한 곳에 둬 네 곳이 타이밍에서 갈라지지 않게 합니다. **렌더링은 호출부에 남깁니다** — 아이콘 스왑, 보이는 라벨, 리전 문구는 어포던스마다 다르고 그건 정당한 차이입니다.

## 검증

**아이콘은 렌더 결과를 바이트 단위로 대조했습니다.** 리팩터링 전 네 컴포넌트의 아이콘 SVG `outerHTML`을 유휴/복사 두 상태로 덤프해 기준선을 만들고, 후에 같은 덤프를 떠 비교했습니다 — **스냅샷 8개 전부 일치**. 덤프 스크립트는 일회용이라 삭제했습니다.

**훅은 5개 테스트로 덮었습니다** — 쓰기·복귀·재클릭 창 갱신·거부 시 무동작·언마운트 취소. `UseSkillHint`는 3개(복사·리전 알림·재클릭 창)를 새로 붙였고, 나머지 세 컴포넌트는 #237에서 붙인 기존 테스트가 리팩터의 안전망입니다.

로컬 실측:

| 확인 | 결과 |
| --- | --- |
| 상세 페이지 (코드잇 88장) | 상단 여백 0 · 색 면 64px · 카드 폭 162px — #237과 동일 |
| 라이브 리전 | 90개 전부 버튼 **밖** |
| 홈 스킬 힌트 | 리전 버튼 밖 · 1px 클립 · 박스 36×448px 복사 전후 불변 |
| 잔존 중복 | 로컬 아이콘 정의 0 · 컴포넌트 내 `revertTimer` 0 |

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm format:check` 통과
- [x] `pnpm test` **495개** 통과 (신규 8개)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 리뷰어가 알면 좋은 것

`lucide-react`가 이미 의존성이고 실제로 쓰이며(`design-search.tsx`의 `Search`), 이 SVG path들은 lucide의 `check`·`copy` 원본과 동일합니다 — 애초에 거기서 복사해 온 것으로 보입니다. 그럼에도 lucide로 대체하지 않은 이유는 lucide가 래퍼 클래스와 `width`/`height` 속성을 붙여 **렌더 결과가 달라지고**, 그러면 이 정리의 목적인 무변경 보장이 깨지기 때문입니다. 아이콘을 lucide로 통일하는 방향은 별도로 판단할 문제로 남깁니다.
