### PR TITLE
docs(tokens): 다크 접두사 예시가 두 슬러그를 뒤섞은 것을 고친다

### DIFF
--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -116,10 +116,13 @@ export function curateColors(colors: Array<ColorToken>): {
 // Entries mark dark-theme tokens two different ways, and the card filter has to
 // understand both:
 //   1. name prefix   — seed-design writes `dark-gray-00` against a bare
-//      `gray-00`, 109 such pairs. codeit prefixes BOTH themes instead
-//      (`light-gray-00` / `dark-gray-00`, 78 each, no bare name), which is the
-//      reason the test names `dark-` alone: `light-` entries are light tokens
-//      and have to survive it.
+//      `gray-00`: 112 such pairs across its sidecar, 109 of them colours and 3
+//      shadows (`s1`/`dark-s1`…). Counting only the colours understates what
+//      this filter covers, and the shadow trio is the pair it most recently
+//      missed. codeit prefixes BOTH themes instead (`light-gray-00` /
+//      `dark-gray-00`, 78 colours each, no bare name), which is the reason the
+//      test names `dark-` alone: `light-` entries are light tokens and have to
+//      survive it.
 //   2. group heading — wanted writes `### Semantic alias — Dark` and REUSES the
 //      light names (`bg-canvas` exists in both themes), so the name alone can't
 //      tell them apart. Without the group check those 23 dark swatches render in

--- a/src/lib/token-curation.ts
+++ b/src/lib/token-curation.ts
@@ -115,7 +115,11 @@ export function curateColors(colors: Array<ColorToken>): {
 
 // Entries mark dark-theme tokens two different ways, and the card filter has to
 // understand both:
-//   1. name prefix   — codeit writes `dark-gray-00` (light counterpart is `gray-00`)
+//   1. name prefix   — seed-design writes `dark-gray-00` against a bare
+//      `gray-00`, 109 such pairs. codeit prefixes BOTH themes instead
+//      (`light-gray-00` / `dark-gray-00`, 78 each, no bare name), which is the
+//      reason the test names `dark-` alone: `light-` entries are light tokens
+//      and have to survive it.
 //   2. group heading — wanted writes `### Semantic alias — Dark` and REUSES the
 //      light names (`bg-canvas` exists in both themes), so the name alone can't
 //      tell them apart. Without the group check those 23 dark swatches render in

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,13 +27,13 @@ interface HomeSearch {
 // and a filtered view would go on advertising itself as the canonical list.
 // A param that changes the view without narrowing it gets `false` rather than an
 // exemption from the map.
-const NARROWS_LIST: Record<keyof HomeSearch, boolean> = {
+const NARROWS_MAP: Record<keyof HomeSearch, boolean> = {
   cat: true,
   q: true,
 }
 
 function isFiltered(search: HomeSearch): boolean {
-  return Object.entries(NARROWS_LIST).some(
+  return Object.entries(NARROWS_MAP).some(
     ([key, narrows]) => narrows && search[key as keyof HomeSearch] !== undefined
   )
 }


### PR DESCRIPTION
사실 오류 하나와 부정확한 이름 하나. 둘 다 동작 무변경이다.

## ① 다크 접두사 예시가 두 슬러그를 뒤섞었다

`src/lib/token-curation.ts` 의 주석이 이렇게 적고 있었다:

> `1. name prefix — codeit writes `dark-gray-00` (light counterpart is `gray-00`)`

**codeit 사이드카에 맨 `gray-00` 은 0건이다.** 실측:

| 슬러그 | `dark-*` | 접두사 뗀 이름이 실재 | 실제 모양 |
| --- | --- | --- | --- |
| **seed-design** | 109 | **109** | `dark-gray-00` ↔ `gray-00` |
| **codeit** | 78 | **0** | `light-gray-00` / `dark-gray-00` — 양쪽 다 접두사 |

즉 주석이 든 짝은 seed-design 것이고, codeit 은 정반대 사례다.

**예시가 틀린 것만 문제가 아니다.** codeit 의 실제 모양은 필터 설계의 근거를 하나 더 담고 있는데 주석이 그걸 말하지 않았다 — **양쪽 다 접두사를 쓰는 항목이 있으므로 검사가 `dark-` 만 이름해야 하고 `light-` 는 살아남아야 한다.** 그 근거를 함께 적었다.

동작은 원래 맞았다. `/^dark-/` 가 의도대로 걸리고 `light-*` 는 통과한다. 이건 주석만의 결함이다.

수치는 코드로 재확인했고, 기존 주석의 wanted `23 dark swatches` 도 여전히 정확하다(`DARK_GROUP` 매칭 23건, 그룹명 `Semantic alias — Dark`).

## ② `NARROWS_LIST` → `NARROWS_MAP`

리스트가 아니라 `Record<keyof HomeSearch, boolean>` 이다. 바로 위 주석 산문이 이미 *"The annotation is the point of **the map**"*, *"exemption from **the map**"* 이라고 부르고 있어 이름만 어긋나 있었다. PR #301 리뷰 지적.

## 출처

①은 네 PR 을 합쳐 놓고 돌린 다중 렌즈 서브에이전트 리뷰가 찾았다(주석↔코드 대조 렌즈). ②는 #301 리뷰가 머지 직후 남긴 nit 이다.

## 검증

```
typecheck · lint · format:check   통과
vitest                            46 files · 654 tests
```

`services/*.md` 무변경 → `check:last-updated` 해당 없음.
