### PR TITLE
fix(templates): 이슈 템플릿 자동 라벨을 레포 라벨과 맞춘다

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,6 +1,6 @@
 name: 📝 문서 개선
 description: README, CONTRIBUTING, 사이트 문서 등의 개선 제안
-labels: ["docs"]
+labels: ["documentation"]
 body:
   - type: dropdown
     id: target-doc

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -60,7 +60,7 @@
     "name": "javascript"
   },
   {
-    "color": "B60205",
+    "color": "b60205",
     "description": "저작권·상표 등 권리자의 콘텐츠·로고 삭제(takedown) 요청",
     "name": "legal/takedown"
   },

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,77 @@
+[
+  {
+    "color": "d73a4a",
+    "description": "Something isn't working",
+    "name": "bug"
+  },
+  {
+    "color": "0e8a16",
+    "description": "기존 카탈로그 항목 정정 제안",
+    "name": "catalog/correction"
+  },
+  {
+    "color": "0e8a16",
+    "description": "새 카탈로그 항목 제안",
+    "name": "catalog/new-entry"
+  },
+  {
+    "color": "0366d6",
+    "description": "Pull requests that update a dependency file",
+    "name": "dependencies"
+  },
+  {
+    "color": "0075ca",
+    "description": "Improvements or additions to documentation",
+    "name": "documentation"
+  },
+  {
+    "color": "cfd3d7",
+    "description": "This issue or pull request already exists",
+    "name": "duplicate"
+  },
+  {
+    "color": "a2eeef",
+    "description": "New feature or request",
+    "name": "enhancement"
+  },
+  {
+    "color": "000000",
+    "description": "Pull requests that update GitHub Actions code",
+    "name": "github_actions"
+  },
+  {
+    "color": "7057ff",
+    "description": "Good for newcomers",
+    "name": "good first issue"
+  },
+  {
+    "color": "008672",
+    "description": "Extra attention is needed",
+    "name": "help wanted"
+  },
+  {
+    "color": "e4e669",
+    "description": "This doesn't seem right",
+    "name": "invalid"
+  },
+  {
+    "color": "168700",
+    "description": "Pull requests that update javascript code",
+    "name": "javascript"
+  },
+  {
+    "color": "B60205",
+    "description": "저작권·상표 등 권리자의 콘텐츠·로고 삭제(takedown) 요청",
+    "name": "legal/takedown"
+  },
+  {
+    "color": "d876e3",
+    "description": "Further information is requested",
+    "name": "question"
+  },
+  {
+    "color": "ffffff",
+    "description": "This will not be worked on",
+    "name": "wontfix"
+  }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ git push --force-with-lease
 
 - **사이트 코드**: TypeScript + TanStack Start. PR 전 `pnpm typecheck && pnpm lint && pnpm build` 통과 필수.
 - **스킬 (`.claude/skills/design-md/`)**: 영향이 크므로 변경 의도를 이슈에서 먼저 합의해주세요. 특히 `SKILL.md`의 13단계 파이프라인이나 reference 문서 (`stitch-format.md`, `rubric-design.md`, `rubric-preview.md`)를 바꾸는 PR은 사전 협의 필수.
+- **이슈 템플릿 (`.github/ISSUE_TEMPLATE/*.yml`)**: 새 템플릿을 추가하거나 기존 템플릿의 `labels:`를 바꿀 때는 그 라벨이 레포에 실제로 존재하는지 먼저 확인하세요 (`gh label list`). 존재하지 않는 라벨은 이슈 생성 시 GitHub이 아무 에러 없이 조용히 빼버립니다 — 새 라벨이면 `gh label create`로 만들고 `.github/labels.json`에도 반영해야 `pnpm test`(`src/lib/issue-template-labels.test.ts`, CI 게이트)가 통과합니다.
 
 ---
 

--- a/src/lib/issue-template-labels.test.ts
+++ b/src/lib/issue-template-labels.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+const TEMPLATE_DIR = join(ROOT, ".github/ISSUE_TEMPLATE")
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8")
+}
+
+// GitHub issue forms silently drop any `labels:` entry that doesn't match an
+// existing repo label — no lint error at template-authoring time, no partial
+// apply, the issue is just created with one less label than the template
+// author intended. That is how #268 went unnoticed: new-catalog-entry.yml
+// named catalog/new-entry, the label had never been created, and the issue
+// opened with zero labels. .github/labels.json is a checked-in snapshot of
+// `gh label list`; this test is its only reader, so it must be refreshed
+// whenever a label is created, renamed, or deleted on GitHub (see
+// CONTRIBUTING.md §6) or this test starts passing against a stale roster
+// instead of the real one.
+describe("issue template labels", () => {
+  const knownLabels = new Set<string>(
+    (
+      JSON.parse(readRepoFile(".github/labels.json")) as Array<{
+        name: string
+      }>
+    ).map((l) => l.name)
+  )
+
+  const templateFiles = readdirSync(TEMPLATE_DIR).filter((f) =>
+    f.endsWith(".yml")
+  )
+
+  it("has at least one template with a labels: field to check", () => {
+    // Guards against the corpus silently going empty (e.g. every template
+    // renamed away from .yml) and this whole describe block passing on zero
+    // assertions.
+    const withLabels = templateFiles.filter((file) =>
+      /^labels:\s*\[.*\]\s*$/m.test(
+        readFileSync(join(TEMPLATE_DIR, file), "utf8")
+      )
+    )
+    expect(withLabels.length).toBeGreaterThan(0)
+  })
+
+  for (const file of templateFiles) {
+    // Issue forms declare labels as a top-level `labels: [...]` line — a
+    // JSON-ish array of quoted strings. A full YAML parse buys nothing for a
+    // field this constrained, and the repo has no other reason to depend on
+    // a YAML parser. config.yml (the template chooser) has no `labels:` line
+    // and is skipped by the match failing, not by special-casing the name.
+    const raw = readFileSync(join(TEMPLATE_DIR, file), "utf8")
+    const match = raw.match(/^labels:\s*(\[.*\])\s*$/m)
+    if (!match) continue
+
+    it(`${file}'s declared labels all exist on the repo`, () => {
+      const declared = JSON.parse(match[1]) as Array<string>
+      const missing = declared.filter((label) => !knownLabels.has(label))
+      expect(
+        missing,
+        `${file} names a label GitHub doesn't have — issues filed from it ` +
+          `will silently get created without it`
+      ).toEqual([])
+    })
+  }
+})

--- a/src/lib/issue-template-labels.test.ts
+++ b/src/lib/issue-template-labels.test.ts
@@ -62,7 +62,20 @@ describe("issue template labels", () => {
           `in that form, or extend the regex in this test to parse it`
       ).not.toBeNull()
 
-      const declared = JSON.parse(match![1]) as Array<string>
+      let declared: Array<string>
+      try {
+        declared = JSON.parse(match![1]) as Array<string>
+      } catch (err) {
+        // A regex match doesn't guarantee valid JSON inside the brackets
+        // (trailing comma, single-quoted strings, …). Without this, that
+        // case fails with a raw JSON.parse stack trace instead of the
+        // explanatory message the rest of this test is built around.
+        throw new Error(
+          `${file}'s labels: array matched the expected shape but isn't ` +
+            `valid JSON: ${(err as Error).message}`
+        )
+      }
+
       const missing = declared.filter((label) => !knownLabels.has(label))
       expect(
         missing,

--- a/src/lib/issue-template-labels.test.ts
+++ b/src/lib/issue-template-labels.test.ts
@@ -32,30 +32,37 @@ describe("issue template labels", () => {
     f.endsWith(".yml")
   )
 
-  it("has at least one template with a labels: field to check", () => {
-    // Guards against the corpus silently going empty (e.g. every template
-    // renamed away from .yml) and this whole describe block passing on zero
-    // assertions.
-    const withLabels = templateFiles.filter((file) =>
-      /^labels:\s*\[.*\]\s*$/m.test(
-        readFileSync(join(TEMPLATE_DIR, file), "utf8")
-      )
-    )
-    expect(withLabels.length).toBeGreaterThan(0)
+  it("finds issue templates to check", () => {
+    // Guards against the corpus silently going empty (e.g. the directory
+    // moving) and this whole describe block passing on zero assertions.
+    expect(templateFiles.length).toBeGreaterThan(0)
   })
 
   for (const file of templateFiles) {
-    // Issue forms declare labels as a top-level `labels: [...]` line — a
-    // JSON-ish array of quoted strings. A full YAML parse buys nothing for a
-    // field this constrained, and the repo has no other reason to depend on
-    // a YAML parser. config.yml (the template chooser) has no `labels:` line
-    // and is skipped by the match failing, not by special-casing the name.
     const raw = readFileSync(join(TEMPLATE_DIR, file), "utf8")
-    const match = raw.match(/^labels:\s*(\[.*\])\s*$/m)
-    if (!match) continue
+    // A bare presence check, independent of format — config.yml (the
+    // template chooser) genuinely has no `labels:` line and is the only file
+    // meant to skip the assertion below.
+    if (!/^labels:/m.test(raw)) continue
 
+    // Issue forms declare labels as a top-level `labels: [...]` line — a
+    // JSON-ish array of double-quoted strings. A full YAML parse buys
+    // nothing for a field this constrained, and the repo has no other
+    // reason to depend on a YAML parser. But a checker that silently skips
+    // whatever it can't parse reproduces the exact failure mode it exists to
+    // catch — a label going unverified with no signal — so an unrecognized
+    // `labels:` shape (multi-line array, single quotes, …) is a hard failure
+    // here rather than a skip.
     it(`${file}'s declared labels all exist on the repo`, () => {
-      const declared = JSON.parse(match[1]) as Array<string>
+      const match = raw.match(/^labels:\s*(\[.*\])\s*$/m)
+      expect(
+        match,
+        `${file} has a labels: field this checker doesn't understand ` +
+          `(expected a single-line, double-quoted JSON array) — rewrite it ` +
+          `in that form, or extend the regex in this test to parse it`
+      ).not.toBeNull()
+
+      const declared = JSON.parse(match![1]) as Array<string>
       const missing = declared.filter((label) => !knownLabels.has(label))
       expect(
         missing,


### PR DESCRIPTION
## Summary

- 이슈 템플릿(`.github/ISSUE_TEMPLATE/*.yml`)의 `labels:`가 가리키는 라벨이 레포에 없으면 이슈 생성 시 조용히 안 붙는다는 걸 #268에서 확인했다.
- `new-catalog-entry.yml`(`catalog/new-entry`)·`entry-correction.yml`(`catalog/correction`)이 가리키던 라벨을 레포에 생성했다.
- `documentation.yml`이 가리키던 `docs`는 실제 존재하는 `documentation`으로 정정했다.
- 소급 조치로 #268에 `catalog/new-entry` 라벨을 수동으로 붙여뒀다.

## Test plan

- [x] `gh label list`로 `catalog/new-entry` · `catalog/correction` 생성 확인
- [ ] 머지 후 각 템플릿으로 이슈를 새로 열어 라벨이 자동으로 붙는지 확인