### PR TITLE
docs(skill): Stage 10 에 프리뷰 토큰 별칭 등록 안내를 넣는다 (#246)

### DIFF
--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -431,6 +431,32 @@ The two phrase sentinels are literal (`-F`) for the same reason: the non-affilia
 
 If any `DISCLAIMER_*` sentinel prints, do not proceed to Stage 11. Re-run Stage 9a with a blocking prior-preview issue quoting the verbatim strip from `.claude/agents/preview-html-author.md` and stating it must be the first child of `<body>` in both files.
 
+### Preview token alias registration
+
+The moment the previews land in `public/`, the OKLCH drift gate starts expecting this slug to be accounted for. Run it:
+
+```bash
+cd "${repo_root}" && pnpm test src/lib/oklch-drift-corpus.test.ts
+```
+
+That gate compares each preview's `--custom-property: oklch(…)` declarations against the `name: oklch(…)` definitions in `services/{slug}.md`, by **exact name**. Previews almost always namespace their variables (`--tds-blue-500` for md `blue-500`), so each slug declares a rewrite rule in `PREVIEW_TOKEN_ALIASES` (`src/lib/oklch-drift.ts`). Without one, every declaration in this preview is unreachable and the gate silently checks nothing for the new entry — which is what the corpus test refuses to let happen.
+
+**Stage 9a2's `oklch coverage` metric does not cover this.** It searches the HTML for the design.md's OKLCH *values* as substrings; it never looks at custom-property *names*, and `src/lib/preview-validator.ts` does not consult the drift gate at all. A fully namespaced preview can score 100% coverage at 9a2 and still match zero declarations here.
+
+Three rule shapes are in use, all measured against real entries:
+
+| md name | preview name | rule |
+|---|---|---|
+| `blue-500` | `--tds-blue-500` | `["", "tds-"]` — prepend |
+| `ldsg-color-linegreen` | `--ldsg-linegreen` | `["ldsg-color-", "ldsg-"]` — replace |
+| `gray0` | `--g-gray-0` | `[["gray", "g-gray-"], ["", "g-"]]` — one family differs from the rest |
+
+Rules are tried in order, first match wins, and an empty `from` matches anything so it belongs last.
+
+If the test fails with `these slugs have no entry in MATCH_FLOOR`, add the rule, then record the count the failure message prints into `MATCH_FLOOR` (`src/lib/oklch-drift-corpus.test.ts`) — that table is a per-slug floor, so it also has to be raised deliberately rather than guessed. Recording a bare `0` is refused: only `bezier` is entitled to it, because its preview is hex rather than OKLCH and no naming rule can reach it.
+
+Both files are outside this skill's write scope, so this does not route back to Stage 9a — a human operator running the skill by hand makes these two edits directly. Skipping them does not corrupt the entry; it leaves the drift gate blind to it, and CI fails on the pull request rather than here.
+
 ## Stage 11 — Build OG image
 
 ```bash

--- a/src/lib/design-md-skill-machine-gate.test.ts
+++ b/src/lib/design-md-skill-machine-gate.test.ts
@@ -96,6 +96,34 @@ describe("/design-md machine gates", () => {
     }
   })
 
+  // The drift gate only compares a preview token whose name it can reach, and
+  // previews namespace their custom properties (`--tds-primary` for md
+  // `primary`), so each slug needs a rewrite rule declared in `src/lib`. A new
+  // entry without one contributes nothing and the corpus test fails — on the
+  // PR, in CI, with a message the person onboarding has never seen, because the
+  // skill never runs `pnpm test`. The gate existed with no way for the author
+  // to know about it (#246). These assertions pin both ends: the skill names
+  // the two tables, and the two tables still exist under those names.
+  it("tells onboarding to register a preview token alias rule", () => {
+    const skill = readRepoFile(".claude/skills/design-md/SKILL.md")
+
+    // Naming the symbols is the whole point — a reader who cannot find them
+    // cannot act on the failure.
+    expect(skill).toContain("PREVIEW_TOKEN_ALIASES")
+    expect(skill).toContain("MATCH_FLOOR")
+    // And the step has to actually run, or the failure still lands in CI.
+    expect(skill).toContain("oklch-drift-corpus.test.ts")
+
+    // Without these, a rename in src/lib leaves the skill pointing at symbols
+    // that no longer exist and the prose rots silently.
+    expect(readRepoFile("src/lib/oklch-drift.ts")).toContain(
+      "PREVIEW_TOKEN_ALIASES"
+    )
+    expect(readRepoFile("src/lib/oklch-drift-corpus.test.ts")).toContain(
+      "MATCH_FLOOR"
+    )
+  })
+
   // created_at is the catalog's sort key, but nothing in the pipeline would
   // notice its absence: an entry missing it still renders, just pinned to the
   // bottom of the list. Four entries shipped that way before the field became

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -121,9 +121,16 @@ describe("oklch-drift — catalogue coverage", () => {
     // `PREVIEW_TOKEN_ALIASES`, and this is where not having one becomes visible
     // instead of being absorbed by the other sixteen slugs' totals.
     const unaccounted = all.filter((s) => !(s in MATCH_FLOOR))
+    // Report the measured count, not just the name. Nothing else in the repo
+    // prints it, so a message that only says "record a number" leaves the
+    // reader with no way to obtain one — and recording a 0 is refused below.
+    const measured = unaccounted.map((slug) => {
+      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      return `${slug} (matches ${matchedCount(html, definitionsFor(slug))} today)`
+    })
     expect(
       unaccounted,
-      `these slugs have no entry in MATCH_FLOOR: ${unaccounted.join(", ")}. Measure what the drift gate matches for each (the count is 0 unless PREVIEW_TOKEN_ALIASES in oklch-drift.ts has a rule for its preview's naming) and record it.`
+      `these slugs have no entry in MATCH_FLOOR: ${measured.join(", ")}. Record that count. A count of 0 means PREVIEW_TOKEN_ALIASES in oklch-drift.ts has no rule for this preview's naming — add the rule first, then re-read the number.`
     ).toEqual([])
   })
 


### PR DESCRIPTION
Closes #246.

PR #243 이 슬러그별 커버리지 바닥 표(`MATCH_FLOOR`)를 넣어 새 항목이 별칭 규칙 없이 조용히 0건으로 묻히는 걸 막았다. 그런데 온보딩 문서 어디에도 그 요구가 없어서, 프리뷰가 커스텀 속성에 네임스페이스를 쓰면(대부분 그렇다) 처음 보는 실패를 만난다:

```
these slugs have no entry in MATCH_FLOOR: <slug>
```

게이트는 있는데 작성자에게 그 축이 전달되지 않는 상태 — #214 가 정부 식별자 축에서 지적하는 것과 같은 형태다.

## 조사에서 나온, 접근을 바꾼 사실 둘

### 스킬은 `pnpm test` 를 돌리지 않는다

SKILL.md 의 `pnpm` 호출은 `crawl:docs` · `validate:draft` · `tokens:build` · `validate:previews` · `build:og` · `dev` 뿐이다. 코퍼스 테스트는 CI 의 별도 스텝(`ci.yml:48-49`)에서만 돈다.

즉 **실패는 온보딩 세션이 아니라 PR 이 열린 뒤 빨간 체크로 처음 나타난다.** 안내를 "이 센티널이 찍히면" 형태로 쓰면 거짓이 된다. Stage 10 에 **결정론적 스텝**으로 넣어 나쁜 상태가 배포되기 전에 잡는다.

Stage 10 을 고른 이유는 코퍼스 테스트가 슬러그를 `public/preview` 디렉터리로 열거하기 때문이다 — 그 스테이지의 `cp` 가 실행되는 순간부터 `MATCH_FLOOR` 행을 요구한다.

**닫는 문장은 기존 두 서브섹션과 다르다.** 저 둘은 "Stage 9a 로 되돌아가라"로 끝나는데, 이 수정은 `src/lib/` 편집이라 스킬의 쓰기 허용 범위 밖이다(SKILL.md 의 "What this skill must NOT do"). Stage 8 이 이미 쓰는 하우스 문구("a human operator running the skill by hand may instead fix the section directly")를 재사용했다.

### 9a2 의 `oklch coverage` 지표는 이걸 못 잡는다

SKILL.md 가 9a2 에서 `oklch coverage`(`matched/total`)를 낸다고 적어, 다음 읽는 사람이 이미 커버된다고 오해하기 쉽다. 실제로 `coverage()` 는 design.md 의 OKLCH **값**을 HTML 안에서 부분문자열로 찾을 뿐 커스텀 속성 **이름**을 보지 않고, `preview-validator.ts` 는 `oklch-drift` 를 import 하지도 않는다.

**완전히 네임스페이스된 프리뷰가 9a2 에서 oklch coverage 100% 를 받고도 드리프트 게이트에서 0건일 수 있다.** 새 산문이 이걸 명시한다.

## 부수 수정 — 숫자를 얻을 방법이 없었다

`MATCH_FLOOR` 에 기록할 실측값을 알려주는 명령이 없었다. "표에 없다" 단언은 이름만 말하고, 0 을 적으면 다른 단언(`bezier` 만 0 허용)이 막는다. 안내만 넣으면 사람이 숫자를 구할 수 없다.

실패 메시지가 측정값을 함께 내도록 고쳤다 — 테스트가 이미 계산하고 있었다:

```
these slugs have no entry in MATCH_FLOOR: toss (matches 27 today). Record that count.
A count of 0 means PREVIEW_TOKEN_ALIASES in oklch-drift.ts has no rule for this
preview's naming — add the rule first, then re-read the number.
```

## 계약 테스트

**양 끝을 다 고정한다** — 문서가 두 표를 부르는지, 그리고 그 표들이 그 이름으로 실재하는지. 후자가 없으면 `src/lib` 리네임이 스킬 산문을 존재하지 않는 심볼을 가리킨 채로 남긴다.

SKILL.md 수정 **전에** 올려 실패를 확인했다.

## 안전 확인

- `machine-gate.test.ts` 의 rule-id 누출 가드는 `preview-validator.ts` 에서 id 를 뽑는다. `PREVIEW_TOKEN_ALIASES` · `MATCH_FLOOR` · `oklch-drift.ts` 는 그 목록에 없어 안전하다.
- 같은 파일의 `/100\s?K(B|iB)/i` 금지에 걸리지 않게 새 산문에 그 형태를 쓰지 않았다.
- SKILL.md 에는 스테이지 개수·인접성을 세는 단언이 없어 서브섹션 추가가 기존 테스트를 깨지 않는다.

## 검증

`pnpm typecheck` · `lint` · `test`(520) · `validate:catalog` · `validate:previews` · `audit:oklch` · `tokens:check` 전부 통과.

메시지 변경은 `MATCH_FLOOR` 에서 `toss` 를 빼고 돌려 `toss (matches 27 today)` 가 실제로 찍히는 것을 확인했다.
