### PR TITLE
feat(validate): 정부 식별자 미표시를 block 으로 승격한다 (#214)

### DIFF
--- a/.claude/agents/preview-html-author.md
+++ b/.claude/agents/preview-html-author.md
@@ -96,6 +96,28 @@ qualification about a named company or product, the caption must say that
 assertion is demonstration data. Write the caption by reading the block's rendered
 text, not by recalling what you put there.
 
+**Government identity is its own axis, and the caption has to share a container
+with it.** A design system may document the national emblem, the wordmark
+`대한민국정부`, or the official-site banner (`공식 전자정부 누리집`) as components,
+and a preview that removes them stops demonstrating what it exists to show — so
+render them. But this file is a standalone, indexable page hosted by a site that
+is not the government, and an uncaptioned identifier makes it read as an official
+one. Caption it the way you caption any fabricated block, with one extra
+requirement: the caption must sit **inside the same element as the identifier**,
+not merely somewhere on the page. A caption that is a following sibling under
+`<body>` labels nothing — the reader meets the government sentence and passes no
+qualifier. The emblem needs this even though it renders no text of its own, and
+so does an identifier that lives only in an attribute such as `alt`, because a
+screen reader announces it and a crawler indexes it.
+
+One thing must not be captioned: a line that states, truthfully, who publishes
+the design system, or that this screen is the catalog's unofficial reproduction.
+Calling that a display sample would write a falsehood. Mark it
+`class="catalog-attribution"` instead — that class says "this sentence answers
+the question by being accurate", and the deterministic gate accepts it in place
+of a caption. Use it only for statements that are actually true; it is not an
+escape hatch for an identifier you did not want to caption.
+
 ## Required body composition
 
 In this order:

--- a/.claude/agents/preview-html-author.md
+++ b/.claude/agents/preview-html-author.md
@@ -103,9 +103,12 @@ and a preview that removes them stops demonstrating what it exists to show — s
 render them. But this file is a standalone, indexable page hosted by a site that
 is not the government, and an uncaptioned identifier makes it read as an official
 one. Caption it the way you caption any fabricated block, with one extra
-requirement: the caption must sit **inside the same element as the identifier**,
-not merely somewhere on the page. A caption that is a following sibling under
-`<body>` labels nothing — the reader meets the government sentence and passes no
+requirement: the caption must sit **inside the same container as the identifier**
+— some element other than `<body>` that holds both — not merely somewhere on the
+page. They do not have to be siblings and the caption does not have to be inside
+the identifier's own tag; any shared enclosing element counts. What does not
+count is `<body>` itself, so a caption that is a following sibling at the top
+level labels nothing — the reader meets the government sentence and passes no
 qualifier. The emblem needs this even though it renders no text of its own, and
 so does an identifier that lives only in an attribute such as `alt`, because a
 screen reader announces it and a crawler indexes it.

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -458,7 +458,7 @@ describe("validatePreviewPair — government identifiers", () => {
     '<div class="gov-strip">이 누리집은 대한민국 공식 전자정부 누리집입니다.</div>' +
     '<main class="hero"><h1>데모</h1></main>'
 
-  it("warns when a government identifier carries no dummy-data caption", () => {
+  it("blocks a government identifier that carries no dummy-data caption", () => {
     const input = makeInput({
       lightRaw: makeHtml({ body: GOV_BODY }),
       darkRaw: makeHtml({ theme: "dark", body: GOV_BODY }),
@@ -551,7 +551,7 @@ describe("validatePreviewPair — government identifiers", () => {
   // the file carries the claim just as plainly. The old raw-string search
   // caught these by accident; reading only text nodes would have narrowed the
   // rule silently.
-  it("counts an identifier that only appears in an attribute value", () => {
+  it("blocks an identifier that only appears in an attribute value", () => {
     const inAlt =
       '<img src="/logos/demo.svg" alt="대한민국정부 상징">' +
       '<main class="hero"><h1>데모</h1></main>'
@@ -584,7 +584,7 @@ describe("validatePreviewPair — government identifiers", () => {
   // around it. It has no container, so no caption can ever share an ancestor
   // with it — which is exactly why an ancestor-based rule can skip it by
   // accident. It must be reported, not ignored for lack of a node to blame.
-  it("warns on an identifier in bare text directly under body", () => {
+  it("blocks an identifier in bare text directly under body", () => {
     const bare =
       "이 누리집은 대한민국 공식 전자정부 누리집입니다." +
       '<main class="hero"><h1>데모</h1></main>'
@@ -619,7 +619,7 @@ describe("validatePreviewPair — government identifiers", () => {
   // presence check (`html.includes(DUMMY_CAPTION_CLASS)`) was already true
   // because of the first caption, so the rule stayed silent on the second,
   // uncaptioned identifier — exactly the case it exists to catch.
-  it("warns when one identifier is captioned and another is not", () => {
+  it("blocks when one identifier is captioned and another is not", () => {
     const twoIdentifiersOneCaption =
       '<div class="gov-strip">이 누리집은 대한민국 공식 전자정부 누리집입니다.</div>' +
       '<p class="catalog-dummy">위 문장은 표시 예시입니다.</p>' +
@@ -640,7 +640,7 @@ describe("validatePreviewPair — government identifiers", () => {
   // inside the caption) against 1 caption, and warns on a preview that is
   // already correctly captioned. The caption's inner text must be excluded
   // from the identifier count before comparing against the caption count.
-  it("does not warn when the caption's own prose names the identifier it labels", () => {
+  it("does not block when the caption's own prose names the identifier it labels", () => {
     const body =
       "<section>" +
       '<span class="wordmark">대한민국정부</span>' +
@@ -697,7 +697,7 @@ describe("validatePreviewPair — government identifiers", () => {
   // and was itself replaced by #214: the walk parses attributes, so the class
   // is a token in a list rather than a substring in a string, and quote style
   // stops being a variable at all. Three mechanisms, one behaviour — this must
-  // warn exactly like the plain `class="seal"` case above.
+  // block exactly like the plain `class="seal"` case above.
   it("counts a seal written as part of a class list the same as a bare seal class", () => {
     const body =
       '<div class="seal brand-mark" aria-hidden="true"><img src="/logos/demo.svg" alt=""></div>' +
@@ -720,8 +720,8 @@ describe("validatePreviewPair — government identifiers", () => {
   // vanished from both); the structural rule cannot repeat that, because
   // `.catalog-disclaimer` is simply not one of the two classes that make a
   // label host. The fixture stays either way: this markup has no
-  // `.catalog-dummy` anywhere, so the rule must warn.
-  it("warns when a government identifier appears only inside the disclosure banner's own prose", () => {
+  // `.catalog-dummy` anywhere, so the rule must block.
+  it("blocks a government identifier that appears only inside the disclosure banner's own prose", () => {
     const disclaimerWithIdentifier =
       '<div class="catalog-disclaimer" role="note">이 카탈로그는 대한민국정부 누리집과 ' +
       "제휴·후원 관계가 없습니다. 표시된 정보는 레이아웃 시연용 더미 데이터입니다.</div>"

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -463,7 +463,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: GOV_BODY }),
       darkRaw: makeHtml({ theme: "dark", body: GOV_BODY }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   it("accepts a government identifier captioned inside the same container", () => {
@@ -477,13 +479,13 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: captioned }),
       darkRaw: makeHtml({ theme: "dark", body: captioned }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
 
   it("leaves previews with no government identifier alone", () => {
-    expect(rulesOf(makeInput(), "warn")).not.toContain(
+    expect(rulesOf(makeInput(), "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -502,7 +504,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: siblings }),
       darkRaw: makeHtml({ theme: "dark", body: siblings }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   // services/krds.md:486 makes the footer the one sanctioned slot for source
@@ -520,7 +524,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: attributed }),
       darkRaw: makeHtml({ theme: "dark", body: attributed }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -537,7 +541,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: nested }),
       darkRaw: makeHtml({ theme: "dark", body: nested }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -555,7 +559,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: inAlt }),
       darkRaw: makeHtml({ theme: "dark", body: inAlt }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   it("accepts an attribute identifier captioned in the same container", () => {
@@ -569,7 +575,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: captioned }),
       darkRaw: makeHtml({ theme: "dark", body: captioned }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -586,7 +592,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: bare }),
       darkRaw: makeHtml({ theme: "dark", body: bare }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   // The other half of the scope change: the old check searched the raw file, so
@@ -600,7 +608,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: inStyle }),
       darkRaw: makeHtml({ theme: "dark", body: inStyle }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -621,7 +629,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body: twoIdentifiersOneCaption }),
       darkRaw: makeHtml({ theme: "dark", body: twoIdentifiersOneCaption }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   // The self-reference case: a caption's own prose names the identifier it is
@@ -641,7 +651,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body }),
       darkRaw: makeHtml({ theme: "dark", body }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -660,7 +670,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body }),
       darkRaw: makeHtml({ theme: "dark", body }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   it("accepts a masthead seal captioned inside the same container", () => {
@@ -674,7 +686,7 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body }),
       darkRaw: makeHtml({ theme: "dark", body }),
     })
-    expect(rulesOf(input, "warn")).not.toContain(
+    expect(rulesOf(input, "block")).not.toContain(
       "government-identifier-unlabelled"
     )
   })
@@ -694,7 +706,9 @@ describe("validatePreviewPair — government identifiers", () => {
       lightRaw: makeHtml({ body }),
       darkRaw: makeHtml({ theme: "dark", body }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
   // The disclosure banner is a fixed, page-level notice present in all 34
@@ -718,20 +732,39 @@ describe("validatePreviewPair — government identifiers", () => {
         disclaimer: disclaimerWithIdentifier,
       }),
     })
-    expect(rulesOf(input, "warn")).toContain("government-identifier-unlabelled")
+    expect(rulesOf(input, "block")).toContain(
+      "government-identifier-unlabelled"
+    )
   })
 
-  // warn on purpose: preview-html-author.md does not teach this axis yet, so a
-  // block would leave the pipeline unable to satisfy its own Stage 9a2 gate.
-  // Promotion goes with the skill wiring, in a separate pre-agreement issue.
-  it("is a warn, not a block", () => {
+  // This shipped as a warn on purpose: a block would have left the pipeline
+  // unable to satisfy its own Stage 9a2 gate, because preview-html-author.md
+  // said nothing about government identity and no author could fix what it had
+  // never been told. Both halves of that transition are done — the prompt now
+  // teaches the axis and `public/preview` is at zero occurrences — so the two
+  // assertions live in one test. If the guidance is ever stripped back out of
+  // the author, this fails here rather than silently on the next onboarding.
+  it("blocks, and the author prompt it depends on teaches the axis", () => {
     const input = makeInput({
       lightRaw: makeHtml({ body: GOV_BODY }),
       darkRaw: makeHtml({ theme: "dark", body: GOV_BODY }),
     })
-    expect(rulesOf(input, "block")).not.toContain(
+    expect(rulesOf(input, "block")).toContain(
       "government-identifier-unlabelled"
     )
+
+    const author = readFileSync(
+      join(process.cwd(), ".claude/agents/preview-html-author.md"),
+      "utf8"
+    )
+    // The three literals the rule keys on, so the author can recognise them…
+    expect(author).toContain("대한민국정부")
+    expect(author).toContain("공식 전자정부 누리집")
+    // …the containment requirement, which is the whole structural rule…
+    expect(author).toContain("inside the same element as the identifier")
+    // …and the exemption, or an author faced with a true attribution has no
+    // move that is not a falsehood.
+    expect(author).toContain('class="catalog-attribution"')
   })
 })
 

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -761,7 +761,7 @@ describe("validatePreviewPair — government identifiers", () => {
     expect(author).toContain("대한민국정부")
     expect(author).toContain("공식 전자정부 누리집")
     // …the containment requirement, which is the whole structural rule…
-    expect(author).toContain("inside the same element as the identifier")
+    expect(author).toContain("inside the same container as the identifier")
     // …and the exemption, or an author faced with a true attribution has no
     // move that is not a falsehood.
     expect(author).toContain('class="catalog-attribution"')

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -967,7 +967,8 @@ function checkFile(
   // `block` on the first pass, unlike `missing-disclaimer-banner` (D-1) and
   // `government-identifier-unlabelled` (E), which both shipped at `warn` first
   // and were promoted once the author prompt taught their axis. Those two needed
-  // a transition because existing files violated them and the prompt was silent. Neither holds here: bucket E
+  // a transition because existing files violated them and the prompt was silent.
+  // Neither holds here: bucket E
   // removed the last occurrence, so `public/preview` is at zero, and the
   // pipeline has never prescribed this phrase — no author can emit it and then
   // be unable to fix itself against a Stage 9a2 block.

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -956,7 +956,7 @@ function checkFile(
   const unlabelled = unlabelledGovernmentIdentifiers(html)
   if (unlabelled.length > 0) {
     issues.push(
-      warn(
+      block(
         "government-identifier-unlabelled",
         name,
         `${name} renders ${unlabelled.length} government identifier(s) with no .${DUMMY_CAPTION_CLASS} caption anywhere under a shared ancestor — ${unlabelled.map((u) => `${u.what} in <${u.where}>`).join(", ")}. A standalone, indexable copy of this file would read as an official government page. Put the caption inside the same container as the identifier (a caption elsewhere in the document does not label it), or mark a genuine attribution with class="${ATTRIBUTION_CLASS}".`
@@ -965,9 +965,9 @@ function checkFile(
   }
 
   // `block` on the first pass, unlike `missing-disclaimer-banner` (D-1) and
-  // `government-identifier-unlabelled` (E), which both shipped at `warn` first.
-  // Those two needed a transition because existing files violated them and the
-  // author prompt did not yet teach the axis. Neither holds here: bucket E
+  // `government-identifier-unlabelled` (E), which both shipped at `warn` first
+  // and were promoted once the author prompt taught their axis. Those two needed
+  // a transition because existing files violated them and the prompt was silent. Neither holds here: bucket E
   // removed the last occurrence, so `public/preview` is at zero, and the
   // pipeline has never prescribed this phrase — no author can emit it and then
   // be unable to fix itself against a Stage 9a2 block.


### PR DESCRIPTION
Closes #214. **PR #255 의 뒷 절반** — 판정은 이미 옳고, 이제 게이트를 조인다.

## 왜 이제 승격할 수 있는가

이 규칙은 `warn` 으로 출발했고 그 이유가 코드에 적혀 있었다:

> warn on purpose: `preview-html-author.md` does not teach this axis yet, so a block would leave the pipeline unable to satisfy its own Stage 9a2 gate. Promotion goes with the skill wiring, in a separate pre-agreement issue.

즉 **작성자가 배운 적 없는 것을 고칠 수 없기 때문**이었다. 그 전제의 두 절반이 모두 해소됐다:

- `preview-html-author.md` 가 이제 그 축을 가르친다.
- `public/preview` 는 위반 **0건**이다(PR #255 의 krds 마크업 수정).

## author 프롬프트에 무엇을 가르쳤나

기존 "Fabricated data must be labelled" 절에 이어 붙였다 — 같은 캡션 관례의 한 갈래이기 때문이다.

- **세 리터럴**(`대한민국정부` · `공식 전자정부 누리집` · 정부상징)을 알아볼 수 있게 하고, 디자인 시스템이 컴포넌트로 문서화한 것이라 **지우지 말고 캡션하라**고 적었다.
- **구조 요건**: 캡션이 "식별자와 같은 요소 안"에 있어야 한다. `<body>` 아래 다음 형제인 캡션은 아무것도 라벨하지 않는다 — 읽는 사람이 정부 문장을 만나고 아무 단서도 지나치지 않는다.
- 텍스트를 안 그리는 **seal** 과 `alt` 같은 **속성 안**의 식별자도 대상임을 적었다(스크린리더가 읽고 크롤러가 색인한다).

**면제를 함께 가르치지 않으면 작성자에게 거짓말 외에 수가 없다.** 발행 주체를 사실대로 적은 문장이나 "이 화면은 카탈로그의 비공식 재현"은 "표시 예시"가 아니다 — 거기 캡션을 달면 거짓을 쓰는 것이다. `class="catalog-attribution"` 을 쓰라고 적고, **실제로 참인 문장에만** 쓰라는 단서도 달았다(캡션하기 싫은 식별자의 탈출구가 아니다).

## 테스트

D-1 선례(`missing-disclaimer-banner`)와 같은 형태다 — **block 단언과 author 프롬프트가 그 축을 가르치는지를 한 테스트에서** 본다. 배선이 한쪽만 남는 상태를 만들 수 없다.

```
it("blocks, and the author prompt it depends on teaches the axis", ...)
```

**음성 대조**: 프롬프트에서 `class="catalog-attribution"` 을 지우면 이 테스트가 실패한다(변이로 확인). 배선이 실제로 묶여 있다.

기존 정부 테스트 15건은 `rulesOf(input, "warn")` 을 보고 있어 severity 변경으로 전부 어긋난다 — block 으로 맞췄다.

## 안전 확인

- **rule-id 를 프롬프트에 넣지 않았다.** `design-md-skill-machine-gate.test.ts` 가 `preview-validator.ts` 에서 id 를 뽑아 네 개 문서에 새는지 검사하고, `preview-html-author.md` 가 그중 하나다. `government-identifier-unlabelled` 출현 횟수 0을 확인했고 계약 테스트 11건도 통과한다.
- `validate:previews` 가 **block 상태에서도 exit 0** 이다 — 코퍼스에 위반이 없다.

## 검증

`pnpm typecheck` · `lint` · `test`(527) · `validate:previews` · `validate:catalog` · `audit:oklch` · `tokens:check` 전부 통과.
