### PR TITLE
refactor(drift): 게이트 배선을 헬퍼 하나로 모은다

### DIFF
--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -7,11 +7,7 @@ import {
   matchDefinition,
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
-import {
-  alignToPreviewNames,
-  findPreviewDrift,
-  readDefinitions,
-} from "../src/lib/oklch-drift"
+import { definitionsForSlug, findPreviewDrift } from "../src/lib/oklch-drift"
 import { ALPHA_TOLERANCE, DELTA_E_TOLERANCE } from "../src/lib/oklch-tolerance"
 import {
   deltaE,
@@ -348,8 +344,8 @@ for (const slug of slugs) {
     process.exitCode = 1
     continue
   }
-  const defs = alignToPreviewNames(
-    readDefinitions(fs.readFileSync(path.join(SERVICES, `${slug}.md`), "utf8")),
+  const defs = definitionsForSlug(
+    fs.readFileSync(path.join(SERVICES, `${slug}.md`), "utf8"),
     slug
   )
   const found = findPreviewDrift(fs.readFileSync(preview, "utf8"), defs)

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -2,11 +2,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
-import {
-  alignToPreviewNames,
-  findPreviewDrift,
-  readDefinitions,
-} from "./oklch-drift"
+import { definitionsForSlug, findPreviewDrift } from "./oklch-drift"
 
 // `oklch-drift.test.ts` proves the algorithm on synthetic strings. Nothing
 // proved it still reaches the catalogue — and for a while it barely did: the
@@ -53,10 +49,13 @@ function matchedCount(html: string, defs: Map<string, string>): number {
   return findPreviewDrift(html, names).length
 }
 
-/** Exactly what `scripts/audit-oklch.ts` feeds the gate for this slug. */
+// Calls the same function `scripts/audit-oklch.ts` calls, rather than
+// assembling the pipeline again here. Rebuilding it would let the script change
+// underneath these assertions while they kept passing — which is the failure
+// this file was written to make impossible, reproduced inside the file itself.
 function definitionsFor(slug: string): Map<string, string> {
-  return alignToPreviewNames(
-    readDefinitions(readFileSync(join(SERVICES, `${slug}.md`), "utf8")),
+  return definitionsForSlug(
+    readFileSync(join(SERVICES, `${slug}.md`), "utf8"),
     slug
   )
 }

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -214,6 +214,25 @@ export function alignToPreviewNames(
 }
 
 /**
+ * The definitions the drift gate compares a preview against: parsed from the
+ * md, then aliased to the names that slug's preview uses.
+ *
+ * The two steps are exported separately because their unit tests need them
+ * separately, but every caller wants both — and a caller that assembled them by
+ * hand could fall out of step with the one that matters. That is not a
+ * hypothetical shape of bug in this file: `oklch-drift-corpus.test.ts` exists
+ * because a gate can stay green while checking nothing. A test that rebuilt
+ * this pipeline itself would keep passing after `scripts/audit-oklch.ts`
+ * changed, and would be asserting about a pipeline nothing ships.
+ */
+export function definitionsForSlug(
+  markdown: string,
+  slug: string
+): Map<string, string> {
+  return alignToPreviewNames(readDefinitions(markdown), slug)
+}
+
+/**
  * Compare a LIGHT preview's custom properties against the md definitions.
  *
  * Deliberately narrow, because a loose comparison is unusable: matching token


### PR DESCRIPTION
PR #243 리뷰가 머지 직후 지적한 것 하나를 처리한다.

## 문제

`scripts/audit-oklch.ts` 와 `src/lib/oklch-drift-corpus.test.ts` 가 게이트 배선을 각자 조립하고 있었다:

```ts
alignToPreviewNames(readDefinitions(...), slug)
```

테스트 쪽에 `// Exactly what scripts/audit-oklch.ts feeds the gate for this slug.` 라고 동기화 책임을 주석으로 적어 뒀지만, **스크립트만 바뀌면 테스트는 옛 파이프라인을 계속 검사하며 통과한다.**

이 파일에서는 특히 나쁜 형태다 — `oklch-drift-corpus.test.ts` 는 애초에 **"게이트가 초록인데 아무것도 안 검사하는"** 상태를 막으려고 만든 파일인데, 그 실패를 파일 자신이 재현하고 있었다.

## 변경

`definitionsForSlug(markdown, slug)` 를 `oklch-drift.ts` 에서 export 하고 두 호출부가 같은 함수를 쓰게 했다. `readDefinitions` 와 `alignToPreviewNames` 는 각자의 단위 테스트가 필요로 하므로 export 를 유지한다.

## 검증

동작 변화 없음. 커버리지 **430 / 706** 그대로, 적발 0건.

`pnpm typecheck` · `lint` · `test`(512) · `audit:oklch` 통과.

Refs #240
