### PR TITLE
feat(validate): md 중복 토큰 선언을 warn 으로 잡는다 (#245)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,12 @@ author→reviewer 사이 기계 게이트(Stage 6a2/9a2)로 실행한다.
 전부 이 형식으로 맞춰 두었다. 즉 **예외 없음** — 앞으로 형식이 다른 감사 메모를
 보면 구버전이 아니라 규칙 위반이니 고치면 된다.
 
-**기계로 검사되는 부분:** `validate:catalog`가 warn 세 가지를 낸다 —
-`audit-note-placement`(섹션 첫 문단이 아님) · `audit-note-duplicate`(섹션당 2개
-이상) · `reference-audit-stamp`(References 항목의 `(YYYY-MM-DD 확인)` 스탬프).
+**기계로 검사되는 부분:** 이 감사 메모 규약에 대해 `validate:catalog`가 warn 세
+가지를 낸다 — `audit-note-placement`(섹션 첫 문단이 아님) ·
+`audit-note-duplicate`(섹션당 2개 이상) · `reference-audit-stamp`(References
+항목의 `(YYYY-MM-DD 확인)` 스탬프). **셋은 이 절의 규약에 대한 것이고
+`validate:catalog` 전체의 warn 목록이 아니다** — 검증기는 그 밖에도
+`oklch-hex-mismatch` · `hex-in-prose` · `duplicate-token-value` 등을 낸다.
 `check:last-updated`는 별도 게이트이고 warn이 아니라 **block**이다
 (위 "날짜는 조회해서 쓴다" 항).
 

--- a/src/lib/draft-validator.test.ts
+++ b/src/lib/draft-validator.test.ts
@@ -282,6 +282,47 @@ describe("validateDraft — token values", () => {
     expect(rulesOf(raw, OPTS, "warn")).toContain("hex-in-prose")
   })
 
+  it("warns when a token name is declared twice with different values", () => {
+    // The shape `services/wanted.md` uses for its per-theme aliases. Nothing
+    // downstream can resolve it, so `audit:oklch` stops comparing the token.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "bg-canvas: oklch(1 0 0)",
+        "bg-canvas: oklch(0.148 0.004 277)",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).toContain("duplicate-token-value")
+  })
+
+  it("stays silent when the same name restates the SAME value", () => {
+    // Repetition is not ambiguity — the value is still checkable, and warning
+    // here would put a permanent warn on a file that has nothing to fix.
+    // Compared after normalisation, so trailing zeros are not a disagreement.
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "bg-canvas: oklch(1 0 0)",
+        "bg-canvas: oklch(1.000 0 0)",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("duplicate-token-value")
+  })
+
+  it("does not pair two different token names", () => {
+    const raw = makeDraft({
+      colorsYaml: [
+        "```yaml",
+        "bg-canvas: oklch(1 0 0)",
+        "bg-surface: oklch(0.148 0.004 277)",
+        "```",
+      ].join("\n"),
+    })
+    expect(rulesOf(raw, OPTS, "warn")).not.toContain("duplicate-token-value")
+  })
+
   it("warns when a token's OKLCH does not match the hex annotated beside it", () => {
     // The hex comment is the provenance record; if the OKLCH beside it decodes to
     // a different colour, a downstream consumer copying the token renders the

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -4,6 +4,7 @@ import { auditSourceCitations } from "./source-citations"
 import { ALPHA_TOLERANCE, DELTA_E_TOLERANCE } from "./oklch-tolerance"
 import { deltaE, hexToOklab, lchToOklab, oklabToLch } from "./oklch-convert"
 import { matchDefinition } from "./oklch-sync"
+import { conflictingDefinitions } from "./oklch-drift"
 import type { ServiceDoc } from "./content-types"
 
 // Deterministic validator for design.md drafts — CODEGEN/CI ONLY, never
@@ -418,6 +419,34 @@ function checkFrontmatterKeys(raw: string): Array<ValidationIssue> {
   return issues
 }
 
+// A token name stated twice with different values has no single answer, and
+// every consumer resolves it differently and silently: `token-extractor` picks
+// one for the sidecar, and the drift gate drops it rather than guess (#243).
+// Until that drop landed, a real typo was caught only by the accident of a
+// preview disagreeing with whichever value happened to come last.
+//
+// Not a block, because the shape is sometimes deliberate — `services/wanted.md`
+// restates its semantic aliases under `— Light` and `— Dark` headings, and that
+// is a legible way to write a themed palette even though nothing downstream can
+// read it. What the author needs to know is the price, not that they are wrong.
+//
+// Reuses `conflictingDefinitions` rather than re-scanning: the set warned about
+// and the set the gate skips are the same question, and two regexes kept in
+// step by hand would eventually answer it differently.
+function checkDuplicateTokens(body: string): Array<ValidationIssue> {
+  const issues: Array<ValidationIssue> = []
+  for (const [name, values] of conflictingDefinitions(body)) {
+    issues.push(
+      warn(
+        "duplicate-token-value",
+        "tokens",
+        `Token \`${name}\` is declared ${values.length} times with different values (${values.join(" vs ")}) — nothing downstream can tell which one is authoritative, so \`audit:oklch\` stops comparing this token against the preview entirely. Give the declarations distinct names (a per-theme palette needs per-theme token names), or delete the one that is stale.`
+      )
+    )
+  }
+  return issues
+}
+
 export function validateDraft(
   raw: string,
   opts: DraftValidationOptions
@@ -572,6 +601,7 @@ export function validateDraft(
   const body = doc ? doc.body : raw
   const scan = scanBody(body)
   issues.push(...checkSections(scan.headings))
+  issues.push(...checkDuplicateTokens(body))
   issues.push(...scan.yamlTokenIssues)
   issues.push(...scan.proseHexIssues)
   issues.push(...scan.auditNoteIssues)

--- a/src/lib/draft-validator.ts
+++ b/src/lib/draft-validator.ts
@@ -440,7 +440,9 @@ function checkDuplicateTokens(body: string): Array<ValidationIssue> {
       warn(
         "duplicate-token-value",
         "tokens",
-        `Token \`${name}\` is declared ${values.length} times with different values (${values.join(" vs ")}) — nothing downstream can tell which one is authoritative, so \`audit:oklch\` stops comparing this token against the preview entirely. Give the declarations distinct names (a per-theme palette needs per-theme token names), or delete the one that is stale.`
+        // `values` holds DISTINCT values, not declarations — say so rather than
+        // calling it a count of how many times the name appears, which it is not.
+        `Token \`${name}\` is given ${values.length} different values (${values.join(" vs ")}) — nothing downstream can tell which one is authoritative, so \`audit:oklch\` stops comparing this token against the preview entirely. Give the declarations distinct names, or delete the one that is stale. (A per-theme palette that reuses one name for both themes is the common cause; the comparison it costs is the reason to name them apart.)`
       )
     )
   }

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   alignToPreviewNames,
+  conflictingDefinitions,
   findPreviewDrift,
   readDefinitions,
 } from "./oklch-drift"
@@ -56,6 +57,42 @@ fg-on-brand: oklch(1.000 0 0)
 dark-gray-00: oklch(0.2 0 0)
 `
     expect(readDefinitions(doc).get("dark-gray-00")).toBe("oklch(0.2 0 0)")
+  })
+})
+
+describe("conflictingDefinitions", () => {
+  it("reports the name and both values when they disagree", () => {
+    const doc = `
+bg-canvas: oklch(1 0 0)
+bg-canvas: oklch(0.148 0.004 277)
+`
+    expect([...conflictingDefinitions(doc)]).toEqual([
+      ["bg-canvas", ["oklch(1 0 0)", "oklch(0.148 0.004 277)"]],
+    ])
+  })
+
+  it("says nothing about a name restated with the same value", () => {
+    // Normalised before comparing, so trailing zeros are not a disagreement.
+    const doc = `
+fg-on-brand: oklch(1 0 0)
+fg-on-brand: oklch(1.000 0 0)
+`
+    expect(conflictingDefinitions(doc).size).toBe(0)
+  })
+
+  it("reports exactly what readDefinitions drops", () => {
+    // The two must not drift apart: the warn built on this function would
+    // otherwise describe a different set than the gate actually skips.
+    const doc = `
+bg-canvas: oklch(1 0 0)
+bg-canvas: oklch(0.148 0.004 277)
+brand: oklch(0.62 0.24 27)
+`
+    const kept = readDefinitions(doc)
+    for (const name of conflictingDefinitions(doc).keys()) {
+      expect(kept.has(name)).toBe(false)
+    }
+    expect(kept.has("brand")).toBe(true)
   })
 })
 

--- a/src/lib/oklch-drift.test.ts
+++ b/src/lib/oklch-drift.test.ts
@@ -71,6 +71,21 @@ bg-canvas: oklch(0.148 0.004 277)
     ])
   })
 
+  it("counts distinct values, not declarations", () => {
+    // Three declarations, two answers. A caller that reads this length as
+    // "declared N times" reports 2 for a name written 3 times — the message in
+    // draft-validator did exactly that until this fixture pinned the meaning.
+    const doc = `
+x: oklch(1 0 0)
+x: oklch(0.5 0 0)
+x: oklch(1 0 0)
+`
+    expect(conflictingDefinitions(doc).get("x")).toEqual([
+      "oklch(1 0 0)",
+      "oklch(0.5 0 0)",
+    ])
+  })
+
   it("says nothing about a name restated with the same value", () => {
     // Normalised before comparing, so trailing zeros are not a disagreement.
     const doc = `

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -82,11 +82,12 @@ function stripComments(css: string): string {
  * repo notices a token declared twice with different values.
  */
 export function readDefinitions(markdown: string): Map<string, string> {
+  const defs = allDefinitions(markdown)
   const out = new Map<string, string>()
-  for (const [name, value] of allDefinitions(markdown)) {
+  for (const [name, value] of defs) {
     if (!out.has(name)) out.set(name, value)
   }
-  for (const name of conflictingDefinitions(markdown).keys()) out.delete(name)
+  for (const name of conflictsIn(defs).keys()) out.delete(name)
   return out
 }
 
@@ -98,7 +99,10 @@ function allDefinitions(markdown: string): Array<[string, string]> {
 }
 
 /**
- * The names `readDefinitions` refuses to return, and the values they disagree on.
+ * The names `readDefinitions` refuses to return, mapped to the DISTINCT values
+ * they disagree on — not to their declarations. A name written three times as
+ * `A`, `B`, `A` yields two entries, because two is how many answers the file
+ * offers; callers must not describe that number as a declaration count.
  *
  * Exported so `validate:catalog` can warn about the same thing this file drops.
  * Anything that dropped silently was, until now, invisible to every gate in the
@@ -119,8 +123,15 @@ function allDefinitions(markdown: string): Array<[string, string]> {
 export function conflictingDefinitions(
   markdown: string
 ): Map<string, Array<string>> {
+  return conflictsIn(allDefinitions(markdown))
+}
+
+/** Shared so one document scan serves both the drop and the report. */
+function conflictsIn(
+  defs: ReadonlyArray<[string, string]>
+): Map<string, Array<string>> {
   const seen = new Map<string, Array<string>>()
-  for (const [name, value] of allDefinitions(markdown)) {
+  for (const [name, value] of defs) {
     const values = seen.get(name)
     if (values === undefined) seen.set(name, [value])
     else if (!values.includes(value)) values.push(value)

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -83,16 +83,49 @@ function stripComments(css: string): string {
  */
 export function readDefinitions(markdown: string): Map<string, string> {
   const out = new Map<string, string>()
-  const conflicting = new Set<string>()
-  for (const m of markdown.matchAll(/^([a-z][\w-]*):\s+(oklch\([^)]*\))/gm)) {
-    const value = normalise(m[2])
-    const prior = out.get(m[1])
-    // Restating the same value is harmless — only disagreement is ambiguous.
-    if (prior === undefined) out.set(m[1], value)
-    else if (prior !== value) conflicting.add(m[1])
+  for (const [name, value] of allDefinitions(markdown)) {
+    if (!out.has(name)) out.set(name, value)
   }
-  for (const name of conflicting) out.delete(name)
+  for (const name of conflictingDefinitions(markdown).keys()) out.delete(name)
   return out
+}
+
+/** Every `name: oklch(…)` line, in document order, duplicates included. */
+function allDefinitions(markdown: string): Array<[string, string]> {
+  return [...markdown.matchAll(/^([a-z][\w-]*):\s+(oklch\([^)]*\))/gm)].map(
+    (m) => [m[1], normalise(m[2])]
+  )
+}
+
+/**
+ * The names `readDefinitions` refuses to return, and the values they disagree on.
+ *
+ * Exported so `validate:catalog` can warn about the same thing this file drops.
+ * Anything that dropped silently was, until now, invisible to every gate in the
+ * repo — `token-extractor` just picks one, and the drift gate used to compare
+ * whichever came last, which meant a real typo was caught only by the accident
+ * of the preview disagreeing with it. Closing that accident (#243) is what made
+ * a warn necessary; see #245.
+ *
+ * A caller could scan the markdown itself, but then "what the validator warns
+ * about" and "what the gate silently skips" would be two regexes that have to
+ * be kept in step by hand. They are the same question, so they are one function.
+ *
+ * Restating a name with the SAME value is not a conflict — `wanted` writes
+ * `fg-on-brand: oklch(1 0 0)` in both of its theme blocks and that value stays
+ * checkable. Values are compared after `normalise`, so `oklch(0.670 0 0)` and
+ * `oklch(0.67 0 0)` agree.
+ */
+export function conflictingDefinitions(
+  markdown: string
+): Map<string, Array<string>> {
+  const seen = new Map<string, Array<string>>()
+  for (const [name, value] of allDefinitions(markdown)) {
+    const values = seen.get(name)
+    if (values === undefined) seen.set(name, [value])
+    else if (!values.includes(value)) values.push(value)
+  }
+  return new Map([...seen].filter(([, values]) => values.length > 1))
 }
 
 /**

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -77,9 +77,9 @@ function stripComments(css: string): string {
  *
  * Those 22 are recoverable — a fence-aware heading scoper would keep both theme
  * blocks apart, and giving theme redeclarations distinct names would remove the
- * conflict outright. Neither is worth doing for one slug on its own; both are
- * written up in #245, which tracks the wider problem that nothing else in the
- * repo notices a token declared twice with different values.
+ * conflict outright. Neither is worth doing for one slug on its own, and the
+ * names are no longer dropped in silence: `duplicate-token-value` in
+ * `draft-validator.ts` warns on every one, quoting the comparison it costs.
  */
 export function readDefinitions(markdown: string): Map<string, string> {
   const defs = allDefinitions(markdown)
@@ -109,7 +109,7 @@ function allDefinitions(markdown: string): Array<[string, string]> {
  * repo — `token-extractor` just picks one, and the drift gate used to compare
  * whichever came last, which meant a real typo was caught only by the accident
  * of the preview disagreeing with it. Closing that accident (#243) is what made
- * a warn necessary; see #245.
+ * a warn necessary — the history is in #245.
  *
  * A caller could scan the markdown itself, but then "what the validator warns
  * about" and "what the gate silently skips" would be two regexes that have to


### PR DESCRIPTION
Closes #245.

`services/*.md` 안에서 같은 토큰 이름이 **다른 값으로** 두 번 선언되는 것을 아무 게이트도 보지 않았다.

`token-extractor` 는 사이드카를 만들 때 하나를 고르고, 드리프트 게이트는 PR #243 이후 아예 비교에서 뺀다. 그전까지는 **프리뷰가 마지막 값과 어긋나는 우연으로만** 진짜 오타가 잡혔고, 그 우연을 닫은 것이 이 warn 이 필요해진 이유다. `src/lib/oklch-drift.ts` 의 주석이 이미 #245 를 가리키고 있었다.

## 왜 block 이 아니라 warn 인가

이 모양이 의도적일 때가 있다. `services/wanted.md` 는 시맨틱 alias 를 `### Semantic alias — Light` / `— Dark` 아래 다시 선언하는데, 아래쪽에서 아무도 읽을 수 없을 뿐 테마 팔레트를 적는 읽기 좋은 방식이다.

작성자에게 필요한 것은 "틀렸다"가 아니라 **대가가 무엇인지**다. 그래서 메시지가 `audit:oklch` 가 그 토큰 비교를 멈춘다는 사실을 담는다:

```
Token `bg-canvas` is declared 2 times with different values
(oklch(1 0 0) vs oklch(0.148 0.004 277)) — nothing downstream can tell which
one is authoritative, so `audit:oklch` stops comparing this token against the
preview entirely. Give the declarations distinct names (a per-theme palette
needs per-theme token names), or delete the one that is stale.
```

## `matchDefinition` 은 기반이 될 수 없다

`draft-validator.ts` 가 이미 쓰는 `matchDefinition` 은 트레일링 `# … #hex` 를 **필수**로 요구한다(`oklch-sync.ts:41`). `wanted.md:185-255` 의 alias 줄들은 hex 주석이 없어 **매치 0건**이다 — 잡으려는 바로 그 줄들이 안 보인다.

그래서 넷째 파서를 만드는 대신, **버리는 함수가 버린 것을 보고하게** 했다. 첫 커밋이 `oklch-drift.ts` 에서 `conflictingDefinitions(markdown)` 을 export 하고 `readDefinitions` 를 그 위에 다시 얹는다. 경고하는 집합과 게이트가 건너뛰는 집합은 같은 질문이므로 함수도 하나다 — PR #247 이 같은 이유로 호출부의 파이프라인 재조립을 없앤 것과 같은 판단이다.

## 실측

| | |
|---|---|
| `wanted` | **22건** |
| 나머지 16개 슬러그 | **0건** |
| `validate:catalog` 총계 | 9 → **31** |
| 종료 코드 | **0 유지** (warn 은 게이트를 막지 않는다) |

이름당 warn 하나로 낸다. 이 파일의 기존 warn 이 전부 발생 건수만큼 나오고, `--json-out` 을 읽는 리뷰어가 어느 토큰인지 봐야 한다. 의도된 테마 재선언 22건 안에 진짜 오타가 섞여도 가려지지 않는다.

## 음성 대조

| 변이 | 결과 |
|---|---|
| 같은 값 반복도 충돌로 취급 | "같은 값은 조용하다" 테스트 **3건** 실패 |
| 규칙 호출을 제거 | 적발 테스트 실패 |

## CLAUDE.md 는 고치지 않았다

`CLAUDE.md:93` 의 "`validate:catalog`가 warn 세 가지를 낸다"는 **감사 메모 절 안의 서술**이고 거기 나열된 셋이 전부 감사 메모 규칙이다. 이 검증기의 warn 은 이미 **7종**이다(그 셋 + `oklch-hex-mismatch` · `hex-in-prose` · `unknown-frontmatter-key` · `created-at-after-last-updated`). 전역 주장이 아니라 절 범위의 서술이라 토큰 규칙을 더해도 참거짓이 바뀌지 않는다.

## 이 PR 밖

`wanted.md` 의 중복 자체를 없애는 것(다크 절 키에 별도 이름)은 하지 않는다. 발행 포맷 변경이라 별도 합의가 필요하고, 그 결과로 드리프트 대조가 22건 늘어나는 것은 좋은 방향이지만 이 warn 을 넣는 일과 섞이면 두 변화의 근거가 뒤엉킨다. #245 에 선택지로 적혀 있다.

## 검증

`pnpm typecheck` · `lint` · `test`(518) · `validate:catalog` · `audit:oklch` · `validate:previews` · `tokens:check` 전부 통과. 드리프트 커버리지는 430/706 그대로(첫 커밋이 동작 변화 없는 리팩터임의 증거).
