### PR TITLE
feat(seo): 페이지별 검색 메타데이터를 추가한다

### DIFF
--- a/docs/superpowers/plans/2026-08-10-page-seo.md
+++ b/docs/superpowers/plans/2026-08-10-page-seo.md
@@ -1,0 +1,402 @@
+# 페이지 SEO Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 공개 HTML 페이지에 고유한 SEO 메타데이터, canonical URL, 구조화 데이터와 404 색인 방지를 제공한다.
+
+**Architecture:** `src/lib/seo.ts`가 페이지별 title, description, canonical, Open Graph/Twitter, JSON-LD를 생성하는 순수 경계가 된다. 각 TanStack Router 파일은 이 경계가 반환한 `meta`와 `links`를 head에 연결하고, 서비스 탭은 기본 URL을 정규 주소로 유지한다.
+
+**Tech Stack:** React 19, TypeScript 6, TanStack Start/Router 1, Vite 8, Vitest 4, ESLint 10.
+
+## Global Constraints
+
+- production origin은 기존 `src/lib/site-config.ts`의 `VITE_SITE_URL`과 `absoluteUrl()`만 사용한다.
+- 홈 title은 `한국 서비스 디자인 시스템 카탈로그 | ko/design.md`다.
+- 서비스 title은 `{서비스명} 디자인 시스템·토큰 | ko/design.md`다.
+- 서비스의 기본 주소는 `/services/:slug`이고 `tab`은 색인 대상이 아닌 UI 상태다.
+- 404와 `tab` 쿼리 URL은 `robots: noindex,follow`를 사용한다.
+- JSON-LD에는 화면에서 확인 가능한 값만 넣으며, 보이지 않는 breadcrumb·평점·저자 정보는 추가하지 않는다.
+- sitemap은 canonical HTML URL만 유지하고 RSS, robots, `llms.txt`의 역할은 변경하지 않는다.
+- 다른 사람이 준비한 staged 변경은 작업 범위 밖이다. SEO 관련 파일만 명시적으로 stage하며, 커밋·push·배포는 사용자 승인 후에만 수행한다.
+
+---
+
+## 파일 구조
+
+- Create: `src/lib/seo.ts` — 페이지별 SEO head 모델과 JSON-LD 생성 함수.
+- Create: `src/lib/seo.test.ts` — SEO 모델의 title, canonical, robots, JSON-LD 계약 테스트.
+- Create: `src/routes/seo-head.test.ts` — 실제 라우트 head가 모델을 SSR 메타로 연결하는지 검증.
+- Modify: `src/routes/__root.tsx` — 전역 문서 자산은 유지하고, 정상 페이지의 기본 SEO 중복을 제거하며 404 head를 선택.
+- Modify: `src/routes/index.tsx` — 홈페이지 head를 연결.
+- Modify: `src/routes/services/$slug.tsx` — 서비스 head, 탭 URL 정규화, 탭 `noindex`를 연결.
+- Modify: `src/lib/seo-feed.ts` — sitemap과 RSS가 공유 canonical 경로 함수를 사용하도록 연결.
+- Modify: `src/lib/seo-feed.test.ts` — sitemap URL이 서비스 canonical URL 계약을 유지하는지 확인.
+- Create: `docs/superpowers/specs/2026-08-10-page-seo-design.md` — 이미 작성된 승인 설계 문서.
+
+## Task 1: 순수 SEO 모델과 계약 테스트
+
+**Files:**
+
+- Create: `src/lib/seo.ts`
+- Create: `src/lib/seo.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ServiceDoc`, `truncateForMeta`, `absoluteUrl`.
+- Produces: `serviceCanonicalPath(slug)`, `buildHomeSeo()`, `buildServiceSeo(doc, options)`, `buildNotFoundSeo()`.
+- Produces: TanStack Router `head`가 그대로 사용할 `{ meta, links }` 객체. JSON-LD는 TanStack의 `"script:ld+json"` 메타 키로 전달한다.
+
+- [ ] **Step 1: 실패하는 SEO 모델 테스트를 작성한다.**
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  buildHomeSeo,
+  buildNotFoundSeo,
+  buildServiceSeo,
+} from "./seo"
+import type { ServiceDoc } from "./content-types"
+
+const tossDoc = {
+  frontmatter: {
+    name: "Toss",
+    slug: "toss",
+    category: "finance",
+    last_updated: "2026-08-10",
+    sources: [],
+    related_services: [],
+    lang: "ko",
+  },
+  raw: "# Toss",
+  body: "Toss design system",
+  tagline: "금융 서비스 디자인 시스템과 토큰을 정리한 문서입니다.",
+  filePath: "/services/toss.md",
+  estimatedTokens: 10,
+} satisfies ServiceDoc
+
+it("builds one canonical, title, description, and WebSite graph for home", () => {
+  const head = buildHomeSeo()
+  expect(head.meta).toContainEqual({
+    title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
+  })
+  expect(head.links).toContainEqual({ rel: "canonical", href: "/" })
+  expect(head.meta).toContainEqual(
+    expect.objectContaining({ "script:ld+json": expect.any(Object) })
+  )
+})
+
+it("canonicalizes every service tab and noindexes only query-state views", () => {
+  expect(buildServiceSeo(tossDoc, { isTabView: false }).links).toContainEqual({
+    rel: "canonical",
+    href: "/services/toss",
+  })
+  expect(buildServiceSeo(tossDoc, { isTabView: true }).meta).toContainEqual({
+    name: "robots",
+    content: "noindex,follow",
+  })
+})
+
+it("makes a 404 indexable by neither title nor robots", () => {
+  const head = buildNotFoundSeo()
+  expect(head.meta).toContainEqual({
+    title: "페이지를 찾을 수 없습니다 | ko/design.md",
+  })
+  expect(head.meta).toContainEqual({ name: "robots", content: "noindex,follow" })
+  expect(head.links).toHaveLength(0)
+})
+```
+
+- [ ] **Step 2: 테스트가 실패하는지 확인한다.**
+
+Run: `pnpm test -- src/lib/seo.test.ts`
+
+Expected: FAIL because `./seo` and its exported functions do not exist.
+
+- [ ] **Step 3: 최소 SEO 모델을 구현한다.**
+
+```ts
+export function buildServiceSeo(
+  doc: ServiceDoc,
+  options: { isTabView: boolean }
+) {
+  const canonical = absoluteUrl(serviceCanonicalPath(doc.frontmatter.slug))
+  const title = `${doc.frontmatter.name} 디자인 시스템·토큰 | ko/design.md`
+  const description = truncateForMeta(doc.tagline) || doc.frontmatter.name
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      ...(options.isTabView
+        ? [{ name: "robots", content: "noindex,follow" }]
+        : []),
+      { property: "og:url", content: canonical },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { "script:ld+json": articleJsonLd(doc, canonical, title, description) },
+    ],
+    links: [{ rel: "canonical", href: canonical }],
+  }
+}
+
+export function serviceCanonicalPath(slug: string) {
+  return `/services/${slug}`
+}
+```
+
+`buildHomeSeo()`는 홈페이지 고정 title/description, `og:type: website`, 기본 OG 이미지,
+`WebSite`와 `CollectionPage` graph를 반환한다. `buildServiceSeo()`는 서비스별 OG 이미지와
+`Article` JSON-LD(`headline`, `description`, `image`, `dateModified`, `inLanguage`,
+`mainEntityOfPage`)를 반환하고 `created_at`이 있으면 `datePublished`만 추가한다.
+`buildNotFoundSeo()`는 404 title과 `noindex,follow`만 반환하며 canonical과 OG는 반환하지 않는다.
+
+- [ ] **Step 4: 모델 테스트를 통과시킨다.**
+
+Run: `pnpm test -- src/lib/seo.test.ts`
+
+Expected: PASS. 테스트는 홈페이지 graph의 `WebSite`/`CollectionPage`, 서비스 `Article`의
+canonical·수정일·이미지, 빈 tagline fallback, 탭 robots, 404 canonical 부재도 각각 확인한다.
+
+- [ ] **Step 5: 승인 후 이 작업만 커밋한다.**
+
+```powershell
+git add src/lib/seo.ts src/lib/seo.test.ts
+git commit -m "feat(seo): add page metadata builders"
+```
+
+커밋 전 `git diff --cached -- src/lib/seo.ts src/lib/seo.test.ts`로 staged 범위가 두 파일뿐인지
+확인한다. 현재 작업 트리에 있는 기존 staged 변경은 포함하지 않는다.
+
+## Task 2: 홈페이지와 서비스 라우트에 SEO 정책을 연결한다
+
+**Files:**
+
+- Modify: `src/routes/index.tsx`
+- Modify: `src/routes/services/$slug.tsx`
+- Create: `src/routes/seo-head.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1의 `buildHomeSeo()`와 `buildServiceSeo(doc, { isTabView })`.
+- Produces: 홈페이지와 서비스 상세의 SSR `head`; 쿼리 없는 기본 서비스 URL; `tab` URL의
+  `noindex,follow`.
+
+- [ ] **Step 1: 라우트 head와 탭 정규화의 실패 테스트를 작성한다.**
+
+```ts
+import { Route as HomeRoute } from "./index"
+import { Route as ServiceRoute } from "./services/$slug"
+import { getServiceBySlug } from "@/lib/content-collection"
+
+const tossDoc = getServiceBySlug("toss")!
+
+it("uses homepage metadata on the index route", () => {
+  const head = HomeRoute.options.head?.({} as never)
+  expect(head?.links).toContainEqual({ rel: "canonical", href: "/" })
+})
+
+it("keeps the default detail tab out of search and noindexes a tab query", () => {
+  expect(ServiceRoute.options.validateSearch?.({})).toEqual({ tab: undefined })
+  const head = ServiceRoute.options.head?.({
+    loaderData: { doc: tossDoc, shikiHtml: "", previewAvailable: true },
+    match: { search: { tab: "tokens" } },
+  } as never)
+  expect(head?.meta).toContainEqual({ name: "robots", content: "noindex,follow" })
+})
+```
+
+- [ ] **Step 2: 테스트가 실패하는지 확인한다.**
+
+Run: `pnpm test -- src/routes/seo-head.test.ts`
+
+Expected: FAIL because the index route has no `head`, the default search currently becomes
+`tab: "preview"`, and the service route does not emit canonical/robots metadata.
+
+- [ ] **Step 3: 라우트 head와 기본 탭 URL을 구현한다.**
+
+```ts
+type DetailTab = "preview" | "tokens" | "md"
+type DetailSearch = { tab?: DetailTab }
+
+function parseTab(value: unknown): DetailTab | undefined {
+  if (value === "tokens" || value === "md" || value === "preview") return value
+  return undefined
+}
+
+const activeTab = search.tab ?? "preview"
+
+navigate({
+  search: value === "preview" ? {} : { tab: parseTab(value) },
+  replace: true,
+  resetScroll: false,
+})
+```
+
+Add `head: () => buildHomeSeo()` to the index route. In the service route, build the head from
+`loaderData.doc` and set `isTabView` when `match.search.tab` is present. Pass `activeTab` to the
+existing layout so its props remain the concrete `DetailTab` union. Replace the existing broken
+title separator through `buildServiceSeo()`; do not retain duplicate hand-written title or OG tags.
+
+- [ ] **Step 4: 라우트 SEO 테스트를 통과시킨다.**
+
+Run: `pnpm test -- src/routes/seo-head.test.ts src/lib/seo.test.ts`
+
+Expected: PASS. The test also asserts that `preview`, `tokens`, and `md` all use
+`/services/toss` as canonical, while only query-state tabs receive `noindex,follow`.
+
+- [ ] **Step 5: 승인 후 이 작업만 커밋한다.**
+
+```powershell
+git add src/routes/index.tsx "src/routes/services/$slug.tsx" src/routes/seo-head.test.ts
+git commit -m "feat(seo): add canonical service page metadata"
+```
+
+커밋 전 위 세 파일만 stage되었는지 확인한다.
+
+## Task 3: 404 head와 sitemap canonical 계약을 보강한다
+
+**Files:**
+
+- Modify: `src/routes/__root.tsx`
+- Modify: `src/routes/seo-head.test.ts`
+- Modify: `src/lib/seo-feed.ts`
+- Modify: `src/lib/seo-feed.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1의 `buildNotFoundSeo()`와 `buildServiceSeo()`.
+- Produces: root-level not-found 상태의 전용 SSR head와 sitemap의 canonical-only 계약.
+
+- [ ] **Step 1: 404와 sitemap의 실패 테스트를 추가한다.**
+
+```ts
+import { Route as RootRoute } from "./__root"
+
+it("uses noindex 404 metadata when the root match is a global not-found", () => {
+  const head = RootRoute.options.head?.({
+    matches: [{ status: "success", globalNotFound: true }],
+  } as never)
+  expect(head?.meta).toContainEqual({
+    title: "페이지를 찾을 수 없습니다 | ko/design.md",
+  })
+  expect(head?.meta).toContainEqual({ name: "robots", content: "noindex,follow" })
+})
+```
+
+`src/lib/seo-feed.test.ts`에는 기존 `docs`, `SITE_URL`, `buildSitemapXml` fixture를 재사용하고
+다음 import와 테스트를 추가한다.
+
+```ts
+import { serviceCanonicalPath } from "./seo"
+
+it("lists the same clean URL that the shared canonical path marks indexable", () => {
+  const path = serviceCanonicalPath(docs[0].frontmatter.slug)
+  const xml = buildSitemapXml({ siteUrl: SITE_URL, services: docs })
+  expect(xml).toContain(`<loc>https://ko-design.example${path}</loc>`)
+})
+```
+
+- [ ] **Step 2: 테스트가 실패하는지 확인한다.**
+
+Run: `pnpm test -- src/routes/seo-head.test.ts src/lib/seo-feed.test.ts`
+
+Expected: FAIL because the root head always emits homepage metadata for unknown URLs and there is
+no shared canonical contract assertion.
+
+- [ ] **Step 3: root의 기본/404 head를 분리하고 sitemap 계약을 연결한다.**
+
+```ts
+head: ({ matches }) => {
+  const isNotFound = matches.some(
+    (match) => match.status === "notFound" || match.globalNotFound
+  )
+  if (isNotFound) return buildNotFoundSeo()
+
+  return {
+    meta: [
+      { charSet: "utf-8" },
+      { name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" },
+      { name: "theme-color", content: "#141414" },
+    ],
+    links: DOCUMENT_LINKS,
+  }
+}
+```
+
+루트 파일 상단에 기존 stylesheet, favicon, Apple touch icon, RSS alternate link를 담은
+`const DOCUMENT_LINKS = [...]`를 선언한다. 홈페이지 전용 title, description, OG, Twitter 태그를
+root에서 제거하여 404가 상속하지 않게 한다. `src/lib/seo-feed.ts`는
+`serviceCanonicalPath(doc.frontmatter.slug)`를 사용해 sitemap과 RSS의 서비스 URL을 조합하고,
+`?tab=` URL은 생성하지 않는다.
+
+- [ ] **Step 4: 404와 sitemap 테스트를 통과시킨다.**
+
+Run: `pnpm test -- src/routes/seo-head.test.ts src/lib/seo-feed.test.ts`
+
+Expected: PASS. The root normal state exposes no page title itself, global and nested not-found
+states expose only 404 SEO metadata, and sitemap continues to exclude every `?tab=` URL.
+
+- [ ] **Step 5: 승인 후 이 작업만 커밋한다.**
+
+```powershell
+  git add src/routes/__root.tsx src/routes/seo-head.test.ts src/lib/seo-feed.ts src/lib/seo-feed.test.ts
+git commit -m "fix(seo): noindex not found pages"
+```
+
+커밋 전 `git diff --cached`에 이전의 대규모 staged 변경이 섞이지 않았는지 확인한다.
+
+## Task 4: 전체 검증과 배포 인계 항목을 확인한다
+
+**Files:**
+
+- Modify: 없음 — 아래 검증에서 실패하면 해당 파일 소유 Task로 돌아가 원인을 수정한 뒤 이
+  Task를 처음부터 다시 실행한다.
+
+**Interfaces:**
+
+- Consumes: Tasks 1–3의 SEO 모델, route heads, sitemap 계약.
+- Produces: 로컬 검증 증거와 단일 배포 호스트 정규화에 필요한 운영 인계 목록.
+
+- [ ] **Step 1: 관련 단위·라우트 테스트를 실행한다.**
+
+Run: `pnpm test -- src/lib/seo.test.ts src/routes/seo-head.test.ts src/lib/seo-feed.test.ts`
+
+Expected: PASS with no skipped SEO assertion.
+
+- [ ] **Step 2: 정적 검사와 production build를 실행한다.**
+
+```powershell
+$env:VITE_SITE_URL = "https://getdesign.kr"
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+Expected: all commands exit 0. `VITE_SITE_URL` must be the selected canonical production host;
+the deployment owner must replace it if `www.getdesign.kr` is selected instead.
+
+- [ ] **Step 3: build 산출물을 통해 공개 URL을 smoke test한다.**
+
+```powershell
+pnpm preview -- --host 127.0.0.1 --port 4173
+```
+
+In a second shell, request `/`, `/services/toss`, `/services/toss?tab=tokens`, and an unknown path.
+Confirm the first two have one title, description, canonical, and JSON-LD; the tab and unknown path
+have `noindex,follow`; and the unknown path is HTTP 404. Stop the preview server after recording the
+result.
+
+- [ ] **Step 4: deployment owner에게 남길 운영 확인 항목을 기록한다.**
+
+Confirm that the non-preferred one of `getdesign.kr` and `www.getdesign.kr` responds with a 301 to
+the preferred host. Confirm `VITE_SITE_URL`, canonical, OG URLs, sitemap, and RSS use that same
+host. Run Google Rich Results Test and Search Console URL Inspection after deployment; these two
+external operations are not performed by this plan without authorization.
+
+- [ ] **Step 5: 커밋 범위를 검토한다.**
+
+Tasks 1–3의 커밋은 각 Task의 승인 단계에서 생성한다. 이 Task에서는 추가 커밋을 만들지 않는다.
+`git status --short`와 `git log -3 --oneline`을 확인해 SEO 커밋 외에 기존 staged 변경이 포함되지
+않았는지 기록한다.

--- a/docs/superpowers/specs/2026-08-10-page-seo-design.md
+++ b/docs/superpowers/specs/2026-08-10-page-seo-design.md
@@ -1,0 +1,104 @@
+# 페이지 SEO 설계
+
+## 목적
+
+`ko/design.md`의 공개 HTML 페이지가 페이지별로 고유하고 일관된 검색 신호를
+제공하도록 한다. 범위는 홈페이지, 서비스 상세 페이지, 서비스 탭 URL, 404 페이지와
+검색 엔드포인트의 URL 일관성이다.
+
+## 성공 기준
+
+- 홈페이지와 모든 서비스 상세 페이지가 고유한 title, description, canonical URL을
+  서버 렌더링 HTML에 포함한다.
+- UI 상태인 서비스 탭 URL은 검색 결과의 별도 문서로 색인되지 않는다.
+- 404 응답은 홈페이지 메타데이터를 상속하지 않으며 `noindex,follow`를 제공한다.
+- sitemap의 각 URL은 색인할 페이지의 canonical URL과 정확히 일치한다.
+- 구조화 데이터는 실제 화면에 표시되는 값만 표현한다.
+
+## 페이지별 메타데이터 정책
+
+### 홈페이지 (`/`)
+
+- Title: `한국 서비스 디자인 시스템 카탈로그 | ko/design.md`
+- Description: 한국 서비스 디자인 시스템의 규칙과 디자인 토큰을 AI에 바로 전달할 수
+  있는 `design.md` 카탈로그라는 현재 제품 설명을 사용한다.
+- Canonical: `${SITE_URL}/`
+- Open Graph/Twitter: 홈페이지 title, description, 기본 OG 이미지와 같은 canonical URL을
+  사용한다.
+- JSON-LD: 사이트명, URL, 한국어를 표현하는 `WebSite`와 카탈로그 성격을 표현하는
+  `CollectionPage`를 제공한다.
+
+### 서비스 상세 (`/services/:slug`)
+
+- Title: `{서비스명} 디자인 시스템·토큰 | ko/design.md`
+- Description: 서비스 문서의 `tagline`을 평문으로 정리하고 메타 길이 제한을 적용한다.
+- Canonical: `${SITE_URL}/services/:slug`이며 쿼리 문자열은 포함하지 않는다.
+- Open Graph/Twitter: title, description, 서비스별 OG 이미지와 canonical URL을 같은 값으로
+  사용한다.
+- JSON-LD: 화면에 표시되는 서비스명, 설명, OG 이미지, 수정일, 언어와 canonical URL만으로
+  `Article`을 구성한다. 저자, 평점, breadcrumb처럼 근거 또는 화면 표현이 없는 값은
+  추가하지 않는다.
+- 현재 제목의 손상된 구분문자는 ASCII `|`로 교체한다.
+
+### 서비스 탭 URL (`?tab=preview|tokens|md`)
+
+- 기본 프리뷰는 쿼리 없는 `/services/:slug`를 정규 URL로 사용한다.
+- `tokens`와 `md`는 같은 문서 안의 UI 상태이므로 canonical을 기본 상세 URL로 고정하고
+  `robots`를 `noindex,follow`로 설정한다.
+- 라우트의 검색 파라미터 기본값을 렌더링 시 적용해, 쿼리 없는 기본 URL이 자동으로
+  `?tab=preview`로 리다이렉트되지 않게 한다.
+
+### 404
+
+- Title: `페이지를 찾을 수 없습니다 | ko/design.md`
+- Description와 OG 메타데이터는 홈페이지 값을 재사용하지 않는다.
+- Robots: `noindex,follow`
+- 응답 상태는 현재처럼 HTTP 404를 유지한다.
+
+## 구성과 데이터 흐름
+
+`src/lib/seo.ts`에 사이트 제목, 기본 설명, canonical URL, OG/Twitter 메타데이터,
+JSON-LD를 생성하는 순수 헬퍼를 둔다. `src/lib/site-config.ts`의 `SITE_URL`과
+`absoluteUrl()`을 유일한 origin 입력으로 사용한다.
+
+- 루트 라우트는 전역 charset, viewport, favicon, 테마와 공유 기본값만 제공한다.
+- 홈페이지 라우트는 홈페이지 전용 head와 JSON-LD를 제공한다.
+- 서비스 상세 라우트는 loader의 `ServiceDoc`으로 서비스 전용 head와 JSON-LD를 제공한다.
+- 404 경로는 별도 head 정책을 선택해 색인 방지 메타데이터를 서버 렌더링한다.
+- sitemap 생성기는 canonical URL 규칙을 재사용하며, RSS·robots·`llms.txt`의 기존 역할은
+  변경하지 않는다.
+
+## 오류와 배포 경계
+
+- 서비스 문서를 찾지 못하면 기존 HTTP 404를 유지하고 404 SEO 정책을 적용한다.
+- `VITE_SITE_URL` 누락 시 production build를 실패시키는 현재 보호 장치를 유지한다.
+- 배포 환경에서는 `getdesign.kr` 또는 `www.getdesign.kr` 중 하나를 정해 다른 호스트를
+  301 리다이렉트해야 한다. `VITE_SITE_URL`, canonical, OG URL, sitemap과 RSS의 origin은
+  반드시 이 선호 호스트와 같아야 한다. 이 호스트 리다이렉트 설정은 배포 권한이 필요한
+  별도 운영 작업이다.
+
+## 검증 계획
+
+- SEO 헬퍼 단위 테스트: title, description, canonical, robots, JSON-LD의 입력별 출력을
+  확인한다.
+- 라우트 head 테스트: 홈, 서비스 상세, 세 탭 상태, 미존재 URL에서 SSR 메타데이터를
+  검증한다.
+- sitemap 테스트: 모든 색인 URL이 대응 페이지 canonical과 1:1인지 확인한다.
+- build 검증: production URL을 설정한 상태에서 타입 검사, 테스트, 린트, production build를
+  실행한다.
+- 배포 후: 단일 호스트 301, 실제 응답의 HTTP 상태와 head, Google Rich Results Test,
+  Search Console URL Inspection을 확인한다.
+
+## 제외 범위
+
+- 새 콘텐츠 랜딩 페이지, 키워드용 문서 작성, 보이지 않는 breadcrumb 마크업은 추가하지
+  않는다.
+- `llms.txt`는 Google SEO 표준 sitemap 항목이 아니므로 sitemap에 넣지 않는다.
+- 배포 호스트와 리다이렉트의 실제 변경은 별도 권한 없이는 수행하지 않는다.
+
+## 근거
+
+- [Google Search Central: 중복 URL 통합](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+- [Google Search Central: robots 메타 태그](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
+- [Google Search Central: 구조화 데이터 소개](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- [Google Search Central: title link 제어](https://developers.google.com/search/docs/appearance/title-link)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,17 +29,4 @@ export default [
       ],
     },
   },
-  // These files decode untyped values at an application boundary. Every other
-  // source file must model data with a concrete type instead of `unknown`.
-  {
-    files: [
-      "src/lib/content-collection.ts",
-      "src/lib/content-parser.ts",
-      "src/routes/index.tsx",
-      "src/routes/services/$slug.tsx",
-    ],
-    rules: {
-      "no-restricted-syntax": "off",
-    },
-  },
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,4 +16,30 @@ export default [
     ],
   },
   ...tanstackConfig,
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSUnknownKeyword",
+          message:
+            "Use a concrete type. `unknown` is only allowed at declared external-input boundaries.",
+        },
+      ],
+    },
+  },
+  // These files decode untyped values at an application boundary. Every other
+  // source file must model data with a concrete type instead of `unknown`.
+  {
+    files: [
+      "src/lib/content-collection.ts",
+      "src/lib/content-parser.ts",
+      "src/routes/index.tsx",
+      "src/routes/services/$slug.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
 ]

--- a/src/lib/content-collection.ts
+++ b/src/lib/content-collection.ts
@@ -13,17 +13,20 @@ const RAW_MODULES: Record<string, string> = import.meta.glob("/services/*.md", {
 // runtime cost is a Map lookup — no YAML/markdown parsing at request time. An
 // entry without a sidecar simply leaves `doc.tokens` undefined, and the detail
 // page renders no token-card section for it (graceful during rollout).
+// eslint-disable-next-line no-restricted-syntax -- Vite JSON module values are untyped external input.
 const TOKEN_MODULES: Record<string, unknown> = import.meta.glob(
   "/services/*.tokens.json",
   { import: "default", eager: true }
 )
 
+// eslint-disable-next-line no-restricted-syntax -- This function narrows a Vite JSON module value.
 function coerceServiceTokens(data: unknown, filePath: string): ServiceTokens {
   if (typeof data !== "object" || data === null) {
     throw new Error(
       `[content-collection] token sidecar ${filePath} must be a JSON object`
     )
   }
+  // eslint-disable-next-line no-restricted-syntax -- Narrowed JSON object fields remain untyped.
   const d = data as Record<string, unknown>
   for (const key of ["colors", "typography", "spacing", "radius"] as const) {
     if (d[key] !== undefined && !Array.isArray(d[key])) {
@@ -39,11 +42,14 @@ function coerceServiceTokens(data: unknown, filePath: string): ServiceTokens {
   // are all optional and land in `style={{ fontSize, lineHeight, … }}`, where an
   // invalid value is simply ignored by CSS (graceful degradation, not a silent
   // gap), so the asymmetry is intentional.
+  // eslint-disable-next-line no-restricted-syntax -- JSON array entries require field-level validation.
   for (const color of (d.colors as Array<unknown> | undefined) ?? []) {
     if (
       typeof color !== "object" ||
       color === null ||
+      // eslint-disable-next-line no-restricted-syntax -- Validates an untyped JSON name field.
       typeof (color as { name?: unknown }).name !== "string" ||
+      // eslint-disable-next-line no-restricted-syntax -- Validates an untyped JSON value field.
       typeof (color as { value?: unknown }).value !== "string"
     ) {
       throw new Error(

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -10,6 +10,7 @@ import type { ServiceDoc, ServiceFrontmatter } from "./content-types"
 // a typed validation pass on top to fail loudly when a contributor's frontmatter
 // would otherwise parse to defaults.
 interface MatterResult {
+  // eslint-disable-next-line no-restricted-syntax -- Frontmatter parsed from author-provided YAML is untyped.
   data: Record<string, unknown>
   content: string
 }
@@ -73,8 +74,10 @@ function splitOutsideQuotes(text: string): Array<string> {
   return out
 }
 
+// eslint-disable-next-line no-restricted-syntax -- YAML parsing starts from untyped scalar values.
 function parseYamlSubset(text: string): Record<string, unknown> {
   const lines = text.split(/\r?\n/)
+  // eslint-disable-next-line no-restricted-syntax -- YAML output is validated by downstream field coercion.
   const out: Record<string, unknown> = {}
   let i = 0
   while (i < lines.length) {
@@ -182,6 +185,7 @@ function isRealIsoDate(value: string): boolean {
 }
 
 export function normalizeDateField(
+  // eslint-disable-next-line no-restricted-syntax -- Frontmatter field values are untyped at the parse boundary.
   value: unknown,
   context = "",
   field = "last_updated"
@@ -264,6 +268,7 @@ function estimateTokens(raw: string): number {
 }
 
 function coerceNumberField(
+  // eslint-disable-next-line no-restricted-syntax -- Frontmatter field values are untyped at the parse boundary.
   value: unknown,
   field: string,
   context: string
@@ -287,6 +292,7 @@ function coerceNumberField(
 }
 
 function ensureStringArray(
+  // eslint-disable-next-line no-restricted-syntax -- Frontmatter field values are untyped at the parse boundary.
   value: unknown,
   field: string,
   context: string

--- a/src/lib/seo-feed.test.ts
+++ b/src/lib/seo-feed.test.ts
@@ -7,6 +7,7 @@ import {
   buildRssXml,
   buildSitemapXml,
 } from "./seo-feed"
+import { serviceCanonicalPath } from "./seo"
 import { getAllServices } from "./content-collection"
 import type { ServiceDoc } from "./content-types"
 
@@ -63,6 +64,13 @@ describe("buildSitemapXml", () => {
     expect(xml).toContain("<loc>https://ko-design.example/services/toss</loc>")
     expect(xml).toContain("<loc>https://ko-design.example/services/a-b</loc>")
     expect(xml).not.toContain("?tab=")
+  })
+
+  it("uses the shared indexable service path for sitemap URLs", () => {
+    const path = serviceCanonicalPath(docs[0].frontmatter.slug)
+    const xml = buildSitemapXml({ siteUrl: SITE_URL, services: docs })
+
+    expect(xml).toContain(`<loc>https://ko-design.example${path}</loc>`)
   })
 
   it("uses each service last_updated value as lastmod", () => {

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -1,4 +1,5 @@
 import { sortDocsByUpdated, truncateForMeta } from "./content-parser"
+import { serviceCanonicalPath } from "./seo"
 import type { ServiceDoc } from "./content-types"
 
 const SITE_TITLE = "ko/design.md"
@@ -65,7 +66,7 @@ export function buildSitemapXml({ siteUrl, services }: FeedInput): string {
     ...services.map((doc) =>
       [
         "  <url>",
-        `    <loc>${escapeXml(canonicalUrl(origin, `/services/${doc.frontmatter.slug}`))}</loc>`,
+        `    <loc>${escapeXml(canonicalUrl(origin, serviceCanonicalPath(doc.frontmatter.slug)))}</loc>`,
         doc.frontmatter.last_updated
           ? `    <lastmod>${escapeXml(doc.frontmatter.last_updated)}</lastmod>`
           : "",
@@ -93,7 +94,10 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
   // last_updated as its pubDate — so re-sort here rather than relying on the
   // caller, and keep the invariant local to the builder that owns feed semantics.
   const items = sortDocsByUpdated(services).map((doc) => {
-    const itemUrl = canonicalUrl(origin, `/services/${doc.frontmatter.slug}`)
+    const itemUrl = canonicalUrl(
+      origin,
+      serviceCanonicalPath(doc.frontmatter.slug)
+    )
     const updated = doc.frontmatter.last_updated
     const description = truncateForMeta(
       doc.tagline || doc.frontmatter.name,

--- a/src/lib/seo-feed.ts
+++ b/src/lib/seo-feed.ts
@@ -1,8 +1,8 @@
 import { sortDocsByUpdated, truncateForMeta } from "./content-parser"
 import { serviceCanonicalPath } from "./seo"
+import { SITE_NAME } from "./site-config"
 import type { ServiceDoc } from "./content-types"
 
-const SITE_TITLE = "ko/design.md"
 const SITE_DESCRIPTION =
   "한국 서비스의 시그니처 디자인을 design.md 한 장으로 정리한 카탈로그입니다."
 
@@ -121,7 +121,7 @@ export function buildRssXml({ siteUrl, services }: FeedInput): string {
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
     "  <channel>",
-    `    <title>${escapeXml(SITE_TITLE)}</title>`,
+    `    <title>${escapeXml(SITE_NAME)}</title>`,
     `    <link>${escapeXml(canonicalUrl(origin, "/"))}</link>`,
     `    <description>${escapeXml(SITE_DESCRIPTION)}</description>`,
     "    <language>ko</language>",
@@ -162,7 +162,7 @@ export function buildLlmsTxt({ siteUrl, services }: FeedInput): string {
   })
 
   return [
-    `# ${SITE_TITLE}`,
+    `# ${SITE_NAME}`,
     "",
     `> ${SITE_DESCRIPTION}`,
     "> 각 항목의 원본 design.md는 링크(.../llms.txt)에서 평문 마크다운으로 받을 수 있습니다.",

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -98,7 +98,7 @@ describe("page SEO", () => {
     expect(jsonLdMeta(head)).toMatchObject({
       "script:ld+json": {
         "@type": "Article",
-        headline: "Toss 디자인 시스템·토큰 | ko/design.md",
+        headline: "Toss 디자인 시스템·토큰",
         dateModified: "2026-08-10",
         datePublished: "2026-05-10",
         mainEntityOfPage: "/services/toss",

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -26,6 +26,14 @@ const tossDoc = {
   estimatedTokens: 10,
 } satisfies ServiceDoc
 
+const englishDoc = {
+  ...tossDoc,
+  frontmatter: {
+    ...tossDoc.frontmatter,
+    lang: "en",
+  },
+} satisfies ServiceDoc
+
 describe("page SEO", () => {
   it("builds a unique canonical homepage with a WebSite collection graph", () => {
     const head = buildHomeSeo()
@@ -90,6 +98,19 @@ describe("page SEO", () => {
     })
   })
 
+  it("omits an Open Graph locale when an English document has no regional policy", () => {
+    const head = buildServiceSeo(englishDoc, { isTabView: false })
+
+    expect(head.meta).not.toContainEqual({
+      property: "og:locale",
+      content: "ko_KR",
+    })
+    expect(jsonLdMeta(head)).toMatchObject({
+      "script:ld+json": {
+        inLanguage: "en",
+      },
+    })
+  })
   it("makes 404 pages noindex without a canonical or social preview", () => {
     const head = buildNotFoundSeo()
 

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -35,6 +35,14 @@ const englishDoc = {
 } satisfies ServiceDoc
 
 describe("page SEO", () => {
+  const docWithoutCreatedAt = {
+    ...tossDoc,
+    frontmatter: {
+      ...tossDoc.frontmatter,
+      created_at: "",
+    },
+  } satisfies ServiceDoc
+
   it("builds a unique canonical homepage with a WebSite collection graph", () => {
     const head = buildHomeSeo()
 
@@ -111,9 +119,19 @@ describe("page SEO", () => {
       },
     })
   })
+
+  it("omits datePublished when a malformed document has no creation date", () => {
+    const head = buildServiceSeo(docWithoutCreatedAt, { isTabView: false })
+
+    expect(jsonLdMeta(head)).not.toMatchObject({
+      "script:ld+json": {
+        datePublished: expect.any(String),
+      },
+    })
+  })
+
   it("makes 404 pages noindex without a canonical or social preview", () => {
     const head = buildNotFoundSeo()
-
     expect(head.meta).toContainEqual({
       title: "페이지를 찾을 수 없습니다 | ko/design.md",
     })

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildHomeSeo,
+  buildNotFoundSeo,
+  buildServiceSeo,
+  serviceCanonicalPath,
+} from "./seo"
+import type { ServiceDoc } from "./content-types"
+
+const tossDoc = {
+  frontmatter: {
+    name: "Toss",
+    slug: "toss",
+    category: "finance",
+    last_updated: "2026-08-10",
+    created_at: "2026-05-10",
+    sources: [],
+    related_services: [],
+    lang: "ko",
+  },
+  raw: "# Toss",
+  body: "Toss design system",
+  tagline: "금융 서비스 디자인 시스템과 토큰을 정리한 문서입니다.",
+  filePath: "/services/toss.md",
+  estimatedTokens: 10,
+} satisfies ServiceDoc
+
+function jsonLd(head: { meta: Array<Record<string, unknown>> }) {
+  return head.meta.find((entry) => "script:ld+json" in entry)?.[
+    "script:ld+json"
+  ] as Record<string, unknown>
+}
+
+describe("page SEO", () => {
+  it("builds a unique canonical homepage with a WebSite collection graph", () => {
+    const head = buildHomeSeo()
+
+    expect(head.meta).toContainEqual({
+      title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
+    })
+    expect(head.links).toContainEqual({ rel: "canonical", href: "/" })
+    expect(jsonLd(head)).toMatchObject({
+      "@context": "https://schema.org",
+      "@graph": [
+        expect.objectContaining({ "@type": "WebSite" }),
+        expect.objectContaining({ "@type": "CollectionPage" }),
+      ],
+    })
+  })
+
+  it("uses the clean service URL as canonical for every tab view", () => {
+    expect(serviceCanonicalPath(tossDoc.frontmatter.slug)).toBe(
+      "/services/toss"
+    )
+    expect(buildServiceSeo(tossDoc, { isTabView: false }).links).toContainEqual(
+      {
+        rel: "canonical",
+        href: "/services/toss",
+      }
+    )
+    expect(buildServiceSeo(tossDoc, { isTabView: true }).links).toContainEqual({
+      rel: "canonical",
+      href: "/services/toss",
+    })
+  })
+
+  it("noindexes a service tab while preserving its Article metadata", () => {
+    const head = buildServiceSeo(tossDoc, { isTabView: true })
+
+    expect(head.meta).toContainEqual({
+      title: "Toss 디자인 시스템·토큰 | ko/design.md",
+    })
+    expect(head.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
+    expect(jsonLd(head)).toMatchObject({
+      "@type": "Article",
+      headline: "Toss 디자인 시스템·토큰 | ko/design.md",
+      dateModified: "2026-08-10",
+      datePublished: "2026-05-10",
+      mainEntityOfPage: "/services/toss",
+    })
+  })
+
+  it("makes 404 pages noindex without a canonical or social preview", () => {
+    const head = buildNotFoundSeo()
+
+    expect(head.meta).toContainEqual({
+      title: "페이지를 찾을 수 없습니다 | ko/design.md",
+    })
+    expect(head.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
+    expect(head.links).toHaveLength(0)
+    expect(head.meta).not.toContainEqual(
+      expect.objectContaining({ property: "og:title" })
+    )
+  })
+})

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -5,6 +5,7 @@ import {
   buildServiceSeo,
   serviceCanonicalPath,
 } from "./seo"
+import type { SeoHead } from "./seo"
 import type { ServiceDoc } from "./content-types"
 
 const tossDoc = {
@@ -25,12 +26,6 @@ const tossDoc = {
   estimatedTokens: 10,
 } satisfies ServiceDoc
 
-function jsonLd(head: { meta: Array<Record<string, unknown>> }) {
-  return head.meta.find((entry) => "script:ld+json" in entry)?.[
-    "script:ld+json"
-  ] as Record<string, unknown>
-}
-
 describe("page SEO", () => {
   it("builds a unique canonical homepage with a WebSite collection graph", () => {
     const head = buildHomeSeo()
@@ -39,12 +34,14 @@ describe("page SEO", () => {
       title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
     })
     expect(head.links).toContainEqual({ rel: "canonical", href: "/" })
-    expect(jsonLd(head)).toMatchObject({
-      "@context": "https://schema.org",
-      "@graph": [
-        expect.objectContaining({ "@type": "WebSite" }),
-        expect.objectContaining({ "@type": "CollectionPage" }),
-      ],
+    expect(jsonLdMeta(head)).toMatchObject({
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@graph": [
+          expect.objectContaining({ "@type": "WebSite" }),
+          expect.objectContaining({ "@type": "CollectionPage" }),
+        ],
+      },
     })
   })
 
@@ -74,12 +71,22 @@ describe("page SEO", () => {
       name: "robots",
       content: "noindex,follow",
     })
-    expect(jsonLd(head)).toMatchObject({
-      "@type": "Article",
-      headline: "Toss 디자인 시스템·토큰 | ko/design.md",
-      dateModified: "2026-08-10",
-      datePublished: "2026-05-10",
-      mainEntityOfPage: "/services/toss",
+    expect(head.meta).toContainEqual({
+      property: "og:site_name",
+      content: "ko/design.md",
+    })
+    expect(head.meta).toContainEqual({
+      property: "og:locale",
+      content: "ko_KR",
+    })
+    expect(jsonLdMeta(head)).toMatchObject({
+      "script:ld+json": {
+        "@type": "Article",
+        headline: "Toss 디자인 시스템·토큰 | ko/design.md",
+        dateModified: "2026-08-10",
+        datePublished: "2026-05-10",
+        mainEntityOfPage: "/services/toss",
+      },
     })
   })
 
@@ -99,3 +106,7 @@ describe("page SEO", () => {
     )
   })
 })
+
+function jsonLdMeta(head: SeoHead) {
+  return head.meta.find((entry) => "script:ld+json" in entry)
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,133 @@
+import { truncateForMeta } from "./content-parser"
+import { absoluteUrl } from "./site-config"
+import type { ServiceDoc } from "./content-types"
+
+type SeoMeta = Record<string, unknown>
+
+export interface SeoHead {
+  meta: Array<SeoMeta>
+  links: Array<{ rel: "canonical"; href: string }>
+}
+
+const SITE_NAME = "ko/design.md"
+const HOME_TITLE = "한국 서비스 디자인 시스템 카탈로그 | ko/design.md"
+const HOME_DESCRIPTION =
+  "한국 서비스의 규칙과 디자인 토큰을 design.md 형식으로 정리한 카탈로그입니다. AI 도구에 바로 붙여 넣어 활용하세요."
+
+export function serviceCanonicalPath(slug: string): string {
+  return `/services/${slug}`
+}
+
+export function buildHomeSeo(): SeoHead {
+  const canonical = absoluteUrl("/")
+  const image = absoluteUrl("/og/default.png")
+
+  return {
+    meta: [
+      { title: HOME_TITLE },
+      { name: "description", content: HOME_DESCRIPTION },
+      { property: "og:type", content: "website" },
+      { property: "og:site_name", content: SITE_NAME },
+      { property: "og:locale", content: "ko_KR" },
+      { property: "og:url", content: canonical },
+      { property: "og:title", content: HOME_TITLE },
+      { property: "og:description", content: HOME_DESCRIPTION },
+      { property: "og:image", content: image },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:image:alt", content: HOME_TITLE },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: HOME_TITLE },
+      { name: "twitter:description", content: HOME_DESCRIPTION },
+      { name: "twitter:image", content: image },
+      {
+        "script:ld+json": {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebSite",
+              name: SITE_NAME,
+              url: canonical,
+              inLanguage: "ko-KR",
+            },
+            {
+              "@type": "CollectionPage",
+              name: HOME_TITLE,
+              description: HOME_DESCRIPTION,
+              url: canonical,
+              inLanguage: "ko-KR",
+              isPartOf: { "@type": "WebSite", name: SITE_NAME, url: canonical },
+            },
+          ],
+        },
+      },
+    ],
+    links: [{ rel: "canonical", href: canonical }],
+  }
+}
+
+export function buildServiceSeo(
+  doc: ServiceDoc,
+  options: { isTabView: boolean }
+): SeoHead {
+  const canonical = absoluteUrl(serviceCanonicalPath(doc.frontmatter.slug))
+  const title = `${doc.frontmatter.name} 디자인 시스템·토큰 | ko/design.md`
+  const description =
+    truncateForMeta(doc.tagline) ||
+    `${doc.frontmatter.name} 디자인 시스템과 토큰 문서`
+  const image = absoluteUrl(`/og/${doc.frontmatter.slug}.png`)
+  const article: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: title,
+    description,
+    image,
+    dateModified: doc.frontmatter.last_updated,
+    inLanguage: doc.frontmatter.lang === "ko" ? "ko-KR" : doc.frontmatter.lang,
+    mainEntityOfPage: canonical,
+    isPartOf: {
+      "@type": "WebSite",
+      name: SITE_NAME,
+      url: absoluteUrl("/"),
+    },
+  }
+
+  if (doc.frontmatter.created_at) {
+    article.datePublished = doc.frontmatter.created_at
+  }
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      ...(options.isTabView
+        ? [{ name: "robots", content: "noindex,follow" }]
+        : []),
+      { property: "og:type", content: "article" },
+      { property: "og:url", content: canonical },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:image", content: image },
+      {
+        property: "og:image:alt",
+        content: `${doc.frontmatter.name} design.md`,
+      },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:image", content: image },
+      { "script:ld+json": article },
+    ],
+    links: [{ rel: "canonical", href: canonical }],
+  }
+}
+
+export function buildNotFoundSeo(): SeoHead {
+  return {
+    meta: [
+      { title: "페이지를 찾을 수 없습니다 | ko/design.md" },
+      { name: "robots", content: "noindex,follow" },
+    ],
+    links: [],
+  }
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -82,7 +82,8 @@ export function buildServiceSeo(
   options: { isTabView: boolean }
 ): SeoHead {
   const canonical = absoluteUrl(serviceCanonicalPath(doc.frontmatter.slug))
-  const title = `${doc.frontmatter.name} 디자인 시스템·토큰 | ${SITE_NAME}`
+  const articleHeadline = `${doc.frontmatter.name} 디자인 시스템·토큰`
+  const title = `${articleHeadline} | ${SITE_NAME}`
   const description =
     truncateForMeta(doc.tagline) ||
     `${doc.frontmatter.name} 디자인 시스템과 토큰 문서`
@@ -90,7 +91,7 @@ export function buildServiceSeo(
   const article: JsonLdObject = {
     "@context": "https://schema.org",
     "@type": "Article",
-    headline: title,
+    headline: articleHeadline,
     description,
     image,
     dateModified: doc.frontmatter.last_updated,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -12,7 +12,7 @@ export interface SeoHead {
   links: Array<{ rel: "canonical"; href: string }>
 }
 
-const HOME_TITLE = "한국 서비스 디자인 시스템 카탈로그 | ko/design.md"
+const HOME_TITLE = `한국 서비스 디자인 시스템 카탈로그 | ${SITE_NAME}`
 const HOME_DESCRIPTION =
   "한국 서비스의 규칙과 디자인 토큰을 design.md 형식으로 정리한 카탈로그입니다. AI 도구에 바로 붙여 넣어 활용하세요."
 const SITE_OG_META = [
@@ -82,7 +82,7 @@ export function buildServiceSeo(
   options: { isTabView: boolean }
 ): SeoHead {
   const canonical = absoluteUrl(serviceCanonicalPath(doc.frontmatter.slug))
-  const title = `${doc.frontmatter.name} 디자인 시스템·토큰 | ko/design.md`
+  const title = `${doc.frontmatter.name} 디자인 시스템·토큰 | ${SITE_NAME}`
   const description =
     truncateForMeta(doc.tagline) ||
     `${doc.frontmatter.name} 디자인 시스템과 토큰 문서`
@@ -137,7 +137,7 @@ export function buildServiceSeo(
 export function buildNotFoundSeo(): SeoHead {
   return {
     meta: [
-      { title: "페이지를 찾을 수 없습니다 | ko/design.md" },
+      { title: `페이지를 찾을 수 없습니다 | ${SITE_NAME}` },
       { name: "robots", content: "noindex,follow" },
     ],
     links: [],

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,18 +1,24 @@
 import { truncateForMeta } from "./content-parser"
-import { absoluteUrl } from "./site-config"
+import { SITE_NAME, absoluteUrl } from "./site-config"
 import type { ServiceDoc } from "./content-types"
 
-type SeoMeta = Record<string, unknown>
+type JsonLdPrimitive = string | number | boolean | null
+type JsonLdValue = JsonLdPrimitive | JsonLdObject | ReadonlyArray<JsonLdValue>
+type JsonLdObject = { [key: string]: JsonLdValue }
+type SeoMeta = Record<string, string | JsonLdObject>
 
 export interface SeoHead {
   meta: Array<SeoMeta>
   links: Array<{ rel: "canonical"; href: string }>
 }
 
-const SITE_NAME = "ko/design.md"
 const HOME_TITLE = "한국 서비스 디자인 시스템 카탈로그 | ko/design.md"
 const HOME_DESCRIPTION =
   "한국 서비스의 규칙과 디자인 토큰을 design.md 형식으로 정리한 카탈로그입니다. AI 도구에 바로 붙여 넣어 활용하세요."
+const SITE_OG_META = [
+  { property: "og:site_name", content: SITE_NAME },
+  { property: "og:locale", content: "ko_KR" },
+] satisfies Array<SeoMeta>
 
 export function serviceCanonicalPath(slug: string): string {
   return `/services/${slug}`
@@ -27,8 +33,7 @@ export function buildHomeSeo(): SeoHead {
       { title: HOME_TITLE },
       { name: "description", content: HOME_DESCRIPTION },
       { property: "og:type", content: "website" },
-      { property: "og:site_name", content: SITE_NAME },
-      { property: "og:locale", content: "ko_KR" },
+      ...SITE_OG_META,
       { property: "og:url", content: canonical },
       { property: "og:title", content: HOME_TITLE },
       { property: "og:description", content: HOME_DESCRIPTION },
@@ -76,7 +81,7 @@ export function buildServiceSeo(
     truncateForMeta(doc.tagline) ||
     `${doc.frontmatter.name} 디자인 시스템과 토큰 문서`
   const image = absoluteUrl(`/og/${doc.frontmatter.slug}.png`)
-  const article: Record<string, unknown> = {
+  const article: JsonLdObject = {
     "@context": "https://schema.org",
     "@type": "Article",
     headline: title,
@@ -90,10 +95,9 @@ export function buildServiceSeo(
       name: SITE_NAME,
       url: absoluteUrl("/"),
     },
-  }
-
-  if (doc.frontmatter.created_at) {
-    article.datePublished = doc.frontmatter.created_at
+    ...(doc.frontmatter.created_at
+      ? { datePublished: doc.frontmatter.created_at }
+      : {}),
   }
 
   return {
@@ -104,6 +108,7 @@ export function buildServiceSeo(
         ? [{ name: "robots", content: "noindex,follow" }]
         : []),
       { property: "og:type", content: "article" },
+      ...SITE_OG_META,
       { property: "og:url", content: canonical },
       { property: "og:title", content: title },
       { property: "og:description", content: description },

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -101,7 +101,9 @@ export function buildServiceSeo(
       name: SITE_NAME,
       url: absoluteUrl("/"),
     },
-    datePublished: doc.frontmatter.created_at,
+    ...(doc.frontmatter.created_at
+      ? { datePublished: doc.frontmatter.created_at }
+      : {}),
   }
 
   return {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import { truncateForMeta } from "./content-parser"
 import { SITE_NAME, absoluteUrl } from "./site-config"
-import type { ServiceDoc } from "./content-types"
+import type { Lang, ServiceDoc } from "./content-types"
 
 type JsonLdPrimitive = string | number | boolean | null
 type JsonLdValue = JsonLdPrimitive | JsonLdObject | ReadonlyArray<JsonLdValue>
@@ -17,8 +17,13 @@ const HOME_DESCRIPTION =
   "한국 서비스의 규칙과 디자인 토큰을 design.md 형식으로 정리한 카탈로그입니다. AI 도구에 바로 붙여 넣어 활용하세요."
 const SITE_OG_META = [
   { property: "og:site_name", content: SITE_NAME },
-  { property: "og:locale", content: "ko_KR" },
 ] satisfies Array<SeoMeta>
+
+function ogLocaleMeta(lang: Lang): Array<SeoMeta> {
+  // Open Graph locale requires a language and territory. Do not invent one for
+  // English entries; omit it until a regional policy exists.
+  return lang === "ko" ? [{ property: "og:locale", content: "ko_KR" }] : []
+}
 
 export function serviceCanonicalPath(slug: string): string {
   return `/services/${slug}`
@@ -34,6 +39,7 @@ export function buildHomeSeo(): SeoHead {
       { name: "description", content: HOME_DESCRIPTION },
       { property: "og:type", content: "website" },
       ...SITE_OG_META,
+      ...ogLocaleMeta("ko"),
       { property: "og:url", content: canonical },
       { property: "og:title", content: HOME_TITLE },
       { property: "og:description", content: HOME_DESCRIPTION },
@@ -107,6 +113,7 @@ export function buildServiceSeo(
         : []),
       { property: "og:type", content: "article" },
       ...SITE_OG_META,
+      ...ogLocaleMeta(doc.frontmatter.lang),
       { property: "og:url", content: canonical },
       { property: "og:title", content: title },
       { property: "og:description", content: description },

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -95,9 +95,7 @@ export function buildServiceSeo(
       name: SITE_NAME,
       url: absoluteUrl("/"),
     },
-    ...(doc.frontmatter.created_at
-      ? { datePublished: doc.frontmatter.created_at }
-      : {}),
+    datePublished: doc.frontmatter.created_at,
   }
 
   return {

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -21,6 +21,7 @@ if (import.meta.env.PROD && !RAW) {
 }
 
 export const SITE_URL = RAW.replace(/\/+$/, "")
+export const SITE_NAME = "ko/design.md"
 
 export function absoluteUrl(path: string): string {
   if (/^https?:\/\//.test(path)) return path

--- a/src/lib/token-extractor.ts
+++ b/src/lib/token-extractor.ts
@@ -383,7 +383,9 @@ function parseTypography(
 }
 
 // Drop undefined-valued keys so the emitted JSON stays compact.
-function clean<T extends Record<string, string | number | undefined>>(obj: T): T {
+function clean<T extends Record<string, string | number | undefined>>(
+  obj: T
+): T {
   for (const k of Object.keys(obj)) {
     if (obj[k] === undefined) delete obj[k]
   }

--- a/src/lib/token-extractor.ts
+++ b/src/lib/token-extractor.ts
@@ -383,7 +383,7 @@ function parseTypography(
 }
 
 // Drop undefined-valued keys so the emitted JSON stays compact.
-function clean<T extends Record<string, unknown>>(obj: T): T {
+function clean<T extends Record<string, string | number | undefined>>(obj: T): T {
   for (const k of Object.keys(obj)) {
     if (obj[k] === undefined) delete obj[k]
   }

--- a/src/routes/-seo-head.test.ts
+++ b/src/routes/-seo-head.test.ts
@@ -17,9 +17,10 @@ describe("route SEO heads", () => {
   })
 
   it("keeps the default detail tab out of the URL", () => {
-    const validateSearch = ServiceRoute.options.validateSearch as (
-      search: Record<string, unknown>
-    ) => { tab?: "preview" | "tokens" | "md" }
+    const validateSearch = ServiceRoute.options.validateSearch
+    if (typeof validateSearch !== "function") {
+      throw new Error("Service route must expose a search validator function")
+    }
 
     expect(validateSearch({})).toEqual({
       tab: undefined,
@@ -60,5 +61,16 @@ describe("route SEO heads", () => {
     expect(head?.links).toContainEqual(
       expect.objectContaining({ rel: "stylesheet" })
     )
+  })
+
+  it("uses the same noindex head for route-level not-found matches", async () => {
+    const head = await RootRoute.options.head?.({
+      matches: [{ status: "notFound", globalNotFound: false }],
+    } as never)
+
+    expect(head?.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
   })
 })

--- a/src/routes/-seo-head.test.ts
+++ b/src/routes/-seo-head.test.ts
@@ -26,10 +26,25 @@ describe("route SEO heads", () => {
       tab: undefined,
     })
     expect(validateSearch({ tab: "" })).toEqual({
-      tab: undefined,
+      tab: "",
     })
     expect(validateSearch({ tab: "unknown" })).toEqual({
-      tab: undefined,
+      tab: "unknown",
+    })
+  })
+  it("noindexes an unrecognized tab query while keeping the clean canonical URL", async () => {
+    const head = await ServiceRoute.options.head?.({
+      loaderData: { doc: tossDoc, shikiHtml: "", previewAvailable: true },
+      match: { search: { tab: "unknown" } },
+    } as never)
+
+    expect(head?.links).toContainEqual({
+      rel: "canonical",
+      href: "/services/toss",
+    })
+    expect(head?.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
     })
   })
 

--- a/src/routes/-seo-head.test.ts
+++ b/src/routes/-seo-head.test.ts
@@ -25,6 +25,12 @@ describe("route SEO heads", () => {
     expect(validateSearch({})).toEqual({
       tab: undefined,
     })
+    expect(validateSearch({ tab: "" })).toEqual({
+      tab: undefined,
+    })
+    expect(validateSearch({ tab: "unknown" })).toEqual({
+      tab: undefined,
+    })
   })
 
   it("uses the clean service URL as canonical and noindexes tab states", async () => {

--- a/src/routes/-seo-head.test.ts
+++ b/src/routes/-seo-head.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { Route as RootRoute } from "./__root"
+import { Route as ServiceRoute } from "./services/$slug"
+import { Route as HomeRoute } from "./index"
+import { getServiceBySlug } from "@/lib/content-collection"
+
+const tossDoc = getServiceBySlug("toss")!
+
+describe("route SEO heads", () => {
+  it("uses homepage metadata with the clean root URL as canonical", async () => {
+    const head = await HomeRoute.options.head?.({} as never)
+
+    expect(head?.meta).toContainEqual({
+      title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
+    })
+    expect(head?.links).toContainEqual({ rel: "canonical", href: "/" })
+  })
+
+  it("keeps the default detail tab out of the URL", () => {
+    const validateSearch = ServiceRoute.options.validateSearch as (
+      search: Record<string, unknown>
+    ) => { tab?: "preview" | "tokens" | "md" }
+
+    expect(validateSearch({})).toEqual({
+      tab: undefined,
+    })
+  })
+
+  it("uses the clean service URL as canonical and noindexes tab states", async () => {
+    const head = await ServiceRoute.options.head?.({
+      loaderData: { doc: tossDoc, shikiHtml: "", previewAvailable: true },
+      match: { search: { tab: "tokens" } },
+    } as never)
+
+    expect(head?.links).toContainEqual({
+      rel: "canonical",
+      href: "/services/toss",
+    })
+    expect(head?.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
+  })
+
+  it("replaces homepage metadata with a noindex head for global 404s", async () => {
+    const head = await RootRoute.options.head?.({
+      matches: [{ status: "success", globalNotFound: true }],
+    } as never)
+
+    expect(head?.meta).toContainEqual({
+      title: "페이지를 찾을 수 없습니다 | ko/design.md",
+    })
+    expect(head?.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
+    expect(head?.links).not.toContainEqual(
+      expect.objectContaining({ rel: "canonical" })
+    )
+    expect(head?.links).toContainEqual(
+      expect.objectContaining({ rel: "stylesheet" })
+    )
+  })
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -36,6 +36,9 @@ const DOCUMENT_LINKS = [
     href: absoluteUrl("/rss.xml"),
   },
 ]
+// Indexable child routes must provide page-specific SEO through `head()`.
+// Keep this root head free of fallback title/OG metadata: a fallback masks a
+// missing route head and would make not-found pages inherit site metadata.
 
 export const Route = createRootRoute({
   head: ({ matches }) => {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,71 +9,52 @@ import { TanStackDevtools } from "@tanstack/react-devtools"
 import { Provider as JotaiProvider } from "jotai"
 import { Analytics } from "@vercel/analytics/react"
 import appCss from "../styles.css?url"
+import { buildNotFoundSeo } from "@/lib/seo"
 import { absoluteUrl } from "@/lib/site-config"
 
 import { SiteHeader } from "@/components/site/header"
 import { SiteFooter } from "@/components/site/footer"
 
+const DOCUMENT_META = [
+  { charSet: "utf-8" },
+  {
+    name: "viewport",
+    content: "width=device-width, initial-scale=1, viewport-fit=cover",
+  },
+  { name: "theme-color", content: "#141414" },
+]
+
+const DOCUMENT_LINKS = [
+  { rel: "stylesheet", href: appCss },
+  { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
+  { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
+  { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
+  {
+    rel: "alternate",
+    type: "application/rss+xml",
+    title: "ko/design.md RSS",
+    href: absoluteUrl("/rss.xml"),
+  },
+]
+
 export const Route = createRootRoute({
-  head: () => ({
-    meta: [
-      { charSet: "utf-8" },
-      {
-        name: "viewport",
-        content: "width=device-width, initial-scale=1, viewport-fit=cover",
-      },
-      { title: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그" },
-      {
-        name: "description",
-        content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
-      },
-      { name: "theme-color", content: "#141414" },
-      { property: "og:type", content: "website" },
-      { property: "og:site_name", content: "ko/design.md" },
-      { property: "og:locale", content: "ko_KR" },
-      { property: "og:url", content: absoluteUrl("/") },
-      {
-        property: "og:title",
-        content: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그",
-      },
-      {
-        property: "og:description",
-        content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
-      },
-      { property: "og:image", content: absoluteUrl("/og/default.png") },
-      { property: "og:image:width", content: "1200" },
-      { property: "og:image:height", content: "630" },
-      {
-        property: "og:image:alt",
-        content: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그",
-      },
-      { name: "twitter:card", content: "summary_large_image" },
-      {
-        name: "twitter:title",
-        content: "ko/design.md — 한국 서비스 디자인 컨텍스트 카탈로그",
-      },
-      {
-        name: "twitter:description",
-        content:
-          "한국 서비스의 시그니처 디자인을 design.md 한 장으로. 원하는 AI 도구에 그대로 붙여넣으세요.",
-      },
-      { name: "twitter:image", content: absoluteUrl("/og/default.png") },
-    ],
-    links: [
-      { rel: "stylesheet", href: appCss },
-      { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
-      { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
-      { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
-      {
-        rel: "alternate",
-        type: "application/rss+xml",
-        title: "ko/design.md RSS",
-        href: absoluteUrl("/rss.xml"),
-      },
-    ],
-  }),
+  head: ({ matches }) => {
+    const isNotFound = matches.some(
+      (match) => match.status === "notFound" || match.globalNotFound
+    )
+    if (isNotFound) {
+      const notFoundSeo = buildNotFoundSeo()
+      return {
+        meta: [...DOCUMENT_META, ...notFoundSeo.meta],
+        links: DOCUMENT_LINKS,
+      }
+    }
+
+    return {
+      meta: DOCUMENT_META,
+      links: DOCUMENT_LINKS,
+    }
+  },
   notFoundComponent: () => (
     <main className="mx-auto max-w-6xl px-4 py-24">
       <p className="text-meta-caps">404 — NOT FOUND</p>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,6 +17,7 @@ interface HomeSearch {
 
 export const Route = createFileRoute("/")({
   head: () => buildHomeSeo(),
+  // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
   validateSearch: (raw: Record<string, unknown>): HomeSearch => {
     const cat =
       typeof raw.cat === "string" &&

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import { useFilteredServices } from "./-home/hooks/use-filtered-services"
 import type { Category } from "@/lib/content-types"
 import { getAllServices } from "@/lib/content-collection"
 import { CATEGORIES } from "@/lib/content-types"
+import { buildHomeSeo } from "@/lib/seo"
 
 interface HomeSearch {
   cat?: Category
@@ -15,6 +16,7 @@ interface HomeSearch {
 }
 
 export const Route = createFileRoute("/")({
+  head: () => buildHomeSeo(),
   validateSearch: (raw: Record<string, unknown>): HomeSearch => {
     const cat =
       typeof raw.cat === "string" &&

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -27,6 +27,7 @@ const PREVIEW_THEME_STORAGE_KEY = "ko-design-md.preview-theme"
 
 type DetailTab = "preview" | "tokens" | "md"
 
+// eslint-disable-next-line no-restricted-syntax -- URL search param values are untyped external input.
 function parseTab(value: unknown): DetailTab | undefined {
   if (value === "md") return "md"
   if (value === "tokens") return "tokens"
@@ -35,6 +36,7 @@ function parseTab(value: unknown): DetailTab | undefined {
 }
 
 export const Route = createFileRoute("/services/$slug")({
+  // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
   validateSearch: (search: Record<string, unknown>): { tab?: DetailTab } => ({
     tab: parseTab(search.tab),
   }),

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -27,6 +27,10 @@ const PREVIEW_THEME_STORAGE_KEY = "ko-design-md.preview-theme"
 
 type DetailTab = "preview" | "tokens" | "md"
 
+type DetailSearch = {
+  tab?: string
+}
+
 // eslint-disable-next-line no-restricted-syntax -- URL search param values are untyped external input.
 function parseTab(value: unknown): DetailTab | undefined {
   if (value === "md") return "md"
@@ -37,8 +41,10 @@ function parseTab(value: unknown): DetailTab | undefined {
 
 export const Route = createFileRoute("/services/$slug")({
   // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
-  validateSearch: (search: Record<string, unknown>): { tab?: DetailTab } => ({
-    tab: parseTab(search.tab),
+  validateSearch: (search: Record<string, unknown>): DetailSearch => ({
+    // Preserve an unrecognized tab so its URL is still noindexed. The UI maps
+    // it to the default preview tab with parseTab below.
+    tab: typeof search.tab === "string" ? search.tab : undefined,
   }),
   loader: async ({ params }) => {
     const doc = getServiceBySlug(params.slug)
@@ -73,7 +79,7 @@ function ServiceDetailPage() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const filename = `${doc.frontmatter.slug}.md`
-  const activeTab = search.tab ?? "preview"
+  const activeTab = parseTab(search.tab) ?? "preview"
 
   // Preview theme is independent of the site theme (which is locked to light).
   // Default to light: the site itself is light-only and the audience skews

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -18,26 +18,24 @@ import { TokenBadge } from "./-components/token-badge"
 import { TokenCardSection } from "./-components/token-card-section"
 import type { PreviewTheme } from "./-components/preview-theme-toggle"
 import type { ServiceDoc } from "@/lib/content-types"
-import {
-  getServiceBySlug,
-  hasPreview,
-  truncateForMeta,
-} from "@/lib/content-collection"
+import { getServiceBySlug, hasPreview } from "@/lib/content-collection"
 import { highlightRawMarkdown } from "@/lib/shiki"
+import { buildServiceSeo } from "@/lib/seo"
 import { absoluteUrl } from "@/lib/site-config"
 
 const PREVIEW_THEME_STORAGE_KEY = "ko-design-md.preview-theme"
 
 type DetailTab = "preview" | "tokens" | "md"
 
-function parseTab(value: unknown): DetailTab {
+function parseTab(value: unknown): DetailTab | undefined {
   if (value === "md") return "md"
   if (value === "tokens") return "tokens"
-  return "preview"
+  if (value === "preview") return "preview"
+  return undefined
 }
 
 export const Route = createFileRoute("/services/$slug")({
-  validateSearch: (search: Record<string, unknown>): { tab: DetailTab } => ({
+  validateSearch: (search: Record<string, unknown>): { tab?: DetailTab } => ({
     tab: parseTab(search.tab),
   }),
   loader: async ({ params }) => {
@@ -46,33 +44,16 @@ export const Route = createFileRoute("/services/$slug")({
     const shikiHtml = await highlightRawMarkdown(doc.raw)
     return { doc, shikiHtml, previewAvailable: hasPreview(params.slug) }
   },
-  head: ({ loaderData }) => {
+  head: ({ loaderData, match }) => {
     if (!loaderData) return {}
     const { doc } = loaderData
-    const title = `${doc.frontmatter.name} design.md · ko/design.md`
-    const description = truncateForMeta(doc.tagline)
-    const ogImage = absoluteUrl(`/og/${doc.frontmatter.slug}.png`)
+    const seo = buildServiceSeo(doc, {
+      isTabView: match.search.tab !== undefined,
+    })
     return {
-      meta: [
-        { title },
-        { name: "description", content: description },
-        { property: "og:type", content: "article" },
-        {
-          property: "og:url",
-          content: absoluteUrl(`/services/${doc.frontmatter.slug}`),
-        },
-        { property: "og:title", content: title },
-        { property: "og:description", content: description },
-        { property: "og:image", content: ogImage },
-        {
-          property: "og:image:alt",
-          content: `${doc.frontmatter.name} design.md`,
-        },
-        { name: "twitter:title", content: title },
-        { name: "twitter:description", content: description },
-        { name: "twitter:image", content: ogImage },
-      ],
+      ...seo,
       links: [
+        ...seo.links,
         {
           rel: "alternate",
           type: "text/plain",
@@ -90,6 +71,7 @@ function ServiceDetailPage() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const filename = `${doc.frontmatter.slug}.md`
+  const activeTab = search.tab ?? "preview"
 
   // Preview theme is independent of the site theme (which is locked to light).
   // Default to light: the site itself is light-only and the audience skews
@@ -118,8 +100,9 @@ function ServiceDetailPage() {
       doc={doc}
       filename={filename}
       onTabChange={(value) => {
+        const nextTab = parseTab(value)
         navigate({
-          search: { tab: parseTab(value) },
+          search: nextTab && nextTab !== "preview" ? { tab: nextTab } : {},
           replace: true,
           // Tab change is panel switching, not navigation — preserve scroll
           // so the user keeps reading from the same vertical position.
@@ -129,7 +112,7 @@ function ServiceDetailPage() {
       onThemeChange={handleThemeChange}
       previewAvailable={previewAvailable}
       previewTheme={previewTheme}
-      searchTab={search.tab}
+      searchTab={activeTab}
       shikiHtml={shikiHtml}
     />
   )

--- a/src/routes/services/$slug.tsx
+++ b/src/routes/services/$slug.tsx
@@ -42,8 +42,8 @@ function parseTab(value: unknown): DetailTab | undefined {
 export const Route = createFileRoute("/services/$slug")({
   // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
   validateSearch: (search: Record<string, unknown>): DetailSearch => ({
-    // Preserve an unrecognized tab so its URL is still noindexed. The UI maps
-    // it to the default preview tab with parseTab below.
+    // Preserve any tab query, including an empty value, so duplicate URLs stay
+    // noindexed. The UI maps unrecognized values to the default preview tab below.
     tab: typeof search.tab === "string" ? search.tab : undefined,
   }),
   loader: async ({ params }) => {


### PR DESCRIPTION
## 변경 요약

- 홈페이지·서비스 상세·404에 페이지별 title, description, canonical, OG/Twitter 메타데이터를 추가합니다.
- 서비스 탭 URL은 기본 상세 URL로 canonicalize하고 `noindex,follow`를 적용합니다.
- `WebSite`/`CollectionPage`/`Article` JSON-LD와 sitemap·RSS의 공통 canonical 경로 계약을 추가합니다.
- 전역 `unknown` 제한 lint 규칙을 추가하고, JSON·YAML·URL의 실제 외부 입력 경계에만 명시적 예외를 둡니다.

## 변경 종류

- [x] 사이트 코드/UI
- [x] 코드 품질 / 타입 안전성
- [x] 문서 (설계·구현 계획)

## 카탈로그 PR 체크

- [x] 해당 없음 — `services/*.md`와 프리뷰 산출물 변경 없음

## 일반 체크

- [x] `pnpm test` (39 files, 536 tests), `pnpm typecheck`, `pnpm lint`, `pnpm build` 통과
- [x] 프로덕션 SSR smoke: 홈·서비스 canonical/JSON-LD, 탭 noindex, 404 noindex 및 stylesheet 확인
- [x] DCO 서명: 저장소 내부 브랜치 PR로 CI 적용 대상 아님 (CONTRIBUTING.md 기준)

## 관련 이슈

- 없음

## 운영 후속 항목

- 배포 후 `getdesign.kr`와 `www.getdesign.kr` 중 선호 호스트를 301로 단일화하고, `VITE_SITE_URL`·canonical·OG·sitemap·RSS의 origin이 일치하는지 확인합니다.