### PR TITLE
test(preview): merge-preview-themes 의 가드 3개를 회귀 테스트로 고정한다

### DIFF
--- a/src/lib/preview-merge-anchors.test.ts
+++ b/src/lib/preview-merge-anchors.test.ts
@@ -486,3 +486,90 @@ describe("merge-preview-themes and an author's own html[data-theme] scope", () =
     expect(halves.dark).toContain("html body")
   })
 })
+
+// Three guards in the converter's DOM walk, each the fix for a bug that shipped
+// once. Their reasons lived only in comments, which is not enough: #285 removed
+// a `scopeSelector` duplicate as "a selector nobody writes" when it was the only
+// mark `preview-halves.unscopeSelector` had to tell two sources apart, and no
+// test said otherwise. These pin the observable difference each guard makes, so
+// the next reader who thinks one is dead weight finds out here instead of in a
+// merged file.
+//
+// Each was checked by disabling the guard and re-running: the SVG one starts
+// writing the template INSIDE the <svg>, the mixed one shreds a paragraph into
+// three swaps, and the anchor one throws outright.
+
+describe("merge-preview-themes and <svg>", () => {
+  // `<template>` exists only in the HTML namespace. Parsed back inside `<svg>`
+  // it is a foreign element with no `.content`, so the runtime finds nothing to
+  // swap and the dark artwork is silently gone — the one failure shape a diff
+  // does not show, because the bytes are all still there.
+  it("keeps the variant template outside the svg it varies", () => {
+    const html = merge(
+      `<svg viewBox="0 0 10 10"><path d="M0 0h10"/></svg>`,
+      `<svg viewBox="0 0 10 10"><path d="M0 0v10"/></svg>`
+    )
+
+    // Everything up to the first `</svg>` is the light artwork. A template in
+    // there is the bug; refusing to descend puts it after the closing tag.
+    const lightSvg = html.slice(
+      html.indexOf("<svg"),
+      html.indexOf("</svg>") + 6
+    )
+    expect(lightSvg).not.toContain("<template")
+
+    // The whole <svg> is paired instead of its <path> — one swap, and what it
+    // holds is an <svg>, not a fragment of one.
+    expect(ops(html)).toEqual(["swap"])
+    expect(html).toContain('data-theme-op="swap"><svg')
+  })
+})
+
+describe("merge-preview-themes and mixed-content prose", () => {
+  // A paragraph of text and inline markup cannot be aligned piecewise. Matching
+  // its text nodes positionally spliced half of one theme's sentence onto half
+  // of the other's ("…축이다.인데, gr…") — output that reads as grammatical
+  // Korean, so neither the diff nor the rendered page shows it.
+  //
+  // The guard's contract is what this asserts: such a node is paired WHOLE. It
+  // costs one duplicated paragraph and makes the splice unreachable, because
+  // neither sentence is ever split at a theme boundary.
+  it("pairs a paragraph of text and inline markup whole", () => {
+    const light = `<p class="lead">토큰은 <strong>축</strong>이다.</p>`
+    const dark = `<p class="lead">토큰은 축인데, <strong>값</strong>은 하나다.</p>`
+    const html = merge(light, dark)
+
+    expect(ops(html)).toEqual(["swap"])
+    // Each theme's sentence survives as one contiguous run.
+    expect(html).toContain(light)
+    expect(html).toContain(dark)
+    // Per-fragment text swaps are the shape piecewise alignment leaves behind —
+    // including one nested inside the <strong>. None belongs in a paired node.
+    expect(html).not.toContain("data-theme-text")
+  })
+})
+
+describe("merge-preview-themes and a replaced anchor", () => {
+  // `align()` computes the op list before any mutation, so a later dark-only op
+  // can name an anchor that an earlier op has since replaced. A bare text
+  // difference is exactly that case: it is wrapped in a span, detaching the text
+  // node the anchor points at.
+  //
+  // The existing anchor tests above use whole-element swaps, which never detach
+  // anything, so this path had no coverage at all.
+  it("follows a text node that was wrapped into a span", () => {
+    const html = merge(
+      `<div class="box">라이트</div>`,
+      `<div class="box">다크<p class="only">다크 전용</p></div>`
+    )
+
+    // Without the redirect the insert has a detached anchor and the converter
+    // throws, so reaching any assertion here is already half the test.
+    expect(ops(html)).toEqual(["swap", "insert"])
+    expect(html).toContain('<span data-theme-text="">라이트</span>')
+    // And it lands after the swap that replaced its anchor, not before it.
+    expect(html.indexOf('data-theme-op="insert"')).toBeGreaterThan(
+      html.indexOf('data-theme-op="swap"')
+    )
+  })
+})


### PR DESCRIPTION
`scripts/merge-preview-themes.mjs` 의 가드 셋에 회귀 테스트가 없었다. 셋 다 #235 에서 실제로 터졌다가 고쳐진 버그의 방어벽인데, **왜 있는지가 주석에만** 있었다.

무테스트임을 실측했다 — 기존 테스트에서 `svg` 0건 · `namespaceURI` 0건 · `mixed` 0건 · `replacedBy` 0건 · `strong` 0건.

## 왜 지금

이 스크립트는 더 이상 프로덕션 경로가 아니라 회귀가 사용자에게 닿지 않는다. 실제 위험은 **다음 사람이 셋 중 하나를 "정리" 했을 때 아무것도 막지 않는 것**이고, #285 에서 그대로 났다 — `scopeSelector` 의 중복 속성을 "아무도 안 쓰는 선택자" 라며 없앴는데 그게 `preview-halves.unscopeSelector` 가 두 출처를 가르는 유일한 표식이었다.

## 각 테스트가 가드를 빼면 red 인지 확인했다

이슈의 명시 요구이고, 이 저장소에서 통과만 확인한 테스트가 아무것도 지키지 않던 사례가 반복됐다. 가드를 하나씩 무력화하고 해당 테스트만 돌려 확인한 뒤 되돌렸다 (`git status` 로 스크립트 변경 0 확인).

| 가드 | 위치 | 제거 시 실제 산출물 |
| --- | --- | --- |
| SVG 네임스페이스 | `:969` | `<template>` 이 **`<svg>` 안**으로 — `<svg …><path/><template …><path/></template></svg>`. 재파싱 때 `.content` 없는 foreign element라 다크가 조용히 증발한다 |
| 문장 합성 `mixed` | `:1032-1034` | 문단이 **swap 3개로 파쇄**되고 `<strong>` 안에까지 template 이 생긴다 |
| 앵커 리다이렉트 | `:1012` · `:1230-1232` | **크래시** — `anchor.parentNode` 가 null |

셋 다 `-t` 필터로 `1 failed | 25 skipped` 를 확인했다. 즉 각 테스트가 **자기 가드에만** 반응한다.

## `mixed` 테스트는 이슈가 적은 접합을 단언하지 않는다

이슈가 인용한 `…축이다.인데, gr…` 를 픽스처로 재현하지 못했다. LCS 정렬이 생각보다 강건해서, 조각 수가 맞으면 조각별로 스왑해도 양쪽 문장이 복원된다. 조각 수를 어긋내도 `light-only`/`dark-only` 로 갈려 역시 복원됐다.

**재현하지 못한 실패를 단언하면 테스트가 거짓말을 한다.** 대신 가드가 실제로 보장하는 성질을 건다 — *"이런 노드는 통째로 쌍짓는다"*, 즉 양쪽 문장이 각각 온전하고 문장 안에 테마 경계가 생기지 않는다. 가드를 빼면 이 성질이 깨지는 것은 위 표대로 확인했다.

## 하네스는 신규 작성이 아니다

`preview-merge-anchors.test.ts:45-65` 의 `merge(lightBody, darkBody)` 가 임시 디렉터리에 두 반쪽을 쓰고 스크립트를 `execFileSync` 로 **진짜 실행**한다. 픽스처 3개 + 단언 몇 줄이 전부다.

## 검증

```
typecheck · lint · format:check   통과
vitest                            46 files · 643 tests (신규 3)
validate:previews                 0 blocking · 0 warn (기준선 동일)
```

디스크의 프리뷰를 건드리지 않고 `services/*.md` 도 무변경이라 `check:last-updated` 는 해당 없음.

Closes #299
