### PR TITLE
test(seo): JSON-LD 이스케이핑을 라우터를 통과시켜 매 실행 검증한다

### DIFF
--- a/src/lib/seo-jsonld-render.test.tsx
+++ b/src/lib/seo-jsonld-render.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react"
+import {
+  HeadContent,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router"
+import { afterEach, describe, expect, it } from "vitest"
+import { buildServiceSeo } from "./seo"
+import type { ServiceDoc } from "./content-types"
+
+// The note at the top of `seo.ts` says a catalog string cannot break out of the
+// JSON-LD script element, and until now that was a measurement taken by hand
+// against a dev server (issue #270). Review kept returning to the same gap: the
+// claim was pinned only by `MEASURED_MAJOR`, which assumes the router treats its
+// escaping as part of the semver contract. Nothing re-took the measurement.
+//
+// This does, on every run, through the router's own head pipeline. It needs no
+// SSR harness — `buildTagsFromMatches` applies the escaping on both paths, so a
+// client render in jsdom observes the same output the server writes. (Verified:
+// the string below comes out identical here and from `pnpm dev`.)
+const HOSTILE = "A</script><script>alert(1)</script>B & <!-- C"
+
+const doc = {
+  frontmatter: {
+    name: HOSTILE,
+    slug: "escaping-probe",
+    category: "etc",
+    last_updated: "2026-08-18",
+    created_at: "2026-08-18",
+    sources: [],
+    related_services: [],
+    lang: "ko",
+  },
+  raw: "",
+  body: "",
+  tagline: `프로브 ${HOSTILE} 끝`,
+  filePath: "/services/escaping-probe.md",
+  estimatedTokens: 1,
+} satisfies ServiceDoc
+
+async function renderJsonLd(): Promise<string> {
+  const rootRoute = createRootRoute({ component: () => <HeadContent /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    head: () => buildServiceSeo(doc, { isTabView: false }),
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  })
+  // The head tags are derived from loaded matches, so the route has to resolve
+  // before anything is in the tree to read.
+  await router.load()
+  const { container } = render(<RouterProvider router={router} />)
+  const script = container.querySelector('script[type="application/ld+json"]')
+  if (!script?.textContent) {
+    throw new Error(
+      "no JSON-LD script rendered — the router's head pipeline changed shape, so this guard is no longer measuring anything"
+    )
+  }
+  return script.textContent
+}
+
+afterEach(cleanup)
+
+describe("JSON-LD escaping, through the router that does it", () => {
+  it("emits no character that could close the script element", async () => {
+    const rendered = await renderJsonLd()
+
+    // The control. Without it this test would pass just as happily against a
+    // pipeline that had stopped escaping AND stopped including the string.
+    expect(rendered).toContain("alert(1)")
+    expect(JSON.stringify(doc.frontmatter.name)).toContain("</script>")
+
+    // And the claim: not one bare angle bracket or ampersand survives, so
+    // `</script>` cannot appear no matter what a catalog entry is named.
+    expect(rendered).not.toContain("<")
+    expect(rendered).not.toContain("&")
+  })
+
+  it("still parses back to the original characters", async () => {
+    // Escaping that damaged the value would be its own bug — a crawler has to
+    // read the real name. This is why `seo.ts` adds no encoder of its own: the
+    // router's escaping is already lossless and a second pass would not be.
+    const parsed: { headline: string; description: string } = JSON.parse(
+      await renderJsonLd()
+    )
+    expect(parsed).toMatchObject({
+      headline: expect.stringContaining(HOSTILE),
+      description: expect.stringContaining(HOSTILE),
+    })
+  })
+})


### PR DESCRIPTION
`seo.ts` 상단의 *"카탈로그 문자열이 JSON-LD 스크립트 요소를 벗어날 수 없다"* 는 dev 서버로 **한 번 손으로 잰 값**이었다. 고정하는 건 `MEASURED_MAJOR` 가드뿐이고, 그건 **라우터가 이스케이핑을 semver 계약으로 다룬다는 가정**에 기댄다. #302 리뷰가 세 라운드에 걸쳐 같은 부채를 짚었다:

> 서드파티가 이스케이핑 같은 보안 인접 동작을 semver 계약의 일부로 취급한다는 보장은 없고, 마이너/패치에서 "버그 수정" 으로 이스케이핑 전략이 바뀌는 사례는 실제로 종종 있습니다.

이제 매 실행 다시 잰다.

## SSR 하네스는 필요 없었다

리뷰도 나도 *"`renderToString` 류 하네스가 없다"* → *"그러니 못 한다"* 로 읽었는데, **두 명제가 붙지 않는다.**

`buildTagsFromMatches` 는 `isServer` 분기 **밖**에서 이스케이프를 적용한다. 그래서 jsdom 클라이언트 렌더가 서버와 같은 출력을 낸다. 메모리 히스토리 + 최소 라우트 트리에 우리 `buildServiceSeo` 를 물리면 라우터의 head 파이프라인을 그대로 통과한다 — 목이 아니라 실물이다.

출력이 dev 서버 실측과 동일한 것을 확인했다:

```
{"headline":"A\u003c/script\u003e\u003cscript\u003ealert(1)\u003c/script\u003eB \u0026 …"}
```

## 단언 둘

| | 왜 |
| --- | --- |
| 맨 `<` · `&` 가 **0개** | `</script>` 가 나올 수 없다 |
| `JSON.parse` 왕복 일치 | **이스케이프가 값을 망가뜨려도 버그다.** `seo.ts` 가 자체 인코더를 안 넣는 이유가 이것 — 라우터 쪽이 이미 무손실인데 한 번 더 걸면 아니게 된다 |

## 헛돌지 않게 대조를 같은 테스트에 뒀다

```ts
expect(rendered).toContain("alert(1)")                              // 문자열이 실제로 실려 있고
expect(JSON.stringify(doc.frontmatter.name)).toContain("</script>") // 이스케이프 전엔 위험한 형태다
```

이게 없으면 **문자열이 아예 빠진 파이프라인에도 통과**하는 테스트가 된다.

스크립트 태그를 못 찾으면 `no JSON-LD script rendered — the router's head pipeline changed shape, so this guard is no longer measuring anything` 으로 던진다. "못 재는 것" 과 "재서 통과한 것" 은 다르다.

## 실제로 무는지 확인했다

라우터의 `escapeHtml` 을 항등함수로 바꾸고 돌렸다:

```
AssertionError: expected '{"@context":"https://schema.org","@ty…' not to contain '<'
Tests  1 failed | 1 passed (2)
```

되돌린 뒤 다시 2/2 통과. `node_modules` 는 원상복구했다.

## 두 가드의 분업

| | 무엇을 잡나 |
| --- | --- |
| `MEASURED_MAJOR` (기존) | **버전**이 바뀌면 — 메이저 업그레이드 시 재측정을 강제 |
| 이 테스트 (신규) | **동작**이 바뀌면 — 마이너·패치에서 조용히 바뀌어도 |

## 검증

```
typecheck · lint · format:check   통과
vitest                            47 files · 656 tests (신규 2)
```

`services/*.md` 무변경 → `check:last-updated` 해당 없음.
