### PR TITLE
refactor(seo): SeoMeta 를 실제 쓰이는 네 형태로 좁힌다

### DIFF
--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -187,8 +187,12 @@ describe("SeoMeta shapes", () => {
       { "scirpt:ld+json": { "@type": "Article" } },
       // @ts-expect-error one entry renders one tag: JSON-LD or content, not both.
       { "script:ld+json": { "@type": "Article" }, content: "둘 다" },
+      // @ts-expect-error and `title` wins that race outright — the router's tag
+      // chain checks `m.title` before `"script:ld+json" in m`, so this entry
+      // would render a title and drop the JSON-LD block entirely.
+      { "script:ld+json": { "@type": "Article" }, title: "제목" },
     ]
 
-    expect(rejected).toHaveLength(6)
+    expect(rejected).toHaveLength(7)
   })
 })

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -180,8 +180,10 @@ describe("SeoMeta shapes", () => {
       { content: "고아" },
       // @ts-expect-error JSON-LD must stay structured data, not a string.
       { "script:ld+json": "{}" },
+      // @ts-expect-error the JSON-LD key itself, misspelled.
+      { "scirpt:ld+json": { "@type": "Article" } },
     ]
 
-    expect(rejected).toHaveLength(4)
+    expect(rejected).toHaveLength(5)
   })
 })

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -170,7 +170,10 @@ describe("SeoMeta shapes", () => {
     expect(ok).toHaveLength(4)
   })
 
-  it("rejects a typo, a half-written tag, and an orphaned content", () => {
+  // Three axes, so a case added later has somewhere to belong and the name
+  // above does not drift out of date the way an enumeration would: the KEY is
+  // wrong, the PAIRING of keys is wrong, or the VALUE under a right key is.
+  it("rejects a wrong key, a broken pairing, or a wrong value", () => {
     const rejected: Array<SeoMeta> = [
       // @ts-expect-error `property` misspelled — renders a meta tag with no key.
       { propety: "og:type", content: "website" },

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -182,8 +182,10 @@ describe("SeoMeta shapes", () => {
       { "script:ld+json": "{}" },
       // @ts-expect-error the JSON-LD key itself, misspelled.
       { "scirpt:ld+json": { "@type": "Article" } },
+      // @ts-expect-error one entry renders one tag: JSON-LD or content, not both.
+      { "script:ld+json": { "@type": "Article" }, content: "둘 다" },
     ]
 
-    expect(rejected).toHaveLength(5)
+    expect(rejected).toHaveLength(6)
   })
 })

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -5,7 +5,7 @@ import {
   buildServiceSeo,
   serviceCanonicalPath,
 } from "./seo"
-import type { SeoHead } from "./seo"
+import type { SeoHead, SeoMeta } from "./seo"
 import type { ServiceDoc } from "./content-types"
 
 const tossDoc = {
@@ -149,3 +149,39 @@ describe("page SEO", () => {
 function jsonLdMeta(head: SeoHead) {
   return head.meta.find((entry) => "script:ld+json" in entry)
 }
+
+// Type-level, and `pnpm typecheck` is the gate: an `@ts-expect-error` that does
+// NOT error fails the build with "Unused '@ts-expect-error' directive". So each
+// one below is an assertion that the shape is genuinely rejected, not a comment
+// hoping it is.
+//
+// These are the mistakes the wide `Record<string, string | JsonLdObject>` used
+// to wave through, every one of which renders as a silently useless tag rather
+// than as a crash (issue #271).
+describe("SeoMeta shapes", () => {
+  it("accepts the four shapes the head API is given", () => {
+    const ok: Array<SeoMeta> = [
+      { title: "제목" },
+      { name: "description", content: "설명" },
+      { property: "og:type", content: "website" },
+      { "script:ld+json": { "@type": "Article" } },
+    ]
+
+    expect(ok).toHaveLength(4)
+  })
+
+  it("rejects a typo, a half-written tag, and an orphaned content", () => {
+    const rejected: Array<SeoMeta> = [
+      // @ts-expect-error `property` misspelled — renders a meta tag with no key.
+      { propety: "og:type", content: "website" },
+      // @ts-expect-error a name with no content renders an empty tag.
+      { name: "description" },
+      // @ts-expect-error content with neither name nor property names nothing.
+      { content: "고아" },
+      // @ts-expect-error JSON-LD must stay structured data, not a string.
+      { "script:ld+json": "{}" },
+    ]
+
+    expect(rejected).toHaveLength(4)
+  })
+})

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -5,7 +5,35 @@ import type { Lang, ServiceDoc } from "./content-types"
 type JsonLdPrimitive = string | number | boolean | null
 type JsonLdValue = JsonLdPrimitive | JsonLdObject | ReadonlyArray<JsonLdValue>
 type JsonLdObject = { [key: string]: JsonLdValue }
-type SeoMeta = Record<string, string | JsonLdObject>
+/**
+ * One entry in a head's `meta` array. Four shapes are used and the first three
+ * are spelled out, so a typo (`propety`) or a half-written tag (`name` with no
+ * `content`) is a compile error rather than an empty tag in the HTML.
+ *
+ * The fourth member is deliberately NOT `{ "script:ld+json": JsonLdObject }`,
+ * and the reason is in the router's own types (issue #271). `head`'s `meta` is
+ * declared `Array<React.JSX.IntrinsicElements['meta']>`, whose properties are
+ * all optional — a WEAK TYPE, which TypeScript accepts an object for only if
+ * the two share at least one property. `title`, `name` and `content` are
+ * shared; `script:ld+json` is a router convention that React's `<meta>` props
+ * do not declare, so a member naming only that key has nothing in common and
+ * `tsc` rejects the whole head:
+ *
+ *   Type '{ "script:ld+json": JsonLdObject; }' has no properties in common
+ *   with type 'DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, …>'
+ *
+ * An index signature is exempt from that check — it is treated as carrying
+ * every property — which is why the wide `Record<string, string | JsonLdObject>`
+ * this replaced ever compiled. Keeping an index signature for the JSON-LD
+ * member alone preserves the exemption while the three tag shapes get real
+ * checking. It is still narrower than what it replaced: values must be objects,
+ * so a serialized string is rejected here too.
+ */
+export type SeoMeta =
+  | { title: string }
+  | { name: string; content: string }
+  | { property: string; content: string }
+  | Record<string, JsonLdObject>
 
 export interface SeoHead {
   meta: Array<SeoMeta>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -10,30 +10,34 @@ type JsonLdObject = { [key: string]: JsonLdValue }
  * are spelled out, so a typo (`propety`) or a half-written tag (`name` with no
  * `content`) is a compile error rather than an empty tag in the HTML.
  *
- * The fourth member is deliberately NOT `{ "script:ld+json": JsonLdObject }`,
- * and the reason is in the router's own types (issue #271). `head`'s `meta` is
- * declared `Array<React.JSX.IntrinsicElements['meta']>`, whose properties are
- * all optional — a WEAK TYPE, which TypeScript accepts an object for only if
- * the two share at least one property. `title`, `name` and `content` are
- * shared; `script:ld+json` is a router convention that React's `<meta>` props
- * do not declare, so a member naming only that key has nothing in common and
- * `tsc` rejects the whole head:
+ * `content?: undefined` on the fourth member is load-bearing, and the reason is
+ * in the router's own types (issue #271). `head`'s `meta` is declared
+ * `Array<React.JSX.IntrinsicElements['meta']>`, whose properties are all
+ * optional — a WEAK TYPE, which TypeScript accepts an object for only if the
+ * two share at least one property. `title`, `name` and `content` are shared;
+ * `script:ld+json` is a router convention that React's `<meta>` props do not
+ * declare. Written as `{ "script:ld+json": JsonLdObject }` alone the member has
+ * nothing in common, and `tsc` rejects the whole head:
  *
  *   Type '{ "script:ld+json": JsonLdObject; }' has no properties in common
  *   with type 'DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, …>'
  *
- * An index signature is exempt from that check — it is treated as carrying
- * every property — which is why the wide `Record<string, string | JsonLdObject>`
- * this replaced ever compiled. Keeping an index signature for the JSON-LD
- * member alone preserves the exemption while the three tag shapes get real
- * checking. It is still narrower than what it replaced: values must be objects,
- * so a serialized string is rejected here too.
+ * The check asks only whether a property is shared, not what it holds, so
+ * declaring `content` as `undefined` satisfies it while forbidding the value —
+ * a JSON-LD entry is not also a `content` tag.
+ *
+ * The alternative is an index signature, which is exempt from the check because
+ * it reads as carrying every property. That is why the wide
+ * `Record<string, string | JsonLdObject>` this replaced ever compiled, and it is
+ * exactly what the marker avoids: an index signature buys the exemption by
+ * giving up the key, so `scirpt:ld+json` would compile. Both are pinned in
+ * `seo.test.ts`.
  */
 export type SeoMeta =
   | { title: string }
   | { name: string; content: string }
   | { property: string; content: string }
-  | Record<string, JsonLdObject>
+  | { "script:ld+json": JsonLdObject; content?: undefined }
 
 export interface SeoHead {
   meta: Array<SeoMeta>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -10,10 +10,12 @@ type JsonLdObject = { [key: string]: JsonLdValue }
  * are spelled out, so a typo (`propety`) or a half-written tag (`name` with no
  * `content`) is a compile error rather than an empty tag in the HTML.
  *
- * `content?: undefined` on the fourth member is load-bearing, and the reason is
- * in the router's own types (issue #271). `head`'s `meta` is declared
- * `Array<React.JSX.IntrinsicElements['meta']>`, whose properties are all
- * optional — a WEAK TYPE, which TypeScript accepts an object for only if the
+ * The `undefined` markers on the fourth member are load-bearing twice over, and
+ * both reasons live outside this file (issue #271).
+ *
+ * FIRST, they get the member accepted at all. `head`'s `meta` is declared
+ * `Array<React.JSX.IntrinsicElements['meta'] | undefined>`, whose properties are
+ * all optional — a WEAK TYPE, which TypeScript accepts an object for only if the
  * two share at least one property. `title`, `name` and `content` are shared;
  * `script:ld+json` is a router convention that React's `<meta>` props do not
  * declare. Written as `{ "script:ld+json": JsonLdObject }` alone the member has
@@ -23,8 +25,22 @@ type JsonLdObject = { [key: string]: JsonLdValue }
  *   with type 'DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, …>'
  *
  * The check asks only whether a property is shared, not what it holds, so
- * declaring `content` as `undefined` satisfies it while forbidding the value —
- * a JSON-LD entry is not also a `content` tag.
+ * declaring one as `undefined` satisfies it while forbidding the value.
+ *
+ * SECOND — and this is why `title` is here and not just `content` — the router
+ * renders one tag per entry, by a chain that tries `title` first:
+ *
+ *   if (m.title) { …title tag… }
+ *   else if ("script:ld+json" in m) { …ld+json script… }
+ *   else { …name/property meta… }
+ *   (@tanstack/react-router, dist/esm/headContentUtils.js)
+ *
+ * So an entry carrying BOTH `title` and `script:ld+json` renders the title and
+ * the JSON-LD is never emitted — the whole block, silently. `content` alongside
+ * `script:ld+json` is the harmless one: it falls to the same branch and the
+ * JSON-LD renders fine. The first draft of this type forbade only `content`,
+ * which blocked the harmless pairing and let the destructive one compile.
+ * Both are pinned in `seo.test.ts`.
  *
  * The alternative is an index signature, which is exempt from the check because
  * it reads as carrying every property. That is why the wide
@@ -37,7 +53,11 @@ export type SeoMeta =
   | { title: string }
   | { name: string; content: string }
   | { property: string; content: string }
-  | { "script:ld+json": JsonLdObject; content?: undefined }
+  | {
+      "script:ld+json": JsonLdObject
+      content?: undefined
+      title?: undefined
+    }
 
 export interface SeoHead {
   meta: Array<SeoMeta>


### PR DESCRIPTION
`SeoMeta = Record<string, string | JsonLdObject>` 는 서로 다른 meta 태그 형태를 전부 뭉뚱그려, 오타도 반만 쓴 태그도 통과시켰다. 셋 다 크래시가 아니라 **조용히 쓸모없는 태그**로 렌더된다.

## 완료 기준 1번: 라우터가 무엇을 받는지 먼저 확인했다

```ts
// @tanstack/react-router 1.17.x — Matches.d.ts
interface RouteMatchExtensions {
  meta?: Array<React.JSX.IntrinsicElements['meta'] | undefined>
  …
}
```

React 의 `MetaHTMLAttributes` 는 `charSet` · `content` · `httpEquiv` · `media` · `name` 뿐이고 전부 선택이다 — **weak type** 이라 대입하려면 공통 프로퍼티가 최소 하나 있어야 한다.

네 형태를 전부 리터럴 유니온으로 적어 보고 실제로 재 봤다:

```
Type '{ "script:ld+json": JsonLdObject; }' has no properties in common
with type 'DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, …>'
```

`title` · `name` · `content` 는 공통이지만 **`script:ld+json` 은 공통 프로퍼티가 0개**다. 라우터 자신의 관례인데 그 React 어댑터 타입이 선언하지 않는다. 즉 **완전한 좁힘은 불가능**하다.

## 해법: 공통 프로퍼티를 하나 만들어 준다 (`dd0bbd4`)

```ts
export type SeoMeta =
  | { title: string }
  | { name: string; content: string }
  | { property: string; content: string }
  | { "script:ld+json": JsonLdObject; content?: undefined }
```

weak type 검사는 **공통 프로퍼티가 하나라도 있는지만** 묻고 그게 무엇을 담는지는 보지 않는다. `content` 를 `undefined` 로 선언하면 조건을 만족하면서 값은 금지된다 — JSON-LD 항목이 동시에 `content` 태그일 수는 없으니 의미도 맞는다.

**첫 초안은 여기에 `Record<string, JsonLdObject>` 를 썼다.** 인덱스 시그니처도 검사에서 면제되지만(모든 프로퍼티를 가진 것으로 취급 — 기존 넓은 타입이 애초에 컴파일되던 이유), **면제를 사는 대신 키를 포기하는 거래**라 `scirpt:ld+json` 오타가 통과한다. 리뷰가 이 공백을 짚었고, 마커는 면제만 얻고 키 검사를 지킨다.

근거를 양방향으로 쟀다 — 마커를 빼면 `has no properties in common` 오류가 **2건**(두 head 자리) 나고, 되돌리면 **0건**이다.

## 잡히는 것 — 그리고 그게 실제로 잡히는지 확인했다

게이트는 `pnpm typecheck` 다. `@ts-expect-error` 가 실제로 에러를 만들지 않으면 `Unused '@ts-expect-error' directive` 로 빌드가 깨지므로, 아래 넷은 **주석이 아니라 단언**이다.

| 거부되는 형태 | 왜 위험한가 |
| --- | --- |
| `{ propety: "og:type", content: … }` | 키 없는 meta 태그 |
| `{ name: "description" }` | 빈 태그 |
| `{ content: "고아" }` | 무엇도 가리키지 않음 |
| `{ "script:ld+json": "{}" }` | 구조화 데이터가 아님 |
| `{ "scirpt:ld+json": {…} }` | 키 오타 — 렌더는 되지만 JSON-LD 가 아님 |

**넓은 타입으로 되돌려 5개 전부 미사용이 되는 것을 확인**했다. 즉 이 테스트는 좁힘을 재고 있지 다른 것을 재고 있지 않다.

## 검증

```
typecheck · lint · format:check   통과
vitest                            46 files · 642 tests (신규 2, @ts-expect-error 5건)
```

**런타임 무변경** — 순수 타입 리팩터이고 `satisfies Array<SeoMeta>`(`:20`)도 그대로 성립한다. `services/*.md` 무변경이라 `check:last-updated` 해당 없음.

> #301 · #302 와 `src/lib/seo.ts` · `seo.test.ts` 에서 인접한 줄을 건드린다. 세 PR 이 서로 다른 자리를 고쳐 충돌은 작지만, 마지막에 머지되는 쪽에서 한 번 맞춰 주면 된다.

Closes #271

