### PR TITLE
docs(seo): JSON-LD 의 SSR 이탈 불가를 실측하고 shape 를 고정한다

### DIFF
--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -166,19 +166,36 @@ describe("page SEO", () => {
   // that is the version this guard is worth spending a red build on.
   it("keeps the JSON-LD escaping note tied to the router major it was measured on", () => {
     const MEASURED_MAJOR = 1
+    // The lockfile rather than `node_modules/@tanstack/router-core/package.json`
+    // because that path is not resolvable: router-core is a transitive dep, so
+    // pnpm's strict layout does not link it at the root, and the package does
+    // not export its own package.json either — `require.resolve` on it answers
+    // MODULE_NOT_FOUND. The lockfile is committed, so it also reads the same in
+    // CI as it does here.
     const lock = readFileSync(join(process.cwd(), "pnpm-lock.yaml"), "utf8")
-    const found = lock.match(/^\s*'@tanstack\/router-core@(\d+)\.\d+\.\d+':/m)
 
-    // A miss means the lockfile shape changed, not that the version is fine.
+    // Every occurrence, not the first: the name appears under `packages:` and
+    // again under `snapshots:`. Today both say the same thing, but a split peer
+    // resolution could put two majors in the file, and picking one silently is
+    // the failure this guard exists to prevent. Two distinct majors fails here.
+    const majors = [
+      ...new Set(
+        [
+          ...lock.matchAll(/^\s*'@tanstack\/router-core@(\d+)\.\d+\.\d+':/gm),
+        ].map((m) => m[1])
+      ),
+    ]
+
+    // Nothing found is a lockfile-format change, not a passing version.
     expect(
-      found,
+      majors,
       "could not read @tanstack/router-core out of pnpm-lock.yaml — the lockfile format changed, so this guard is no longer reading anything"
-    ).not.toBeNull()
+    ).not.toEqual([])
 
     expect(
-      Number(found?.[1]),
-      `@tanstack/router-core moved to a new major. Re-measure the JSON-LD escaping (render a catalog entry whose name carries </script> through the SSR path, count bare < and & in the ld+json block), update the note at the top of seo.ts, then bump MEASURED_MAJOR here.`
-    ).toBe(MEASURED_MAJOR)
+      majors,
+      `@tanstack/router-core is no longer on exactly major ${MEASURED_MAJOR}. Re-measure the JSON-LD escaping (render a catalog entry whose name carries </script> through the SSR path, count bare < and & in the ld+json block), update the note at the top of seo.ts, then bump MEASURED_MAJOR here.`
+    ).toEqual([String(MEASURED_MAJOR)])
   })
 
   it("makes 404 pages noindex without a canonical or social preview", () => {

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -130,6 +130,25 @@ describe("page SEO", () => {
     })
   })
 
+  // Not a safety test — the router escapes a hostile catalog string either way,
+  // measured both ways through the real SSR path (see the note at the top of
+  // `seo.ts`, issue #270). This is a VALIDITY test: hand the router
+  // `JSON.stringify(article)` and the block comes out as a JSON string that
+  // contains JSON, double-encoded, and a crawler reads nothing structured from
+  // it. Nothing else in the pipeline notices, which is why it is pinned here.
+  it("hands JSON-LD to the router as data, not as a serialized string", () => {
+    for (const head of [
+      buildHomeSeo(),
+      buildServiceSeo(tossDoc, { isTabView: false }),
+    ]) {
+      const entry = jsonLdMeta(head)
+      expect(entry).toBeDefined()
+      const value = entry?.["script:ld+json"]
+      expect(typeof value).toBe("object")
+      expect(value).not.toBeNull()
+    }
+  })
+
   it("makes 404 pages noindex without a canonical or social preview", () => {
     const head = buildNotFoundSeo()
     expect(head.meta).toContainEqual({

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   buildHomeSeo,
@@ -147,6 +149,36 @@ describe("page SEO", () => {
       expect(typeof value).toBe("object")
       expect(value).not.toBeNull()
     }
+  })
+
+  // The escaping note at the top of `seo.ts` is a MEASUREMENT, and measurements
+  // expire. It was taken against @tanstack/router-core 1.171.24 — which this
+  // project does not depend on directly: it arrives under
+  // `@tanstack/react-router@^1.170.22`, a caret range, so a lockfile
+  // regeneration can move it with nothing in CI saying so. The shape test above
+  // would stay green through an escaping-strategy change, because it never looks
+  // at the escaping.
+  //
+  // Pinned at the MAJOR only, deliberately. An exact pin would go red on every
+  // dependabot bump, and this repo batches lockfile PRs — friction that lands on
+  // unrelated work gets routed around rather than read. How a library serializes
+  // its output is part of its contract, so a change to it belongs in a major;
+  // that is the version this guard is worth spending a red build on.
+  it("keeps the JSON-LD escaping note tied to the router major it was measured on", () => {
+    const MEASURED_MAJOR = 1
+    const lock = readFileSync(join(process.cwd(), "pnpm-lock.yaml"), "utf8")
+    const found = lock.match(/^\s*'@tanstack\/router-core@(\d+)\.\d+\.\d+':/m)
+
+    // A miss means the lockfile shape changed, not that the version is fine.
+    expect(
+      found,
+      "could not read @tanstack/router-core out of pnpm-lock.yaml — the lockfile format changed, so this guard is no longer reading anything"
+    ).not.toBeNull()
+
+    expect(
+      Number(found?.[1]),
+      `@tanstack/router-core moved to a new major. Re-measure the JSON-LD escaping (render a catalog entry whose name carries </script> through the SSR path, count bare < and & in the ld+json block), update the note at the top of seo.ts, then bump MEASURED_MAJOR here.`
+    ).toBe(MEASURED_MAJOR)
   })
 
   it("makes 404 pages noindex without a canonical or social preview", () => {

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 import {
   buildHomeSeo,
@@ -172,7 +173,11 @@ describe("page SEO", () => {
     // not export its own package.json either — `require.resolve` on it answers
     // MODULE_NOT_FOUND. The lockfile is committed, so it also reads the same in
     // CI as it does here.
-    const lock = readFileSync(join(process.cwd(), "pnpm-lock.yaml"), "utf8")
+    // Resolved from this file, not `process.cwd()`: a test should read the same
+    // lockfile whatever directory the runner was started in.
+    // `preview-merge-anchors.test.ts` resolves its repo root the same way.
+    const root = fileURLToPath(new URL("../..", import.meta.url))
+    const lock = readFileSync(join(root, "pnpm-lock.yaml"), "utf8")
 
     // Every occurrence, not the first: the name appears under `packages:` and
     // again under `snapshots:`. Today both say the same thing, but a split peer
@@ -181,7 +186,12 @@ describe("page SEO", () => {
     const majors = [
       ...new Set(
         [
-          ...lock.matchAll(/^\s*'@tanstack\/router-core@(\d+)\.\d+\.\d+':/gm),
+          ...lock.matchAll(
+            // `[^']*` after the patch so a prerelease (`1.171.24-rc.1`) still
+            // reports its major instead of falling through to the "lockfile
+            // format changed" branch, which would name the wrong cause.
+            /^\s*'@tanstack\/router-core@(\d+)\.\d+\.\d+[^']*':/gm
+          ),
         ].map((m) => m[1])
       ),
     ]

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -2,6 +2,25 @@ import { truncateForMeta } from "./content-parser"
 import { SITE_NAME, absoluteUrl } from "./site-config"
 import type { Lang, ServiceDoc } from "./content-types"
 
+// A catalog string cannot break out of the JSON-LD script element. Measured
+// rather than argued (issue #270): an entry whose `name` and tagline carried
+// `</script><script>alert(1)</script>`, `<img src=x onerror=…>` and `<!--` was
+// rendered through the real SSR path (@tanstack/router-core 1.171.24), and
+// every angle bracket and ampersand came out as a unicode escape — a
+// backslash-u sequence for code point 3C in place of each `<`, one for 26 in
+// place of each `&`. Counted over the emitted block: 7 of the former, 2 of the
+// latter, ZERO bare `<` or `&` anywhere in it. `JSON.parse` still returns the
+// original characters, so a crawler reads the value undamaged.
+//
+// So there is no defensive encoder in this file, and adding one would corrupt
+// the value it claims to protect.
+//
+// The same run measured the near miss, because it is the one worth naming.
+// Handing the router `JSON.stringify(article)` instead of the object is still
+// SAFE — identical escaping, still zero bare `<` — but it emits a JSON *string*
+// containing JSON rather than an object, so a crawler gets nothing usable. What
+// the shape buys is validity, not safety, and `seo.test.ts` pins it on those
+// terms.
 type JsonLdPrimitive = string | number | boolean | null
 type JsonLdValue = JsonLdPrimitive | JsonLdObject | ReadonlyArray<JsonLdValue>
 type JsonLdObject = { [key: string]: JsonLdValue }


### PR DESCRIPTION
이슈의 완료 기준이 **"실제 SSR 출력 경로를 재현한다"** 라, 추정하지 않고 쟀다.

## 방법

`name` 과 tagline 에 적대적 문자열을 담은 임시 카탈로그 항목을 만들고 dev 서버로 렌더한 뒤 응답 HTML 을 뜯었다 (항목은 즉시 삭제, 이 PR 에 없음).

```
name:    A</script><script>alert(1)</script>B & <!-- C
tagline: 프로브는 </script><img src=x onerror=alert(2)> 와 & 기호, 그리고 <!-- …
```

## 결과 — 이탈 불가

`@tanstack/router-core 1.171.24` 가 꺾쇠와 앰퍼샌드를 **전부 유니코드 이스케이프**로 내보낸다.

| ld+json 블록 안 | |
| --- | --- |
| 꺾쇠 이스케이프 | **7회** |
| 앰퍼샌드 이스케이프 | **2회** |
| 맨 `<` | **0회** |
| 맨 `&` | **0회** |
| `JSON.parse` 왕복 | **원본과 일치** |

스크립트 요소를 닫을 수 없고, 동시에 파싱하면 원본 문자열이 복원되므로 크롤러가 읽는 값은 손상되지 않는다. **이스케이프와 무손실이 양립하는 지점**이라 방어 인코더를 얹으면 이중 이스케이프로 값만 망가진다. 그래서 이 PR 은 인코더를 넣지 않는다.

문서 전체에도 실행 가능한 리터럴이 새어나오지 않았다 — meta content 는 `&lt;/script&gt;`, 본문은 React 텍스트 이스케이프, Vite 모듈 페이로드는 `\x3C` 로 나온다.

## 같은 실행에서 잰 근접 사례 — 그리고 제 초안이 틀렸던 지점

처음엔 *"`JSON.stringify(article)` 로 넘기면 라우터가 인코딩하는 데이터가 아니게 된다"* 고 코멘트에 적었다. **측정이 그 문장을 반증했다.** 실제로 바꿔 렌더해 보니:

```
"{\"@context\":\"https://schema.org\",\"headline\":\"A<...>/script<...>…\"}"
```

여전히 **안전하다** — 같은 이스케이프, 맨 꺾쇠 0개. 대신 **JSON 을 담은 JSON 문자열**로 이중 인코딩되어 크롤러가 구조화 데이터로 못 읽는다.

즉 shape 가 지키는 것은 **주입 안전이 아니라 JSON-LD 유효성**이다. 코멘트와 테스트를 그 조건으로 다시 썼다. 측정하지 않았으면 "문자열로 넘기면 위험하다" 는 거짓을 코드 주석에 박을 뻔했다.

## 남기는 것

- `seo.ts` 상단에 **측정 결과 + 라우터 버전 + 왜 인코더가 없는지**를 기록. 다음 리뷰가 같은 질문을 다시 열지 않도록.
- `seo.test.ts` 에 shape 고정 1건. 헛돌지 않는 것도 확인했다 — `JSON.stringify` 로 바꾸면 red 다.

위험 표면은 서비스 라우트 하나다. 홈의 `@graph` 는 값이 전부 상수라 카탈로그 문자열이 들어가지 않는다.

## 검증

```
typecheck · lint   통과
vitest             46 files · 641 tests (신규 1)
```

`services/*.md` 무변경 → `check:last-updated` 해당 없음. 임시 프로브 항목은 삭제 확인했다 (`git status` 비어 있음).

> #301 과 `src/lib/seo.test.ts` 에서 한 줄 겹친다 — 그쪽이 `buildHomeSeo` 에 인자를 추가한다. 나중에 머지되는 쪽에서 호출 한 줄만 맞추면 된다.

Closes #270
