### PR TITLE
feat(drift): 슬러그별 별칭 맵으로 드리프트 대조 범위를 22 → 430 으로 (#240)

### DIFF
--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -7,7 +7,11 @@ import {
   matchDefinition,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
-import { findPreviewDrift, readDefinitions } from "../src/lib/oklch-drift"
+import {
+  alignToPreviewNames,
+  findPreviewDrift,
+  readDefinitions,
+} from "../src/lib/oklch-drift"
 import { ALPHA_TOLERANCE, DELTA_E_TOLERANCE } from "../src/lib/oklch-tolerance"
 import {
   deltaE,
@@ -344,8 +348,9 @@ for (const slug of slugs) {
     process.exitCode = 1
     continue
   }
-  const defs = readDefinitions(
-    fs.readFileSync(path.join(SERVICES, `${slug}.md`), "utf8")
+  const defs = alignToPreviewNames(
+    readDefinitions(fs.readFileSync(path.join(SERVICES, `${slug}.md`), "utf8")),
+    slug
   )
   const found = findPreviewDrift(fs.readFileSync(preview, "utf8"), defs)
   if (found.length === 0) continue

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -64,29 +64,21 @@ function slugs(): Array<string> {
 
 // The floor, not the exact number. Previews change for legitimate reasons and
 // the count moves with them; what must never happen is the total collapsing.
-// Measured 22 on 2026-08-06 (11st 19, class101 2, seed-design 1).
-const MATCH_FLOOR = 22
+// Measured 397 of 706 considered declarations on 2026-08-06, after the
+// per-slug prefix map landed (it was 22 before — see issue #240).
+const MATCH_FLOOR = 397
 
-// Slugs whose preview names cannot reach their md names today, with the reason.
+// Slugs whose preview names cannot reach their md names, with the reason.
 // Being listed here is not approval — it is the coverage gap written down where
 // the next person will see it. A slug LEAVING this list is an improvement and
 // does not fail; a slug JOINING it is a regression the total-floor check above
 // catches.
+//
+// The prefix map (#240) emptied this of everything that was a naming problem.
+// What is left is not one: bezier's preview has no oklch to compare, so no name
+// rule can reach it.
 const NO_MATCH_TODAY: Record<string, string> = {
-  baemin: "preview `--bm-*`, md bare",
   bezier: "preview declares no oklch at all — it is hex",
-  codeit: "preview `--ci-*`, md `codeit-*`",
-  gmarket: "preview semantic + `--gds-*`, md palette names",
-  greeting: "preview `--g-gray-0`, md `gray0` — prefix and hyphen both differ",
-  krds: "preview `--krds-*`, md bare",
-  kyobobook: "preview `--kds-*`, md bare",
-  "line-design-system": "preview `--ldsg-linegreen`, md `ldsg-color-linegreen`",
-  socar: "preview `--sf-*`, md bare",
-  teamsparta: "preview `--sp-red`, md `brand-red`",
-  toss: "preview `--tds-*`, md bare",
-  "vapor-ui": "preview `--vp-*`, md bare",
-  wanted: "preview `--w-*`, md bare",
-  yeogi: "preview `--yg-*`, md `yeogi-*`",
 }
 
 describe("oklch-drift — catalogue coverage", () => {
@@ -128,6 +120,33 @@ describe("oklch-drift — catalogue coverage", () => {
         `${slug}/light.html declares ${declared} oklch custom properties and the scanner considered none of them — the whole file is silently unchecked`
       ).toBeGreaterThan(0)
     }
+  })
+
+  // Raising coverage is only worth anything if the comparisons it adds are
+  // sound. `pnpm audit:oklch` is the shipping gate for this, but it is a
+  // separate CI step, and a finding there reads as "a preview drifted" — which
+  // is the wrong diagnosis when the fault is on the md side. Asserting it here
+  // too means a bad comparison fails next to the coverage numbers that caused
+  // it. This is what catches `wanted`: its md restates the same alias names
+  // under a Dark heading, so a light preview value gets compared against a dark
+  // md value and reports ten disagreements that do not exist.
+  it("finds no drift anywhere in the catalogue", () => {
+    const found: Array<string> = []
+    for (const slug of all) {
+      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const defs = readDefinitions(
+        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
+      )
+      for (const d of findPreviewDrift(html, defs)) {
+        found.push(
+          `${slug} --${d.name}: preview ${d.preview}, md ${d.expected}`
+        )
+      }
+    }
+    expect(
+      found,
+      `the drift gate reports ${found.length} disagreement(s). Before editing a preview, check whether the md side is at fault — a token restated under a dark-scoped heading is read as the light definition unless readDefinitions skips it:\n${found.join("\n")}`
+    ).toEqual([])
   })
 
   it("documents which slugs match no md token name, and why", () => {

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -2,15 +2,19 @@ import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
-import { findPreviewDrift, readDefinitions } from "./oklch-drift"
+import {
+  alignToPreviewNames,
+  findPreviewDrift,
+  readDefinitions,
+} from "./oklch-drift"
 
 // `oklch-drift.test.ts` proves the algorithm on synthetic strings. Nothing
-// proved it still reaches the catalogue — and it barely does. Measured over the
-// shipped previews, the gate compares 22 declarations out of the 650 it looks
-// at, and 14 of 17 slugs contribute nothing, because previews prefix their
-// custom properties (`--tds-blue-500`) while the md keys are bare (`blue-500`).
-// A regression in `readDefinitions` could take that 22 to 0 and every existing
-// test would stay green.
+// proved it still reaches the catalogue — and for a while it barely did: the
+// gate compared 22 declarations out of the 706 it looks at, and 14 of 17 slugs
+// contributed nothing, because previews namespace their custom properties
+// (`--tds-blue-500`) while the md keys are bare (`blue-500`). The per-slug
+// alias map (#240) took that to 430. A regression in `readDefinitions` or in
+// the map could take it back toward 0 and every other test would stay green.
 //
 // `scripts/audit-oklch.ts` already worries about this in prose: its drift loop
 // stops the run when a preview file is missing, because otherwise the loop
@@ -49,6 +53,14 @@ function matchedCount(html: string, defs: Map<string, string>): number {
   return findPreviewDrift(html, names).length
 }
 
+/** Exactly what `scripts/audit-oklch.ts` feeds the gate for this slug. */
+function definitionsFor(slug: string): Map<string, string> {
+  return alignToPreviewNames(
+    readDefinitions(readFileSync(join(SERVICES, `${slug}.md`), "utf8")),
+    slug
+  )
+}
+
 function slugs(): Array<string> {
   if (!existsSync(PREVIEW)) return []
   return readdirSync(PREVIEW, { withFileTypes: true })
@@ -64,9 +76,9 @@ function slugs(): Array<string> {
 
 // The floor, not the exact number. Previews change for legitimate reasons and
 // the count moves with them; what must never happen is the total collapsing.
-// Measured 397 of 706 considered declarations on 2026-08-06, after the
-// per-slug prefix map landed (it was 22 before — see issue #240).
-const MATCH_FLOOR = 397
+// Measured 430 of 706 considered declarations on 2026-08-06, after the
+// per-slug alias map landed (it was 22 before — see issue #240).
+const MATCH_FLOOR = 430
 
 // Slugs whose preview names cannot reach their md names, with the reason.
 // Being listed here is not approval — it is the coverage gap written down where
@@ -93,9 +105,7 @@ describe("oklch-drift — catalogue coverage", () => {
     const perSlug: Array<string> = []
     for (const slug of all) {
       const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
-      const defs = readDefinitions(
-        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
-      )
+      const defs = definitionsFor(slug)
       const n = matchedCount(html, defs)
       total += n
       if (n > 0) perSlug.push(`${slug} ${n}`)
@@ -134,9 +144,7 @@ describe("oklch-drift — catalogue coverage", () => {
     const found: Array<string> = []
     for (const slug of all) {
       const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
-      const defs = readDefinitions(
-        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
-      )
+      const defs = definitionsFor(slug)
       for (const d of findPreviewDrift(html, defs)) {
         found.push(
           `${slug} --${d.name}: preview ${d.preview}, md ${d.expected}`
@@ -153,9 +161,7 @@ describe("oklch-drift — catalogue coverage", () => {
     const measured: Array<string> = []
     for (const slug of all) {
       const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
-      const defs = readDefinitions(
-        readFileSync(join(SERVICES, `${slug}.md`), "utf8")
-      )
+      const defs = definitionsFor(slug)
       if (matchedCount(html, defs) === 0) measured.push(slug)
     }
     // Only one direction is a failure. A slug that starts matching has been

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -74,23 +74,39 @@ function slugs(): Array<string> {
     .sort()
 }
 
-// The floor, not the exact number. Previews change for legitimate reasons and
-// the count moves with them; what must never happen is the total collapsing.
-// Measured 430 of 706 considered declarations on 2026-08-06, after the
-// per-slug alias map landed (it was 22 before — see issue #240).
-const MATCH_FLOOR = 430
-
-// Slugs whose preview names cannot reach their md names, with the reason.
-// Being listed here is not approval — it is the coverage gap written down where
-// the next person will see it. A slug LEAVING this list is an improvement and
-// does not fail; a slug JOINING it is a regression the total-floor check above
-// catches.
+// Floors, not exact numbers — previews change for legitimate reasons and the
+// counts move with them. Measured 2026-08-06, totalling 430 of the 706
+// declarations the gate considers (it was 22 before the alias map, #240).
 //
-// The prefix map (#240) emptied this of everything that was a naming problem.
-// What is left is not one: bezier's preview has no oklch to compare, so no name
-// rule can reach it.
-const NO_MATCH_TODAY: Record<string, string> = {
-  bezier: "preview declares no oklch at all — it is hex",
+// Per-slug rather than one total, because a total hides the case this table
+// exists for: a new catalogue entry whose preview namespaces its custom
+// properties and has no rule in `PREVIEW_TOKEN_ALIASES`. It would contribute
+// few matches or none, and the total would still clear a global floor on the
+// strength of the other sixteen. Requiring every slug to appear here means the
+// number has to be looked at once, deliberately, per entry.
+//
+// A slug's count going UP is fine and does not fail — raise its floor when
+// convenient. Going down means something stopped matching.
+const MATCH_FLOOR: Partial<Record<string, number>> = {
+  "11st": 19,
+  baemin: 37,
+  // Not a naming problem and not fixable by one: bezier's preview declares no
+  // `oklch` at all — it is hex — so there is nothing for a name rule to reach.
+  bezier: 0,
+  class101: 14,
+  codeit: 8,
+  gmarket: 27,
+  greeting: 13,
+  krds: 33,
+  kyobobook: 41,
+  "line-design-system": 24,
+  "seed-design": 27,
+  socar: 40,
+  teamsparta: 18,
+  toss: 27,
+  "vapor-ui": 36,
+  wanted: 37,
+  yeogi: 29,
 }
 
 describe("oklch-drift — catalogue coverage", () => {
@@ -100,20 +116,31 @@ describe("oklch-drift — catalogue coverage", () => {
     expect(all.length).toBeGreaterThan(0)
   })
 
-  it("still compares at least as many declarations as it did when measured", () => {
-    let total = 0
-    const perSlug: Array<string> = []
+  it("accounts for every slug in the catalogue", () => {
+    // A new entry has to be added here on purpose. That is the point: an entry
+    // whose preview namespaces its custom properties needs a rule in
+    // `PREVIEW_TOKEN_ALIASES`, and this is where not having one becomes visible
+    // instead of being absorbed by the other sixteen slugs' totals.
+    const unaccounted = all.filter((s) => !(s in MATCH_FLOOR))
+    expect(
+      unaccounted,
+      `these slugs have no entry in MATCH_FLOOR: ${unaccounted.join(", ")}. Measure what the drift gate matches for each (the count is 0 unless PREVIEW_TOKEN_ALIASES in oklch-drift.ts has a rule for its preview's naming) and record it.`
+    ).toEqual([])
+  })
+
+  it("still compares at least as many declarations per slug as when measured", () => {
+    const regressed: Array<string> = []
     for (const slug of all) {
+      const floor = MATCH_FLOOR[slug]
+      if (floor === undefined) continue
       const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
-      const defs = definitionsFor(slug)
-      const n = matchedCount(html, defs)
-      total += n
-      if (n > 0) perSlug.push(`${slug} ${n}`)
+      const n = matchedCount(html, definitionsFor(slug))
+      if (n < floor) regressed.push(`${slug}: ${n} < ${floor}`)
     }
     expect(
-      total,
-      `the drift gate now compares ${total} declarations, below the ${MATCH_FLOOR} measured on 2026-08-06 (${perSlug.join(", ")}). Something stopped matching — check readDefinitions' regex and the scope rules in findPreviewDrift before lowering this floor.`
-    ).toBeGreaterThanOrEqual(MATCH_FLOOR)
+      regressed,
+      `the drift gate now compares fewer declarations than when measured — ${regressed.join(", ")}. Something stopped matching; check readDefinitions, PREVIEW_TOKEN_ALIASES, and the scope rules in findPreviewDrift before lowering a floor.`
+    ).toEqual([])
   })
 
   it("reads a nonzero number of declarations out of every preview that has them", () => {
@@ -157,20 +184,17 @@ describe("oklch-drift — catalogue coverage", () => {
     ).toEqual([])
   })
 
-  it("documents which slugs match no md token name, and why", () => {
-    const measured: Array<string> = []
-    for (const slug of all) {
-      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
-      const defs = definitionsFor(slug)
-      if (matchedCount(html, defs) === 0) measured.push(slug)
-    }
-    // Only one direction is a failure. A slug that starts matching has been
-    // fixed, so drop it from the map; a slug that stops matching is caught by
-    // the floor assertion, not here.
-    const unexplained = measured.filter((s) => !(s in NO_MATCH_TODAY))
+  it("checks something in every slug the gate can reach", () => {
+    // A floor of 0 says "this slug is not checked at all", which is a claim
+    // worth making explicit rather than letting it sit in a table of numbers.
+    // Only `bezier` is entitled to it — its preview has no `oklch` for any name
+    // rule to reach. Any other slug at 0 means the gate went quiet on it.
+    const unchecked = all.filter(
+      (s) => s !== "bezier" && (MATCH_FLOOR[s] ?? 0) === 0
+    )
     expect(
-      unexplained,
-      `these slugs now match no md token name and are not in NO_MATCH_TODAY — the drift gate is not checking them at all: ${unexplained.join(", ")}`
+      unchecked,
+      `these slugs are recorded as matching nothing: ${unchecked.join(", ")}. Only bezier is expected to, because its preview is hex rather than oklch. For anything else, add a rule to PREVIEW_TOKEN_ALIASES instead of recording a zero.`
     ).toEqual([])
   })
 })

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -7,6 +7,52 @@ gray-07: oklch(0.68 0 0)     # #999999
 brand:   oklch(0.62 0.24 27) # #FF0038
 `
 
+describe("readDefinitions", () => {
+  // A design.md may state the same semantic alias twice — once for light, once
+  // for dark. `wanted` does exactly that (`### Semantic alias — Light` and
+  // `— Dark` declaring the same keys). The gate compares the LIGHT preview, so
+  // the light value is the one it needs; taking the dark one reports a
+  // disagreement that does not exist.
+  //
+  // This mirrors what `findPreviewDrift` already does on the preview side,
+  // where `[data-theme="dark"]` blocks are skipped. Until now only one half of
+  // that symmetry existed.
+  const themed = `
+## Colors
+
+### Semantic alias — Light
+
+bg-canvas: oklch(1 0 0)
+
+### Semantic alias — Dark
+
+bg-canvas: oklch(0.148 0.004 277)
+`
+
+  it("keeps the light definition when a dark section restates it", () => {
+    expect(readDefinitions(themed).get("bg-canvas")).toBe("oklch(1 0 0)")
+  })
+
+  it("resumes reading after the dark section ends", () => {
+    const md = `${themed}
+## Typography
+
+brand: oklch(0.62 0.24 27)
+`
+    expect(readDefinitions(md).get("brand")).toBe("oklch(0.62 0.24 27)")
+  })
+
+  it("does not skip a section merely because a token name contains dark", () => {
+    // The heading is what scopes a block, not the tokens inside it.
+    const md = `
+### Semantic alias
+
+surface-darker: oklch(0.2 0 0)
+`
+    expect(readDefinitions(md).get("surface-darker")).toBe("oklch(0.2 0 0)")
+  })
+})
+
 describe("findPreviewDrift", () => {
   it("catches a preview value that drifted from its md definition", () => {
     // The shipped 11st defect: gray-06 holding gray-07's colour.

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -110,6 +110,27 @@ describe("alignToPreviewNames", () => {
     expect(out.has("ldsg-ldsg-color-linegreen")).toBe(false)
   })
 
+  it("drops an alias that two md names would fold onto with different values", () => {
+    // teamsparta's rules are `brand-` -> `sp-` then a `sp-` catch-all, so
+    // `brand-red` and a bare `red` both produce `sp-red`. Whichever came first
+    // in the md would win on declaration order alone and the gate would compare
+    // against a value chosen by nothing. The catalogue has no such collision
+    // today (measured: 0 across all 17 slugs), which is why this is a fixture.
+    const out = alignToPreviewNames(
+      defs({ "brand-red": "oklch(0.61 0.21 19)", red: "oklch(0.5 0.2 19)" }),
+      "teamsparta"
+    )
+    expect(out.has("sp-red")).toBe(false)
+  })
+
+  it("keeps the alias when both md names carry the same value", () => {
+    const out = alignToPreviewNames(
+      defs({ "brand-red": "oklch(0.61 0.21 19)", red: "oklch(0.61 0.21 19)" }),
+      "teamsparta"
+    )
+    expect(out.get("sp-red")).toBe("oklch(0.61 0.21 19)")
+  })
+
   it("returns a slug with no rules unchanged", () => {
     const input = defs({ "gray-06": "oklch(0.67 0 0)" })
     expect(alignToPreviewNames(input, "11st")).toBe(input)

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -131,6 +131,27 @@ describe("alignToPreviewNames", () => {
     expect(out.get("sp-red")).toBe("oklch(0.61 0.21 19)")
   })
 
+  it("does not double a namespace the md name already carries", () => {
+    // class101's only rule is a catch-all prepend, so an md name that already
+    // reads `c101-…` would gain `c101-c101-…` — a name no preview declares.
+    const out = alignToPreviewNames(
+      defs({ "c101-primary": "oklch(0.68 0.21 41)" }),
+      "class101"
+    )
+    expect(out.has("c101-c101-primary")).toBe(false)
+  })
+
+  it("still rewrites a name that starts with a replacement rule's target", () => {
+    // The guard above must not catch this: `ldsg-color-` -> `ldsg-` legitimately
+    // rewrites a name that already starts with `ldsg-`. Applying the guard to
+    // replacement rules as well would silently drop this slug's whole palette.
+    const out = alignToPreviewNames(
+      defs({ "ldsg-color-linegreen": "oklch(0.72 0.205 149)" }),
+      "line-design-system"
+    )
+    expect(out.get("ldsg-linegreen")).toBe("oklch(0.72 0.205 149)")
+  })
+
   it("adds nothing for a slug with no rules", () => {
     const input = defs({ "gray-06": "oklch(0.67 0 0)" })
     expect([...alignToPreviewNames(input, "11st")]).toEqual([...input])

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -131,9 +131,19 @@ describe("alignToPreviewNames", () => {
     expect(out.get("sp-red")).toBe("oklch(0.61 0.21 19)")
   })
 
-  it("returns a slug with no rules unchanged", () => {
+  it("adds nothing for a slug with no rules", () => {
     const input = defs({ "gray-06": "oklch(0.67 0 0)" })
-    expect(alignToPreviewNames(input, "11st")).toBe(input)
+    expect([...alignToPreviewNames(input, "11st")]).toEqual([...input])
+  })
+
+  it("never hands back the caller's own map", () => {
+    // The contract has to be the same for every slug. Returning the input for
+    // the no-rules case and a copy otherwise means a caller that mutates the
+    // result corrupts `readDefinitions` output for half the catalogue and not
+    // the other half — a bug that would reproduce per slug.
+    const input = defs({ "gray-06": "oklch(0.67 0 0)" })
+    expect(alignToPreviewNames(input, "11st")).not.toBe(input)
+    expect(alignToPreviewNames(input, "toss")).not.toBe(input)
   })
 })
 

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { findPreviewDrift, readDefinitions } from "./oklch-drift"
+import {
+  alignToPreviewNames,
+  findPreviewDrift,
+  readDefinitions,
+} from "./oklch-drift"
 
 const md = `
 gray-06: oklch(0.67 0 0)     # #949494
@@ -52,6 +56,63 @@ fg-on-brand: oklch(1.000 0 0)
 dark-gray-00: oklch(0.2 0 0)
 `
     expect(readDefinitions(doc).get("dark-gray-00")).toBe("oklch(0.2 0 0)")
+  })
+})
+
+describe("alignToPreviewNames", () => {
+  const defs = (entries: Record<string, string>): Map<string, string> =>
+    new Map(Object.entries(entries))
+
+  it("adds the definition under the name the preview uses", () => {
+    const out = alignToPreviewNames(
+      defs({ "blue-500": "oklch(0.62 0.19 258)" }),
+      "toss"
+    )
+    expect(out.get("tds-blue-500")).toBe("oklch(0.62 0.19 258)")
+  })
+
+  it("keeps the original name too, so an unprefixed preview still matches", () => {
+    const out = alignToPreviewNames(
+      defs({ "blue-500": "oklch(0.62 0.19 258)" }),
+      "toss"
+    )
+    expect(out.get("blue-500")).toBe("oklch(0.62 0.19 258)")
+  })
+
+  it("never overwrites a name the md already defines", () => {
+    // class101's preview declares BOTH `--primary` and `--c101-primary`, so the
+    // alias for `primary` collides with a real md token. The md definition is
+    // the authority; letting the alias win would report the wrong expected
+    // value for whichever token loses. They agree in the catalogue today, which
+    // is exactly why this needs a fixture rather than a corpus assertion.
+    const out = alignToPreviewNames(
+      defs({
+        primary: "oklch(0.68 0.21 41)",
+        "c101-primary": "oklch(0.5 0 0)",
+      }),
+      "class101"
+    )
+    expect(out.get("c101-primary")).toBe("oklch(0.5 0 0)")
+  })
+
+  it("applies the first matching rule and stops", () => {
+    // line-design-system needs two: the `ldsg-color-` family loses that infix,
+    // everything else just gains the namespace.
+    const out = alignToPreviewNames(
+      defs({
+        "ldsg-color-linegreen": "oklch(0.72 0.205 149)",
+        radius: "oklch(0 0 0)",
+      }),
+      "line-design-system"
+    )
+    expect(out.get("ldsg-linegreen")).toBe("oklch(0.72 0.205 149)")
+    expect(out.get("ldsg-radius")).toBe("oklch(0 0 0)")
+    expect(out.has("ldsg-ldsg-color-linegreen")).toBe(false)
+  })
+
+  it("returns a slug with no rules unchanged", () => {
+    const input = defs({ "gray-06": "oklch(0.67 0 0)" })
+    expect(alignToPreviewNames(input, "11st")).toBe(input)
   })
 })
 

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -8,18 +8,12 @@ brand:   oklch(0.62 0.24 27) # #FF0038
 `
 
 describe("readDefinitions", () => {
-  // A design.md may state the same semantic alias twice — once for light, once
-  // for dark. `wanted` does exactly that (`### Semantic alias — Light` and
-  // `— Dark` declaring the same keys). The gate compares the LIGHT preview, so
-  // the light value is the one it needs; taking the dark one reports a
-  // disagreement that does not exist.
-  //
-  // This mirrors what `findPreviewDrift` already does on the preview side,
-  // where `[data-theme="dark"]` blocks are skipped. Until now only one half of
-  // that symmetry existed.
+  // A design.md may restate the same semantic alias per theme — `wanted` does,
+  // under `### Semantic alias — Light` and `— Dark`. With no theme context to
+  // choose with, the old last-wins behaviour handed the gate the DARK value
+  // while it compares a LIGHT preview, and every such token reported a
+  // disagreement that did not exist.
   const themed = `
-## Colors
-
 ### Semantic alias — Light
 
 bg-canvas: oklch(1 0 0)
@@ -29,27 +23,35 @@ bg-canvas: oklch(1 0 0)
 bg-canvas: oklch(0.148 0.004 277)
 `
 
-  it("keeps the light definition when a dark section restates it", () => {
-    expect(readDefinitions(themed).get("bg-canvas")).toBe("oklch(1 0 0)")
+  it("drops a name stated twice with different values", () => {
+    expect(readDefinitions(themed).has("bg-canvas")).toBe(false)
   })
 
-  it("resumes reading after the dark section ends", () => {
-    const md = `${themed}
-## Typography
-
+  it("keeps the other definitions in a file that has a conflict", () => {
+    const doc = `${themed}
 brand: oklch(0.62 0.24 27)
 `
-    expect(readDefinitions(md).get("brand")).toBe("oklch(0.62 0.24 27)")
+    expect(readDefinitions(doc).get("brand")).toBe("oklch(0.62 0.24 27)")
   })
 
-  it("does not skip a section merely because a token name contains dark", () => {
-    // The heading is what scopes a block, not the tokens inside it.
-    const md = `
-### Semantic alias
-
-surface-darker: oklch(0.2 0 0)
+  it("keeps a name restated with the SAME value", () => {
+    // Repetition is not ambiguity. `wanted` restates `fg-on-brand` as
+    // `oklch(1 0 0)` in both theme blocks, and that value is still checkable.
+    const doc = `
+fg-on-brand: oklch(1 0 0)
+fg-on-brand: oklch(1.000 0 0)
 `
-    expect(readDefinitions(md).get("surface-darker")).toBe("oklch(0.2 0 0)")
+    expect(readDefinitions(doc).get("fg-on-brand")).toBe("oklch(1 0 0)")
+  })
+
+  it("does not care what a token name contains", () => {
+    // The rule is about conflicting definitions, not about the word "dark"
+    // appearing anywhere — `codeit` has 78 uniquely-named `dark-gray-*` tokens
+    // that must stay checkable.
+    const doc = `
+dark-gray-00: oklch(0.2 0 0)
+`
+    expect(readDefinitions(doc).get("dark-gray-00")).toBe("oklch(0.2 0 0)")
   })
 })
 

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -185,6 +185,12 @@ export function alignToPreviewNames(
   for (const [name, value] of definitions) {
     for (const [from, to] of rules) {
       if (from !== "" && !name.startsWith(from)) continue
+      // A catch-all prepend must not double a namespace the md name already
+      // carries — `c101-primary` would otherwise gain `c101-c101-primary`, a
+      // name no preview declares. Restricted to `from === ""` on purpose: a
+      // replacement rule legitimately rewrites names that already start with
+      // its target, which is exactly what `ldsg-color-` -> `ldsg-` does.
+      if (from === "" && name.startsWith(to)) break
       const alias = to + name.slice(from.length)
       // An md name outranks any alias, always.
       if (definitions.has(alias)) break

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -50,12 +50,42 @@ function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, (m) => m.replace(/[^\n]/g, " "))
 }
 
-/** `name: oklch(…)` definitions in a design.md, normalised for comparison. */
+/**
+ * `name: oklch(…)` definitions in a design.md, normalised for comparison.
+ *
+ * A name stated twice with DIFFERENT values is dropped, not resolved. A design.md
+ * may restate the same semantic alias per theme — `services/wanted.md` declares
+ * `bg-canvas` under both `### Semantic alias — Light` and `— Dark` — and this
+ * function has no theme context to choose with. It used to keep whichever came
+ * last, so the map held the dark value while the gate compares a LIGHT preview,
+ * and every such token reported a disagreement that did not exist (measured: 10
+ * on `wanted`, all spurious). Not comparing is the honest answer; guessing is
+ * how the gate ends up accusing a correct preview.
+ *
+ * Note the asymmetry this closes. `findPreviewDrift` tracks brace depth to skip
+ * `[data-theme="dark"]` blocks on the preview side; nothing did the equivalent
+ * on the md side. The prefix map is what made it observable — at 22 matched
+ * declarations none of these names were reached.
+ *
+ * Scoping by markdown heading was measured and rejected: keying on a heading
+ * whose text mentions dark also swallows `services/codeit.md`'s
+ * `### 프리미티브 스케일 — 다크 테마`, dropping 78 uniquely-named `dark-gray-*`
+ * definitions that conflict with nothing. It also needs fence-aware heading
+ * detection, because a `# Neutral dark` comment inside a yaml fence
+ * (`services/yeogi.md:156`) is not a heading. Dropping conflicts costs 22
+ * comparisons on one slug and needs neither.
+ */
 export function readDefinitions(markdown: string): Map<string, string> {
   const out = new Map<string, string>()
+  const conflicting = new Set<string>()
   for (const m of markdown.matchAll(/^([a-z][\w-]*):\s+(oklch\([^)]*\))/gm)) {
-    out.set(m[1], normalise(m[2]))
+    const value = normalise(m[2])
+    const prior = out.get(m[1])
+    // Restating the same value is harmless — only disagreement is ambiguous.
+    if (prior === undefined) out.set(m[1], value)
+    else if (prior !== value) conflicting.add(m[1])
   }
+  for (const name of conflicting) out.delete(name)
   return out
 }
 

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -90,6 +90,97 @@ export function readDefinitions(markdown: string): Map<string, string> {
 }
 
 /**
+ * How each slug's preview renames its md tokens, as leading-substring rewrites
+ * applied to the MD name to produce the preview's name.
+ *
+ * Previews namespace their custom properties (`--tds-blue-500`) while md keys
+ * are bare (`blue-500`), so exact-name matching reached 22 of 706 declarations
+ * and 14 of 17 slugs were unchecked entirely (issue #240). Suffix matching is
+ * not the answer — it pairs `--c101-on-primary` with `primary`, which is why
+ * `findPreviewDrift` refuses it. A declared, per-slug rewrite is.
+ *
+ * Rules are tried in order and the first whose `from` matches wins; an empty
+ * `from` matches anything, so it belongs last as the catch-all. Two rules are
+ * needed where a slug renames one family differently from the rest — md
+ * `ldsg-color-linegreen` is `--ldsg-linegreen`, and `gray0` is `--g-gray-0`,
+ * neither of which a single prefix reaches.
+ *
+ * This lives here rather than in md frontmatter deliberately. `KNOWN_FRONTMATTER_KEYS`
+ * is a published surface — it ships verbatim in llms.txt and the site reads it —
+ * and how this repo's preview CSS names its variables is not a property of the
+ * design system being documented. A new catalogue entry missing from this table
+ * is caught by `oklch-drift-corpus.test.ts`, not by a silent zero.
+ */
+// `Partial` so indexing a slug that has no entry types as `undefined` — most
+// of the catalogue needs no rewrite and the lookup below must say so.
+const PREVIEW_TOKEN_ALIASES: Partial<
+  Record<string, ReadonlyArray<readonly [string, string]>>
+> = {
+  baemin: [["", "bm-"]],
+  class101: [["", "c101-"]],
+  codeit: [
+    ["codeit-", "ci-"],
+    ["", "ci-"],
+  ],
+  gmarket: [["", "gds-"]],
+  greeting: [
+    ["gray", "g-gray-"],
+    ["", "g-"],
+  ],
+  krds: [["", "krds-"]],
+  kyobobook: [["", "kds-"]],
+  "line-design-system": [
+    ["ldsg-color-", "ldsg-"],
+    ["", "ldsg-"],
+  ],
+  "seed-design": [["", "seed-"]],
+  socar: [["", "sf-"]],
+  teamsparta: [
+    ["brand-", "sp-"],
+    ["", "sp-"],
+  ],
+  toss: [["", "tds-"]],
+  "vapor-ui": [["", "vp-"]],
+  wanted: [["", "w-"]],
+  yeogi: [
+    ["yeogi-", "yg-"],
+    ["", "yg-"],
+  ],
+}
+
+/**
+ * Add each definition under the name that `slug`'s preview uses for it.
+ *
+ * Aliases are ADDED, never substituted, and never overwrite a name the md
+ * already defines. `class101` declares both `--primary` and `--c101-primary`
+ * in its preview and both would fold onto md `primary`; keeping the exact name
+ * authoritative means the alias can only ever fill a gap. The two agree today,
+ * so nothing changes — this is what stops one of the two reports becoming
+ * meaningless on the day they diverge.
+ *
+ * A slug with no entry is returned unchanged, which is correct for `11st`
+ * (preview and md already agree) and unavoidable for `bezier` (its preview
+ * declares no `oklch` at all — hex — so no naming rule can reach it).
+ */
+export function alignToPreviewNames(
+  definitions: Map<string, string>,
+  slug: string
+): Map<string, string> {
+  const rules = PREVIEW_TOKEN_ALIASES[slug]
+  if (rules === undefined) return definitions
+  const out = new Map(definitions)
+  for (const [name, value] of definitions) {
+    for (const [from, to] of rules) {
+      if (from !== "" && !name.startsWith(from)) continue
+      const alias = to + name.slice(from.length)
+      if (!out.has(alias)) out.set(alias, value)
+      break
+    }
+  }
+  return out
+}
+
+/**
  * Compare a LIGHT preview's custom properties against the md definitions.
  *
  * Deliberately narrow, because a loose comparison is unusable: matching token

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -169,14 +169,30 @@ export function alignToPreviewNames(
   const rules = PREVIEW_TOKEN_ALIASES[slug]
   if (rules === undefined) return definitions
   const out = new Map(definitions)
+  const claimedBy = new Map<string, string>()
+  const ambiguous = new Set<string>()
   for (const [name, value] of definitions) {
     for (const [from, to] of rules) {
       if (from !== "" && !name.startsWith(from)) continue
       const alias = to + name.slice(from.length)
-      if (!out.has(alias)) out.set(alias, value)
+      // An md name outranks any alias, always.
+      if (definitions.has(alias)) break
+      const prior = claimedBy.get(alias)
+      if (prior === undefined) {
+        claimedBy.set(alias, value)
+        out.set(alias, value)
+      } else if (prior !== value) {
+        // Two md names folding onto one alias with different values is the same
+        // ambiguity `readDefinitions` drops, one layer up: whichever md name
+        // came first would win on declaration order alone, and the gate would
+        // compare the preview against a value picked by nothing. Restating the
+        // same value is fine.
+        ambiguous.add(alias)
+      }
       break
     }
   }
+  for (const alias of ambiguous) out.delete(alias)
   return out
 }
 

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -74,6 +74,12 @@ function stripComments(css: string): string {
  * detection, because a `# Neutral dark` comment inside a yaml fence
  * (`services/yeogi.md:156`) is not a heading. Dropping conflicts costs 22
  * comparisons on one slug and needs neither.
+ *
+ * Those 22 are recoverable — a fence-aware heading scoper would keep both theme
+ * blocks apart, and giving theme redeclarations distinct names would remove the
+ * conflict outright. Neither is worth doing for one slug on its own; both are
+ * written up in #245, which tracks the wider problem that nothing else in the
+ * repo notices a token declared twice with different values.
  */
 export function readDefinitions(markdown: string): Map<string, string> {
   const out = new Map<string, string>()
@@ -158,17 +164,22 @@ const PREVIEW_TOKEN_ALIASES: Partial<
  * so nothing changes — this is what stops one of the two reports becoming
  * meaningless on the day they diverge.
  *
- * A slug with no entry is returned unchanged, which is correct for `11st`
- * (preview and md already agree) and unavoidable for `bezier` (its preview
- * declares no `oklch` at all — hex — so no naming rule can reach it).
+ * A slug with no entry gets no aliases, which is correct for `11st` (preview
+ * and md already agree) and unavoidable for `bezier` (its preview declares no
+ * `oklch` at all — hex — so no naming rule can reach it).
+ *
+ * Always returns a NEW map, including in that case. Handing back the caller's
+ * own map for some slugs and a copy for others is the kind of contract that
+ * holds right up until someone mutates the result and quietly corrupts the
+ * `readDefinitions` output for one half of the catalogue.
  */
 export function alignToPreviewNames(
   definitions: Map<string, string>,
   slug: string
 ): Map<string, string> {
-  const rules = PREVIEW_TOKEN_ALIASES[slug]
-  if (rules === undefined) return definitions
   const out = new Map(definitions)
+  const rules = PREVIEW_TOKEN_ALIASES[slug]
+  if (rules === undefined) return out
   const claimedBy = new Map<string, string>()
   const ambiguous = new Set<string>()
   for (const [name, value] of definitions) {


### PR DESCRIPTION
Closes #240.

드리프트 게이트가 카탈로그의 **3.1%** 만 대조하고 있었다. 706개 선언 중 22개, 17개 슬러그 중 14개가 통째로 미검사. 원인은 프리뷰가 커스텀 속성에 네임스페이스를 붙이는데(`--tds-blue-500`) md 키는 맨이름(`blue-500`)이라는 것이다.

**대조 22 → 430 (3.1% → 60.9%), 적발 0건.**

## 이름 정렬 — 접두 "제거"가 아니라 재작성 매핑

md 이름을 프리뷰 이름으로 재작성해 별칭을 **추가**한다(치환이 아니라 추가). `findPreviewDrift` 는 손대지 않았다 — 이름 정렬은 정의 맵의 문제이지 스캐너의 문제가 아니다.

규칙은 순서대로 시도하고 첫 매치에서 멈춘다. 빈 `from` 은 무엇에나 맞으므로 catch-all 로 마지막에 둔다. **한 슬러그가 한 계열만 다르게 renaming 하는 경우가 있어 두 규칙이 필요하다:**

| slug | md | 프리뷰 | 규칙 |
|---|---|---|---|
| toss 외 다수 | `blue-500` | `--tds-blue-500` | `` → `tds-` |
| line-design-system | `ldsg-color-linegreen` | `--ldsg-linegreen` | `ldsg-color-` → `ldsg-`, 그 외 `` → `ldsg-` |
| greeting | `gray0` | `--g-gray-0` | `gray` → `g-gray-`, 그 외 `` → `g-` |

단일 접두만 쓰면 line-design-system 과 greeting 은 0 으로 남는다. 미커버는 **`bezier` 하나**뿐이고, 그건 이름 문제가 아니다 — 프리뷰가 oklch 를 아예 안 쓰고 hex 다.

## 선행 조건 — md 쪽에 다크 대응이 없었다

커버리지를 올리자마자 `wanted` 에서 **10건이 적발**됐다. 전부 오탐이고 원인은 접두가 아니라 별개 버그였다.

`services/wanted.md` 는 같은 시맨틱 alias 를 테마별로 두 번 선언한다:

```
:185  ### Semantic alias — Light      :222  ### Semantic alias — Dark
:189  bg-canvas: oklch(1 0 0)         :226  bg-canvas: oklch(0.148 0.004 277)
```

`readDefinitions` 는 섹션을 모르고 last-wins 라 맵이 **다크 값**을 들고 있었다. 게이트는 **라이트** 프리뷰를 비교하므로, 맞는 프리뷰를 고발하고 있었던 셈이다.

**비대칭이 요점이다** — `findPreviewDrift` 는 중괄호 깊이를 추적해가며 프리뷰 쪽 `[data-theme="dark"]` 를 건너뛰는데 md 쪽에 그 대응이 없었다. 대조가 22건뿐이라 아무도 이 이름들에 닿지 못해 드러나지 않았다.

**해법: 값이 충돌하는 중복 정의는 비교에서 제외한다.** 테마 맥락이 없는 함수가 고를 근거가 없으므로, 비교하지 않는 것이 정직한 답이다. 같은 값으로 반복된 것은 모호하지 않으므로 남긴다(wanted 의 `fg-on-brand`).

### 헤딩 스코프 안은 실측으로 기각했다

헤딩 텍스트에 dark/다크 가 있으면 그 절을 건너뛰는 방식은:

- `services/codeit.md` 의 `### 프리미티브 스케일 — 다크 테마` 까지 삼켜, **아무와도 충돌하지 않는 유일한 이름 `dark-gray-*` 78개**를 날린다.
- 펜스 인식이 필요하다 — `services/yeogi.md:156` 의 `# Neutral dark` 는 yaml 펜스 **안의 주석**이지 헤딩이 아닌데 `^#` 로는 구분되지 않는다. 이걸 헤딩으로 읽으면 그 뒤 정의가 조용히 사라진다.

충돌 제외는 한 슬러그에서 22개를 잃을 뿐이고 둘 다 필요 없다. **카탈로그 전수 확인: 중복 키를 가진 파일은 `wanted` 하나뿐**(24개 중복 중 22개가 값 충돌), 나머지 16개는 0이다.

## 음성 대조

| 변이 | 결과 |
|---|---|
| 충돌 제외를 last-wins 로 되돌림 | `wanted` **10건** 적발, 코퍼스 테스트 실패 |
| 별칭이 정확 일치를 덮도록 | 단위 픽스처 실패 (`c101-primary`) |

두 번째는 **처음엔 판별되지 않았다.** class101 의 `--primary` 와 `--c101-primary` 가 오늘 같은 값이라 코퍼스로는 드러나지 않는다. 변이를 돌려 아무 테스트도 안 깨지는 것을 보고 단위 픽스처를 따로 붙였다. 값이 갈라지는 날 한쪽 보고가 무의미해지는 것을 막는 자리다.

## 맵을 frontmatter 에 넣지 않은 이유

`KNOWN_FRONTMATTER_KEYS`(`src/lib/content-parser.ts:17`)는 **발행 표면**이다 — llms.txt 에 그대로 실리고 사이트가 읽는다. 이 저장소 프리뷰 CSS 의 변수 작명은 카탈로그가 기술하는 디자인 시스템의 속성이 아니라 게이트의 내부 사정이므로, 발행 포맷에 새 키를 내보낼 이유가 없다. 새 항목이 표에서 빠지는 것은 `oklch-drift-corpus.test.ts` 가 잡는다(바닥 430).

## 리뷰 순서

`test` 커밋이 먼저 실패한 채 들어간다 — `git show` 로 옛 커버리지(22)와 wanted 오적발을 재현할 수 있다. 그다음 충돌 제외, 그다음 별칭 맵.

## 검증

`pnpm typecheck` · `lint` · `test`(506) · `audit:oklch` · `validate:previews` · `validate:catalog` · `tokens:check` 전부 통과. `format:check` 로컬 실패 14건은 전부 `.claude/skills/docs-crawler/` CRLF 오탐(CLAUDE.md 기재)이며 이 PR 이 건드린 파일은 없다.
