### PR TITLE
feat(seo): 홈 필터 쿼리를 noindex,follow 로 명시한다

### DIFF
--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -47,7 +47,7 @@ describe("page SEO", () => {
   } satisfies ServiceDoc
 
   it("builds a unique canonical homepage with a WebSite collection graph", () => {
-    const head = buildHomeSeo()
+    const head = buildHomeSeo({ isFiltered: false })
 
     expect(head.meta).toContainEqual({
       title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
@@ -62,6 +62,22 @@ describe("page SEO", () => {
         ],
       },
     })
+  })
+
+  it("noindexes a filtered home view but keeps / as its canonical", () => {
+    // A filter narrows the same list; it adds no indexable content of its own.
+    // Canonical must NOT follow the filter — it names the page to prefer.
+    const filtered = buildHomeSeo({ isFiltered: true })
+
+    expect(filtered.meta).toContainEqual({
+      name: "robots",
+      content: "noindex,follow",
+    })
+    expect(filtered.links).toContainEqual({ rel: "canonical", href: "/" })
+    // The unfiltered list is the indexable one, so it carries no robots meta.
+    expect(buildHomeSeo({ isFiltered: false }).meta).not.toContainEqual(
+      expect.objectContaining({ name: "robots" })
+    )
   })
 
   it("uses the clean service URL as canonical for every tab view", () => {

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -157,7 +157,9 @@ describe("page SEO", () => {
   // it. Nothing else in the pipeline notices, which is why it is pinned here.
   it("hands JSON-LD to the router as data, not as a serialized string", () => {
     for (const head of [
-      buildHomeSeo(),
+      // `isFiltered` is required (issue #269) — the shape being pinned here is
+      // the JSON-LD value, and either filter state carries the same one.
+      buildHomeSeo({ isFiltered: false }),
       buildServiceSeo(tossDoc, { isTabView: false }),
     ]) {
       const entry = jsonLdMeta(head)

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -100,7 +100,29 @@ export function serviceCanonicalPath(slug: string): string {
   return `/services/${slug}`
 }
 
-export function buildHomeSeo(): SeoHead {
+/**
+ * The home head. `isFiltered` says whether the URL narrows the catalogue list
+ * with `?cat=` or `?q=`.
+ *
+ * A filtered view is `noindex,follow` and still canonicals to `/`. It renders
+ * the same cards as the full list, only fewer, and carries no title or
+ * description of its own — there is nothing in it for a crawler to index that
+ * `/` does not already have. `?q=` is user-typed on top of that, so its URL
+ * space is unbounded. `follow` rather than `none` because the links out of a
+ * filtered list are the same catalogue links worth crawling.
+ *
+ * Canonical stays `/` in both cases rather than naming the filtered URL:
+ * canonical points at the page a crawler should prefer, and that is the whole
+ * list.
+ *
+ * `buildServiceSeo` answers the same question for tab states — a URL that
+ * varies the view without varying the content — and this mirrors it, down to
+ * the options-object shape and where the robots meta sits.
+ *
+ * The parameter is required rather than defaulted: this policy went unwritten
+ * because nothing in the signature asked (issue #269).
+ */
+export function buildHomeSeo(options: { isFiltered: boolean }): SeoHead {
   const canonical = absoluteUrl("/")
   const image = absoluteUrl("/og/default.png")
 
@@ -108,6 +130,9 @@ export function buildHomeSeo(): SeoHead {
     meta: [
       { title: HOME_TITLE },
       { name: "description", content: HOME_DESCRIPTION },
+      ...(options.isFiltered
+        ? [{ name: "robots", content: "noindex,follow" }]
+        : []),
       { property: "og:type", content: "website" },
       ...SITE_OG_META,
       ...ogLocaleMeta("ko"),

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -115,6 +115,14 @@ export function serviceCanonicalPath(slug: string): string {
  * canonical points at the page a crawler should prefer, and that is the whole
  * list.
  *
+ * The answer comes from the URL, never from what the filter happens to return.
+ * A category holding every entry would still be `noindex` — today none holds
+ * more than 3 of 17, so the case is hypothetical, but the rule is not about
+ * this catalogue's shape. An indexing directive that varied with the data would
+ * flip a URL between indexable and not as entries land, and a crawler that
+ * cached the indexable answer would be acting on a page that has since retracted
+ * it. A stable directive is worth more than a marginally more precise one.
+ *
  * `buildServiceSeo` answers the same question for tab states — a URL that
  * varies the view without varying the content — and this mirrors it, down to
  * the options-object shape and where the robots meta sits.

--- a/src/routes/-seo-head.test.ts
+++ b/src/routes/-seo-head.test.ts
@@ -8,7 +8,9 @@ const tossDoc = getServiceBySlug("toss")!
 
 describe("route SEO heads", () => {
   it("uses homepage metadata with the clean root URL as canonical", async () => {
-    const head = await HomeRoute.options.head?.({} as never)
+    const head = await HomeRoute.options.head?.({
+      match: { search: {} },
+    } as never)
 
     expect(head?.meta).toContainEqual({
       title: "한국 서비스 디자인 시스템 카탈로그 | ko/design.md",
@@ -93,5 +95,60 @@ describe("route SEO heads", () => {
       name: "robots",
       content: "noindex,follow",
     })
+  })
+})
+
+// The home list narrows with `?cat=` and `?q=`. Those URLs render the same
+// cards as `/` — fewer of them, with no title or description of their own — so
+// the policy is `noindex,follow` with `/` as canonical either way (issue #269).
+//
+// These go through `validateSearch` before `head`, in that order, because that
+// is the order the router runs them and because the normalization it does is
+// half the policy: a `cat` that names no category and an empty `q` produce the
+// FULL list, so they must stay indexable. Asserting against a hand-built search
+// object would test the head in isolation and miss that.
+describe("home filter queries and indexing", () => {
+  // Concrete rather than `Record<string, unknown>`: the route's own validator
+  // takes the wide type because a URL is external input, but a test writes the
+  // query itself and knows its shape.
+  async function homeHead(raw: { cat?: string; q?: string }) {
+    const validateSearch = HomeRoute.options.validateSearch
+    if (typeof validateSearch !== "function") {
+      throw new Error("Home route must expose a search validator function")
+    }
+    return await HomeRoute.options.head?.({
+      match: { search: validateSearch(raw) },
+    } as never)
+  }
+
+  const NOINDEX = { name: "robots", content: "noindex,follow" }
+  const CANONICAL = { rel: "canonical", href: "/" }
+
+  it.each([
+    ["a category filter", { cat: "finance" }],
+    ["a search query", { q: "토스" }],
+    ["both at once", { cat: "finance", q: "토스" }],
+  ])("noindexes %s", async (_label, raw) => {
+    const head = await homeHead(raw)
+    expect(head?.meta).toContainEqual(NOINDEX)
+    // Canonical never follows the filter — it names the page to prefer.
+    expect(head?.links).toContainEqual(CANONICAL)
+  })
+
+  it.each([
+    ["the unfiltered list", {}],
+    // `validateSearch` drops both of these, so the page IS the full list and
+    // the head must not noindex it. Measured against the dev server, the router
+    // goes further and answers these two URLs with `307 → /` rather than
+    // rendering at all — so at the HTTP level they are already deduplicated,
+    // and this pins the head for the case that reaches it.
+    ["a cat that names no category", { cat: "없는카테고리" }],
+    ["an empty q", { q: "" }],
+  ])("leaves %s indexable", async (_label, raw) => {
+    const head = await homeHead(raw)
+    expect(head?.meta).not.toContainEqual(
+      expect.objectContaining({ name: "robots" })
+    )
+    expect(head?.links).toContainEqual(CANONICAL)
   })
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,7 +16,15 @@ interface HomeSearch {
 }
 
 export const Route = createFileRoute("/")({
-  head: () => buildHomeSeo(),
+  // `validateSearch` below already normalizes an unknown `cat` and an empty `q`
+  // to undefined, so those URLs are NOT filtered views and stay indexable —
+  // they render the full list. Reading the validated search rather than the raw
+  // query is what makes that true.
+  head: ({ match }) =>
+    buildHomeSeo({
+      isFiltered:
+        match.search.cat !== undefined || match.search.q !== undefined,
+    }),
   // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
   validateSearch: (raw: Record<string, unknown>): HomeSearch => {
     const cat =

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,16 +15,35 @@ interface HomeSearch {
   q?: string
 }
 
+// Which search params narrow the catalogue list, which is the question the home
+// head's indexing policy turns on (issue #269).
+//
+// The annotation is the point of the map: `Record<keyof HomeSearch, boolean>`
+// requires every key, so adding a param to `HomeSearch` is a compile error here
+// until someone says whether it narrows. (An annotation rather than `satisfies`
+// — the latter keeps the literal `true` types, which makes the `narrows` check
+// below dead code.) Written as a bare `search.cat !== undefined || search.q !== undefined`
+// the two would drift apart silently — the new param would just never be counted,
+// and a filtered view would go on advertising itself as the canonical list.
+// A param that changes the view without narrowing it gets `false` rather than an
+// exemption from the map.
+const NARROWS_LIST: Record<keyof HomeSearch, boolean> = {
+  cat: true,
+  q: true,
+}
+
+function isFiltered(search: HomeSearch): boolean {
+  return Object.entries(NARROWS_LIST).some(
+    ([key, narrows]) => narrows && search[key as keyof HomeSearch] !== undefined
+  )
+}
+
 export const Route = createFileRoute("/")({
   // `validateSearch` below already normalizes an unknown `cat` and an empty `q`
   // to undefined, so those URLs are NOT filtered views and stay indexable —
   // they render the full list. Reading the validated search rather than the raw
   // query is what makes that true.
-  head: ({ match }) =>
-    buildHomeSeo({
-      isFiltered:
-        match.search.cat !== undefined || match.search.q !== undefined,
-    }),
+  head: ({ match }) => buildHomeSeo({ isFiltered: isFiltered(match.search) }),
   // eslint-disable-next-line no-restricted-syntax -- URL search params are untyped external input.
   validateSearch: (raw: Record<string, unknown>): HomeSearch => {
     const cat =


### PR DESCRIPTION
`?cat=` 와 `?q=` 의 색인 정책이 정해진 적이 없었다. 원인이 코드에 드러나 있다 — `head: () => buildHomeSeo()` 는 **인자를 받지 않아 물어볼 자리 자체가 없었다.**

## 결정: 필터 뷰는 `noindex,follow`, canonical 은 `/` 유지

필터 뷰는 같은 카드의 부분집합이고 카테고리별 고유 title/description 이 없어 `/` 가 갖지 않은 색인 대상이 없다. `?q=` 는 사용자가 타이핑하므로 URL 공간이 무한하다. `none` 이 아니라 `follow` 인 것은 필터된 목록에서 나가는 링크가 크롤링할 가치가 있는 같은 카탈로그 링크이기 때문이다.

**canonical 은 필터를 따라가지 않는다** — canonical 은 크롤러가 선호할 페이지를 가리키는 것이고 그건 전체 목록이다.

`buildServiceSeo` 가 탭 상태에 대해 같은 질문(내용은 그대로인데 뷰만 바뀌는 URL)에 이미 답하고 있어, 옵션 객체 모양과 robots meta 위치까지 그대로 맞췄다. **인자는 기본값 없이 필수**로 뒀다 — 시그니처가 묻지 않아서 정책이 안 적힌 것이었으니, 다음 호출자는 답하고 지나가게 된다.

## dev 서버 실측 — 유닛 호출이 아니라 실제 SSR `<head>`

| URL | HTTP | robots | canonical |
| --- | --- | --- | --- |
| `/` | 200 | 없음 | `/` |
| `?cat=finance` | 200 | **noindex,follow** | `/` |
| `?q=토스` | 200 | **noindex,follow** | `/` |
| `?cat=finance&q=토스` | 200 | **noindex,follow** | `/` |
| `?cat=없는카테고리` | **307 → `/`** | — | — |
| `?q=` | **307 → `/`** | — | — |

**마지막 두 줄이 예상 밖이었다.** `validateSearch` 가 값을 떨어뜨리자 라우터가 URL 자체를 정규화해 리다이렉트한다 — 렌더조차 하지 않는다. 즉 그 두 경우는 HTTP 레벨에서 이미 중복이 해소돼 있고, head 단언은 head 에 도달하는 경우를 고정한다. 이걸 확인하지 않았으면 "noindex 를 안 붙이면 색인된다" 고 쓸 뻔했다. 발견을 테스트 주석에 남겼다.

## 테스트

`validateSearch` → `head` 순서로 통과시킨다. 라우터가 그 순서로 돌리기 때문이고, **정규화가 정책의 절반**이기 때문이다 — 모르는 `cat` 과 빈 `q` 는 전체 목록을 렌더하므로 색인 가능해야 한다. 손으로 만든 search 객체로 단언하면 head 를 고립시켜 이 합성을 놓친다.

`seo.test.ts` 에는 필터/비필터 대조 1건, `-seo-head.test.ts` 에는 `it.each` 로 6경우.

## 검증

```
typecheck · lint   통과
vitest             46 files · 647 tests (신규 7)
format:check       변경 파일 4개 전부 통과
```

`format:check` 전체는 `.claude/skills/docs-crawler/` 14개 파일에서 실패하는데 CLAUDE.md 가 기록한 Windows CRLF 오탐이라 손대지 않았다. `services/*.md` 무변경이므로 `check:last-updated` 해당 없음.

Closes #269
