### PR TITLE
refactor(validate): 프리뷰 레이아웃 해석을 한 자리로 모은다 (#235)

### DIFF
--- a/scripts/audit-oklch.ts
+++ b/scripts/audit-oklch.ts
@@ -8,6 +8,13 @@ import {
   syncOklchLiterals,
 } from "../src/lib/oklch-sync"
 import { definitionsForSlug, findPreviewDrift } from "../src/lib/oklch-drift"
+import {
+  DARK_PREVIEW_FILE,
+  LIGHT_PREVIEW_FILE,
+  MERGED_PREVIEW_FILE,
+  lightScopeFile,
+  resolvePreviewLayout,
+} from "../src/lib/preview-layout"
 import { ALPHA_TOLERANCE, DELTA_E_TOLERANCE } from "../src/lib/oklch-tolerance"
 import {
   deltaE,
@@ -327,30 +334,42 @@ for (const slug of slugs) {
   // 다른 값으로 재정의하므로 라이트 기준 md 와 비교하면 오탐이 쏟아진다
   // (이슈 #187, 측정 231건).
   //
-  // 없으면 조용히 넘기지 않는다. 프리뷰 파일 이름이 바뀌면(단일 파일 병합 등)
-  // 이 루프가 exit 0 에 아무 출력 없이 통과해 "게이트는 초록인데 검사는 안 됨"
-  // 상태를 만든다. 현재 카탈로그는 모든 슬러그가 light.html 을 갖고 있으므로
-  // 여기서 멈추는 것이 정상이다.
-  const preview = path.join(PREVIEW, slug, "light.html")
-  if (!fs.existsSync(preview)) {
+  // 어느 파일이 라이트 스코프를 갖는지는 resolvePreviewLayout 이 답한다 —
+  // 병합 레이아웃(preview.html 하나)에서는 그 한 파일이고, 분리 레이아웃에서는
+  // light.html 이다. 여기서 파일명을 직접 조립하지 않는 이유가 곧 그 모듈의
+  // 존재 이유다: 레이아웃이 바뀌었을 때 이 루프가 실패하는 게 아니라 조용히
+  // 아무것도 검사하지 않게 되는 것을 막는다.
+  //
+  // 없으면 조용히 넘기지 않는다. exit 0 에 아무 출력 없이 통과하면
+  // "게이트는 초록인데 검사는 안 됨" 상태가 된다.
+  const dir = path.join(PREVIEW, slug)
+  const layout = resolvePreviewLayout((file) =>
+    fs.existsSync(path.join(dir, file))
+  )
+  if (layout === null) {
     console.error(
-      `\n${slug}: no light.html under public/preview/${slug}/ — the drift ` +
-        `check cannot run for this slug. Most likely this services/*.md landed ` +
-        `before its preview files were generated; run the preview pipeline for ` +
-        `${slug}. Less likely: the preview format changed and moved off ` +
-        `light.html, in which case teach this loop the new layout instead of ` +
-        `letting it skip silently.`
+      `\n${slug}: no usable preview under public/preview/${slug}/ — the drift ` +
+        `check cannot run for this slug. It needs either ${MERGED_PREVIEW_FILE} ` +
+        `or both ${LIGHT_PREVIEW_FILE} and ${DARK_PREVIEW_FILE}. Most likely ` +
+        `this services/*.md landed before its preview files were generated; ` +
+        `run the preview pipeline for ${slug}. Less likely: the preview format ` +
+        `changed again, in which case teach src/lib/preview-layout.ts the new ` +
+        `layout instead of letting this skip silently.`
     )
     process.exitCode = 1
     continue
   }
+  const previewFile = lightScopeFile(layout)
+  const preview = path.join(dir, previewFile)
   const defs = definitionsForSlug(
     fs.readFileSync(path.join(SERVICES, `${slug}.md`), "utf8"),
     slug
   )
   const found = findPreviewDrift(fs.readFileSync(preview, "utf8"), defs)
   if (found.length === 0) continue
-  console.log(`\n${slug}/light.html — ${found.length} drifted from ${slug}.md`)
+  console.log(
+    `\n${slug}/${previewFile} — ${found.length} drifted from ${slug}.md`
+  )
   for (const d of found) {
     console.log(`  --${d.name.padEnd(24)} ${d.preview}   md says ${d.expected}`)
   }

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 import { definitionsForSlug, findPreviewDrift } from "./oklch-drift"
+import { lightScopeFile, resolvePreviewLayout } from "./preview-layout"
 
 // `oklch-drift.test.ts` proves the algorithm on synthetic strings. Nothing
 // proved it still reaches the catalogue — and for a while it barely did: the
@@ -60,6 +61,24 @@ function definitionsFor(slug: string): Map<string, string> {
   )
 }
 
+// Ask which file holds the light scope rather than joining "light.html".
+//
+// The hardcoded name was itself a way to check nothing: a slug converted to a
+// single `preview.html` would drop out of `slugs()` entirely, taking its
+// MATCH_FLOOR entry, its scanner-coverage assertion and its no-drift assertion
+// with it — and the suite would stay green on the slugs that had not been
+// converted yet. That is the same silent-zero this file exists to prevent,
+// arriving through the door the file did not watch.
+function lightScope(slug: string): { file: string; html: string } {
+  const layout = resolvePreviewLayout((file) =>
+    existsSync(join(PREVIEW, slug, file))
+  )
+  // Unreachable for slugs from `slugs()`, which filters on the same predicate.
+  if (layout === null) throw new Error(`${slug}: no usable preview layout`)
+  const file = lightScopeFile(layout)
+  return { file, html: readFileSync(join(PREVIEW, slug, file), "utf8") }
+}
+
 function slugs(): Array<string> {
   if (!existsSync(PREVIEW)) return []
   return readdirSync(PREVIEW, { withFileTypes: true })
@@ -67,8 +86,8 @@ function slugs(): Array<string> {
     .map((d) => d.name)
     .filter(
       (s) =>
-        existsSync(join(PREVIEW, s, "light.html")) &&
-        existsSync(join(SERVICES, `${s}.md`))
+        resolvePreviewLayout((file) => existsSync(join(PREVIEW, s, file))) !==
+          null && existsSync(join(SERVICES, `${s}.md`))
     )
     .sort()
 }
@@ -125,7 +144,7 @@ describe("oklch-drift — catalogue coverage", () => {
     // prints it, so a message that only says "record a number" leaves the
     // reader with no way to obtain one — and recording a 0 is refused below.
     const measured = unaccounted.map((slug) => {
-      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const { html } = lightScope(slug)
       return `${slug} (matches ${matchedCount(html, definitionsFor(slug))} today)`
     })
     expect(
@@ -139,7 +158,7 @@ describe("oklch-drift — catalogue coverage", () => {
     for (const slug of all) {
       const floor = MATCH_FLOOR[slug]
       if (floor === undefined) continue
-      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const { html } = lightScope(slug)
       const n = matchedCount(html, definitionsFor(slug))
       if (n < floor) regressed.push(`${slug}: ${n} < ${floor}`)
     }
@@ -155,12 +174,12 @@ describe("oklch-drift — catalogue coverage", () => {
     // always a scanner bug. codeit was exactly that — a `[data-theme="dark"]`
     // string inside a banner comment closed the light scope over all 91.
     for (const slug of all) {
-      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const { file, html } = lightScope(slug)
       const declared = [...html.matchAll(/--[\w-]+:\s*oklch\(/g)].length
       if (declared === 0) continue
       expect(
         consideredCount(html),
-        `${slug}/light.html declares ${declared} oklch custom properties and the scanner considered none of them — the whole file is silently unchecked`
+        `${slug}/${file} declares ${declared} oklch custom properties and the scanner considered none of them — the whole file is silently unchecked`
       ).toBeGreaterThan(0)
     }
   })
@@ -176,7 +195,7 @@ describe("oklch-drift — catalogue coverage", () => {
   it("finds no drift anywhere in the catalogue", () => {
     const found: Array<string> = []
     for (const slug of all) {
-      const html = readFileSync(join(PREVIEW, slug, "light.html"), "utf8")
+      const { html } = lightScope(slug)
       const defs = definitionsFor(slug)
       for (const d of findPreviewDrift(html, defs)) {
         found.push(

--- a/src/lib/preview-layout.test.ts
+++ b/src/lib/preview-layout.test.ts
@@ -20,15 +20,11 @@ describe("resolvePreviewLayout", () => {
     const layout = resolvePreviewLayout(
       has(LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE)
     )
-    expect(layout).toEqual({
-      kind: "split",
-      files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE],
-    })
+    expect(layout).toBe("split")
   })
 
   it("reports the merged layout when the single file is present", () => {
-    const layout = resolvePreviewLayout(has(MERGED_PREVIEW_FILE))
-    expect(layout).toEqual({ kind: "merged", files: [MERGED_PREVIEW_FILE] })
+    expect(resolvePreviewLayout(has(MERGED_PREVIEW_FILE))).toBe("merged")
   })
 
   // During the migration a slug can briefly carry both. Split wins, because
@@ -39,14 +35,14 @@ describe("resolvePreviewLayout", () => {
     const layout = resolvePreviewLayout(
       has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE)
     )
-    expect(layout?.kind).toBe("split")
+    expect(layout).toBe("split")
   })
 
   // ...but a merged file plus a stray half is not a servable split, so the
   // merged file is the only thing left to judge.
   it("falls back to merged when the split layout is incomplete", () => {
     expect(
-      resolvePreviewLayout(has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE))?.kind
+      resolvePreviewLayout(has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE))
     ).toBe("merged")
   })
 
@@ -65,18 +61,11 @@ describe("resolvePreviewLayout", () => {
 
 describe("lightScopeFile", () => {
   it("reads light.html for the split layout", () => {
-    expect(
-      lightScopeFile({
-        kind: "split",
-        files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE],
-      })
-    ).toBe(LIGHT_PREVIEW_FILE)
+    expect(lightScopeFile("split")).toBe(LIGHT_PREVIEW_FILE)
   })
 
   it("reads the single file for the merged layout", () => {
-    expect(
-      lightScopeFile({ kind: "merged", files: [MERGED_PREVIEW_FILE] })
-    ).toBe(MERGED_PREVIEW_FILE)
+    expect(lightScopeFile("merged")).toBe(MERGED_PREVIEW_FILE)
   })
 })
 

--- a/src/lib/preview-layout.test.ts
+++ b/src/lib/preview-layout.test.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+  DARK_PREVIEW_FILE,
+  LIGHT_PREVIEW_FILE,
+  MERGED_PREVIEW_FILE,
+  lightScopeFile,
+  resolvePreviewLayout,
+} from "./preview-layout"
+
+const has =
+  (...present: Array<string>) =>
+  (file: string) =>
+    present.includes(file)
+
+describe("resolvePreviewLayout", () => {
+  it("reports the split layout when both theme files are present", () => {
+    const layout = resolvePreviewLayout(
+      has(LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE)
+    )
+    expect(layout).toEqual({
+      kind: "split",
+      files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE],
+    })
+  })
+
+  it("reports the merged layout when the single file is present", () => {
+    const layout = resolvePreviewLayout(has(MERGED_PREVIEW_FILE))
+    expect(layout).toEqual({ kind: "merged", files: [MERGED_PREVIEW_FILE] })
+  })
+
+  // During the migration a slug can briefly carry both. The merged file is the
+  // one the site serves, so it is the one the gates must judge — otherwise a
+  // converted slug would keep being checked through its leftover halves.
+  it("prefers merged when both layouts are present", () => {
+    const layout = resolvePreviewLayout(
+      has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE)
+    )
+    expect(layout?.kind).toBe("merged")
+  })
+
+  // A half-generated slug must not read as usable. This is the case that turns
+  // a loud failure into a silent skip if it returns a layout anyway.
+  it("returns null when only one half of the split layout exists", () => {
+    expect(resolvePreviewLayout(has(LIGHT_PREVIEW_FILE))).toBeNull()
+    expect(resolvePreviewLayout(has(DARK_PREVIEW_FILE))).toBeNull()
+  })
+
+  it("returns null when the directory holds neither layout", () => {
+    expect(resolvePreviewLayout(has())).toBeNull()
+    expect(resolvePreviewLayout(has("index.html", "assets"))).toBeNull()
+  })
+})
+
+describe("lightScopeFile", () => {
+  it("reads light.html for the split layout", () => {
+    expect(
+      lightScopeFile({
+        kind: "split",
+        files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE],
+      })
+    ).toBe(LIGHT_PREVIEW_FILE)
+  })
+
+  it("reads the single file for the merged layout", () => {
+    expect(
+      lightScopeFile({ kind: "merged", files: [MERGED_PREVIEW_FILE] })
+    ).toBe(MERGED_PREVIEW_FILE)
+  })
+})
+
+// The unit cases above are hypothetical directories. This one asserts the
+// resolver against the tree that actually ships, so a slug that loses a half
+// fails here rather than in a gate that quietly checks nothing.
+describe("the shipped catalogue", () => {
+  const PREVIEW_DIR = fileURL("../../public/preview")
+
+  it("resolves a layout for every preview slug", () => {
+    const slugs = readdirSync(PREVIEW_DIR, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith("_"))
+      .map((e) => e.name)
+
+    expect(slugs.length).toBeGreaterThan(0)
+    const unresolved = slugs.filter(
+      (slug) =>
+        resolvePreviewLayout((file) =>
+          existsSync(join(PREVIEW_DIR, slug, file))
+        ) === null
+    )
+    expect(unresolved).toEqual([])
+  })
+})
+
+function fileURL(relative: string): string {
+  return new URL(relative, import.meta.url).pathname.replace(
+    /^\/([A-Za-z]:)/,
+    "$1"
+  )
+}

--- a/src/lib/preview-layout.test.ts
+++ b/src/lib/preview-layout.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync } from "node:fs"
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 import {
   DARK_PREVIEW_FILE,
@@ -30,14 +31,23 @@ describe("resolvePreviewLayout", () => {
     expect(layout).toEqual({ kind: "merged", files: [MERGED_PREVIEW_FILE] })
   })
 
-  // During the migration a slug can briefly carry both. The merged file is the
-  // one the site serves, so it is the one the gates must judge — otherwise a
-  // converted slug would keep being checked through its leftover halves.
-  it("prefers merged when both layouts are present", () => {
+  // During the migration a slug can briefly carry both. Split wins, because
+  // split is what ships today — the iframe requests `{theme}.html` and the Vite
+  // plugin only discovers slugs that have a `light.html`. Judging a
+  // `preview.html` nobody serves would let the shipped halves drift unwatched.
+  it("prefers split when both layouts are present", () => {
     const layout = resolvePreviewLayout(
       has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE)
     )
-    expect(layout?.kind).toBe("merged")
+    expect(layout?.kind).toBe("split")
+  })
+
+  // ...but a merged file plus a stray half is not a servable split, so the
+  // merged file is the only thing left to judge.
+  it("falls back to merged when the split layout is incomplete", () => {
+    expect(
+      resolvePreviewLayout(has(MERGED_PREVIEW_FILE, LIGHT_PREVIEW_FILE))?.kind
+    ).toBe("merged")
   })
 
   // A half-generated slug must not read as usable. This is the case that turns
@@ -74,7 +84,9 @@ describe("lightScopeFile", () => {
 // resolver against the tree that actually ships, so a slug that loses a half
 // fails here rather than in a gate that quietly checks nothing.
 describe("the shipped catalogue", () => {
-  const PREVIEW_DIR = fileURL("../../public/preview")
+  const PREVIEW_DIR = fileURLToPath(
+    new URL("../../public/preview", import.meta.url)
+  )
 
   it("resolves a layout for every preview slug", () => {
     const slugs = readdirSync(PREVIEW_DIR, { withFileTypes: true })
@@ -91,10 +103,3 @@ describe("the shipped catalogue", () => {
     expect(unresolved).toEqual([])
   })
 })
-
-function fileURL(relative: string): string {
-  return new URL(relative, import.meta.url).pathname.replace(
-    /^\/([A-Za-z]:)/,
-    "$1"
-  )
-}

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -55,6 +55,11 @@ export function resolvePreviewLayout(
   // Flip this preference in the same change that migrates those two serving
   // sites, not before.
   //
+  // The corollary binds the conversion step: writing a `preview.html` while
+  // leaving the halves in place means this keeps judging the halves, so a slug
+  // whose real content moved would be checked against stale files. Convert and
+  // delete in one commit.
+  //
   // Both halves are required. A lone `light.html` is a half-generated slug, and
   // reporting it as a usable split layout would hide that.
   if (exists(LIGHT_PREVIEW_FILE) && exists(DARK_PREVIEW_FILE)) return "split"

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -24,9 +24,12 @@ export const MERGED_PREVIEW_FILE = "preview.html"
 export const LIGHT_PREVIEW_FILE = "light.html"
 export const DARK_PREVIEW_FILE = "dark.html"
 
-export type PreviewLayout =
-  | { kind: "merged"; files: readonly [string] }
-  | { kind: "split"; files: readonly [string, string] }
+// Which of the two shapes a slug is in, and nothing more. An earlier draft also
+// carried the filenames, but no caller read them — `lightScopeFile` answers the
+// only question asked so far. The pair validator will want both halves; it can
+// add that when its merged-file semantics are settled, rather than inheriting a
+// field shaped by a guess.
+export type PreviewLayout = "merged" | "split"
 
 /**
  * Resolve the preview layout for one slug, given a predicate that answers
@@ -54,12 +57,8 @@ export function resolvePreviewLayout(
   //
   // Both halves are required. A lone `light.html` is a half-generated slug, and
   // reporting it as a usable split layout would hide that.
-  if (exists(LIGHT_PREVIEW_FILE) && exists(DARK_PREVIEW_FILE)) {
-    return { kind: "split", files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE] }
-  }
-  if (exists(MERGED_PREVIEW_FILE)) {
-    return { kind: "merged", files: [MERGED_PREVIEW_FILE] }
-  }
+  if (exists(LIGHT_PREVIEW_FILE) && exists(DARK_PREVIEW_FILE)) return "split"
+  if (exists(MERGED_PREVIEW_FILE)) return "merged"
   return null
 }
 
@@ -72,5 +71,5 @@ export function resolvePreviewLayout(
  * its dark block is scoped and therefore skipped by the drift walker.
  */
 export function lightScopeFile(layout: PreviewLayout): string {
-  return layout.kind === "merged" ? MERGED_PREVIEW_FILE : LIGHT_PREVIEW_FILE
+  return layout === "merged" ? MERGED_PREVIEW_FILE : LIGHT_PREVIEW_FILE
 }

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -51,8 +51,10 @@ export type PreviewLayout = "merged" | "split"
  * without a fixture tree, and lets the two callers keep their own base paths
  * (they resolve the preview directory differently).
  *
- * Returns `null` when neither layout is present. Callers must treat that as an
- * error — never as "nothing to check".
+ * Returns `null` when no layout is usable — which covers the half-generated
+ * slug (one theme file, no merged file) as well as the empty directory, since
+ * neither is something a gate can judge. Callers must treat `null` as an error,
+ * never as "nothing to check".
  */
 export function resolvePreviewLayout(
   exists: (file: string) => boolean

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -1,0 +1,66 @@
+// Which files hold a slug's preview.
+//
+// Two layouts exist. The catalogue ships the split one — `light.html` and
+// `dark.html`, near-duplicates that differ only in `data-theme`, the palette
+// block and a title. The merged one puts both themes in a single `preview.html`
+// so the ~89% of shared markup has one copy instead of two (issue #235).
+//
+// Readers ask here rather than joining a filename themselves. That is the whole
+// point: a reader that hardcodes `light.html` does not fail when the layout
+// changes, it silently checks nothing — the failure mode `scripts/audit-oklch.ts`
+// already warns about in its drift loop, and the one that let that same gate
+// compare 22 of 650 declarations without anyone noticing.
+//
+// The drift check needs no other change to read a merged file. It walks brace
+// depth and skips declarations scoped under `[data-theme="dark"]`, so a merged
+// document yields exactly the findings its light half would
+// (measured across all 17 slugs, with both mutation directions controlled).
+// That is a CONTRACT, not a coincidence: the merged file must scope its dark
+// tokens under `[data-theme="dark"]` and not at `:root`. Redefining them at
+// `:root` — the way `dark.html` legitimately does today, being a wholly dark
+// document — produces 138 false drift findings across the catalogue.
+
+export const MERGED_PREVIEW_FILE = "preview.html"
+export const LIGHT_PREVIEW_FILE = "light.html"
+export const DARK_PREVIEW_FILE = "dark.html"
+
+export type PreviewLayout =
+  | { kind: "merged"; files: readonly [string] }
+  | { kind: "split"; files: readonly [string, string] }
+
+/**
+ * Resolve the preview layout for one slug, given a predicate that answers
+ * whether a filename exists in that slug's directory.
+ *
+ * Taking `exists` as an argument rather than touching `fs` keeps this testable
+ * without a fixture tree, and lets the two callers keep their own base paths
+ * (they resolve the preview directory differently).
+ *
+ * Returns `null` when neither layout is present. Callers must treat that as an
+ * error — never as "nothing to check".
+ */
+export function resolvePreviewLayout(
+  exists: (file: string) => boolean
+): PreviewLayout | null {
+  if (exists(MERGED_PREVIEW_FILE)) {
+    return { kind: "merged", files: [MERGED_PREVIEW_FILE] }
+  }
+  // Both halves are required. A lone `light.html` is a half-generated slug, and
+  // reporting it as a usable split layout would hide that.
+  if (exists(LIGHT_PREVIEW_FILE) && exists(DARK_PREVIEW_FILE)) {
+    return { kind: "split", files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE] }
+  }
+  return null
+}
+
+/**
+ * The file whose light-scope token definitions the drift check should read.
+ *
+ * For the split layout that is `light.html`: `dark.html` redefines the same
+ * tokens at `:root` by design, so comparing it against the md's light values
+ * reports drift that is not drift. For the merged layout it is the one file —
+ * its dark block is scoped and therefore skipped by the drift walker.
+ */
+export function lightScopeFile(layout: PreviewLayout): string {
+  return layout.kind === "merged" ? MERGED_PREVIEW_FILE : LIGHT_PREVIEW_FILE
+}

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -42,13 +42,23 @@ export type PreviewLayout =
 export function resolvePreviewLayout(
   exists: (file: string) => boolean
 ): PreviewLayout | null {
-  if (exists(MERGED_PREVIEW_FILE)) {
-    return { kind: "merged", files: [MERGED_PREVIEW_FILE] }
-  }
+  // Split wins while both halves exist, because split is what the site
+  // actually serves: the iframe builds `/preview/{slug}/{theme}.html`
+  // (`src/routes/services/-components/preview-frame.tsx`) and the Vite plugin
+  // only discovers a slug that has a `light.html` (`vite.config.ts`). Judging a
+  // `preview.html` that nothing serves would let the shipped halves drift while
+  // the gate stayed green — this module's own failure mode, pointed backwards.
+  //
+  // Flip this preference in the same change that migrates those two serving
+  // sites, not before.
+  //
   // Both halves are required. A lone `light.html` is a half-generated slug, and
   // reporting it as a usable split layout would hide that.
   if (exists(LIGHT_PREVIEW_FILE) && exists(DARK_PREVIEW_FILE)) {
     return { kind: "split", files: [LIGHT_PREVIEW_FILE, DARK_PREVIEW_FILE] }
+  }
+  if (exists(MERGED_PREVIEW_FILE)) {
+    return { kind: "merged", files: [MERGED_PREVIEW_FILE] }
   }
   return null
 }

--- a/src/lib/preview-layout.ts
+++ b/src/lib/preview-layout.ts
@@ -11,6 +11,18 @@
 // already warns about in its drift loop, and the one that let that same gate
 // compare 22 of 650 declarations without anyone noticing.
 //
+// One reader has NOT moved here yet: `src/lib/preview-validator.ts`, reached
+// through `scripts/validate-preview.ts`, still joins both filenames itself. It
+// stayed behind because it validates the two halves as a pair — separate raw
+// text, separate byte counts, per-theme coverage metrics — and how a single
+// file splits into those is a question the merged format has to answer first.
+// `identical-style-blocks` is the sharpest case: it warns when the two halves
+// carry the same `<style>` content, which in a merged file has to become a
+// comparison between the `:root` scope and the `[data-theme="dark"]` one.
+// Convert it in the same change that converts the files. Left as it is past
+// that point, `validate:previews` walks straight into the trap this module was
+// written to close, while `audit:oklch` no longer can.
+//
 // The drift check needs no other change to read a merged file. It walks brace
 // depth and skips declarations scoped under `[data-theme="dark"]`, so a merged
 // document yields exactly the findings its light half would


### PR DESCRIPTION
#235(프리뷰 단일 파일 병합)의 1단계입니다. **프리뷰 파일은 하나도 바꾸지 않습니다** — 읽는 쪽만 두 레이아웃을 모두 이해하게 만듭니다.

## 왜 이 순서인가

지금 열려 있는 #272(greeting)와 #273(gmarket·vapor-ui)이 `light.html`/`dark.html` 쌍을 수정 중입니다. 파일 변환을 먼저 하면 두 PR의 diff가 존재하지 않는 파일을 대상으로 남아 해결할 수 없는 충돌이 됩니다. 이 PR은 그 파일들과 교집합이 0입니다.

## 무엇이 바뀌나

`src/lib/preview-layout.ts`(신규)가 "이 슬러그의 프리뷰는 어느 파일인가"를 답합니다. `light.html` + `dark.html` 쌍이 있으면 분리 레이아웃, 없고 `preview.html`이 있으면 병합 레이아웃, 어느 쪽도 아니면 `null`.

**두 레이아웃이 공존하면 분리가 이깁니다.** 오늘 서빙되는 게 그쪽이기 때문입니다 — iframe은 `/preview/{slug}/{theme}.html`을 요청하고([preview-frame.tsx:73](../blob/main/src/routes/services/-components/preview-frame.tsx#L73)), Vite 플러그인은 `light.html`이 있어야 슬러그를 발견합니다([vite.config.ts:90](../blob/main/vite.config.ts#L90)). 아무도 서빙하지 않는 `preview.html`을 판정하면 실제로 나가는 절반들이 드리프트해도 게이트가 초록입니다 — 이 모듈이 막으려는 실패를 반대 방향으로 재현하는 셈입니다. 서빙 경로 두 곳을 옮기는 변경에서 이 선호를 함께 뒤집으라고 주석에 남겼고, 그 따름정리로 **전환 커밋이 옛 절반을 같이 지워야 한다**는 것도 적어 뒀습니다.

`null`이 중요합니다. 한쪽 반만 있는 슬러그를 사용 가능한 레이아웃으로 인정하면 반쪽만 생성된 슬러그가 게이트를 통과합니다. 호출자는 `null`을 "검사할 것 없음"이 아니라 오류로 다뤄야 합니다.

**여기서 동작이 한 군데 엄격해집니다.** 예전 드리프트 루프는 `light.html` 존재만 확인하고 `dark.html` 유무는 보지 않았습니다. 이제 분리 레이아웃은 두 반쪽을 모두 요구하므로 `light.html`만 있는 슬러그는 통과가 아니라 실패합니다. 카탈로그 17개가 전부 쌍을 갖고 있어 실질 회귀는 없고, `validate:previews`가 이미 `missing-preview-file`로 block하던 판정과 일치하게 됩니다.

`scripts/audit-oklch.ts`의 드리프트 루프가 이 해석기를 씁니다. 그 루프는 원래 주석에 이렇게 적고 있었습니다 — *"프리뷰 파일 이름이 바뀌면(단일 파일 병합 등) 이 루프가 exit 0에 아무 출력 없이 통과해 '게이트는 초록인데 검사는 안 됨' 상태를 만든다."* 이 PR이 그 주석이 요구하던 일을 합니다.

## findPreviewDrift 는 고치지 않았습니다

이미 중괄호 깊이로 `[data-theme="dark"]` 스코프를 건너뛰도록 쓰여 있어서, 병합 문서에서도 라이트 절반과 같은 결과를 냅니다. 추측이 아니라 측정입니다:

| 검사 대상 | 드리프트 |
|---|---|
| `light.html` (17개 전수) | 0건 |
| `dark.html` 단독 (17개 전수) | **138건** |
| 병합 합성 문서 (17개 전수) | 0건 — 라이트와 동일 |

138이라는 숫자가 이 PR의 핵심 제약입니다. **병합 파일은 다크 토큰을 `[data-theme="dark"]` 아래 두어야 하고 `:root`에 두면 안 됩니다.** 오늘의 `dark.html`은 문서 전체가 다크라 `:root`에 재정의하는 게 맞지만, 병합 파일이 그러면 게이트가 오탐 138건으로 폭발합니다. 취향이 아니라 게이트가 강제하는 계약이라 코드 주석에 근거와 함께 적어 뒀습니다.

## 음성 대조

0건이 "통과"인지 "검사가 죽음"인지 갈랐습니다. 양방향 모두 밀었습니다:

- 라이트 스코프 값 변조 → **1건 잡힘** (`--tds-blue-500`)
- 다크 스코프 값 변조 → **0건, 무시됨**
- 변조가 실제로 파일에 적용됐는지도 확인

배선 자체도 end-to-end로 확인했습니다. `toss`를 병합-단독으로 바꾸고(절반 두 개 삭제) 라이트 값 하나를 틀리게 하니 `toss/preview.html — 1 drifted`를 보고했습니다 — 병합 파일을 **읽었고** 건너뛰지 않았습니다. 반대로 다크 블록에만 틀린 값을 넣으면 0건입니다.

같은 픽스처가 코퍼스 배선의 음성 대조도 됩니다. 그 상태로 `oklch-drift-corpus.test.ts`를 돌리면:

| 판본 | 결과 |
|---|---|
| HEAD (`light.html` 하드코딩) | `6 passed` — 조용한 0 |
| 이 PR | `toss --tds-blue-500` 지목해 실패 |

병합된 슬러그가 `slugs()` 필터에서 통째로 빠지면서 `MATCH_FLOOR`·스캐너 커버리지·무드리프트 보장을 함께 잃는데도, 남은 16개 슬러그가 스위트를 초록으로 유지하고 있었습니다. (임시 파일은 전부 커밋 전에 되돌렸습니다.)

측정 도중 "4개 슬러그 불일치"가 한 번 나왔는데, 제 합성 스크립트가 주석 뒤의 `:root`를 놓친 인공물이었습니다. 대용물을 고치니 전 슬러그 0건으로 수렴했습니다.

## 남긴 것

`scripts/validate-preview.ts` 배선은 뺐습니다. 그쪽은 `validatePreviewPair`가 light/dark 원문과 바이트 수를 따로 받아 테마별 지표를 내는데, 병합 파일에서 그 둘을 어떻게 나눌지는 병합 포맷이 정해져야 답할 수 있습니다. 지금 정하면 추측이 됩니다.

가장 날카로운 사례는 `identical-style-blocks`입니다 — 두 반쪽의 `<style>` 내용이 같으면 "다크가 복사본"이라고 경고하는 규칙이라, 병합 파일에서는 `:root` 스코프와 `[data-theme="dark"]` 스코프의 비교로 **의미 자체가 바뀌어야** 합니다.

**이건 2단계에서 반드시 함께 옮겨야 합니다.** 안 옮기면 이 PR이 `audit:oklch`에서 막은 함정에 `validate:previews`가 그대로 빠집니다 — 병합 후 조용히 절반만, 혹은 아무것도 검사하지 않게 됩니다. 잊히지 않도록 어느 리더가 남았는지와 그 이유를 `preview-layout.ts` 주석에 이름으로 적어 뒀습니다(`fd23a06`).

## 검증

`typecheck` · `lint` · `format:check` · `test`(549, 신규 9) · `validate:previews`(0 block) · `validate:catalog`(0 block) · `audit:oklch`(0 mismatch) · `tokens:check` 전부 통과.

`services/*.md`를 건드리지 않으므로 `check:last-updated` 대상이 아닙니다.

Refs #235
