### PR TITLE
feat(catalog): 멋쟁이사자처럼(LIKELION)을 카탈로그에 추가한다

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -71,6 +71,7 @@ until then, update this section whenever a logo file is added or removed.
   krds.svg                       KRDS (national emblem — see above)
   kyobobook-logotype.png         교보문고
   kyobobook.png                  교보문고
+  likelion.svg                   멋쟁이사자처럼
   line-design-system.png         라인
   seed-design-symbol.png         당근
   seed-design.svg                당근

--- a/public/logos/likelion.svg
+++ b/public/logos/likelion.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60' viewBox='0 0 120 60'><path d='M0 0L34.85 21.8083V60H85.1583V45.9333H41.8833V0H0ZM85.15 0V21.8083L120 0H85.15Z' fill='#FF6000'/></svg>

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -256,6 +256,7 @@
       border-radius: var(--ll-radius-full);
       background: var(--ll-bg-normal);
       color: var(--ll-fg-secondary);
+      font-family: inherit;
       cursor: pointer;
       flex: none;
     }

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -603,6 +603,10 @@
     }
     .section-desc { margin: 10px 0 0; font-size: var(--ll-fs-body3); line-height: 1.6; color: var(--ll-fg-secondary); word-break: keep-all; }
 
+    /* .span-6 collapses to full width only under 720px (below); it stays
+       side-by-side through the 721-1024px band on purpose — tracks are
+       minmax(0, 1fr) and .panel children carry min-width: 0 + keep-all, so a
+       half-width column never overflows there. */
     .grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 20px; }
     .span-6 { grid-column: span 6; }
     .span-12 { grid-column: 1 / -1; }

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -501,8 +501,11 @@
       min-width: 32px;
       height: 32px;
       padding: 0 6px;
+      border: none;
       border-radius: var(--ll-radius-1);
+      background: transparent;
       color: var(--ll-fg-secondary);
+      font: inherit;
       font-size: 13px;
       font-weight: 600;
       cursor: pointer;

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -571,7 +571,7 @@
       left: 50%;
       transform: translateX(-50%);
       border: 5px solid transparent;
-      border-top-color: var(--ll-fg-normal);
+      border-top-color: var(--ll-gray-800);
     }
 
     /* ============ Showcase shell (section / grid / panel) ============ */
@@ -734,7 +734,7 @@
     .page-foot { display: flex; justify-content: center; padding: 0 28px 28px; }
 
     @media (max-width: 720px) {
-      .shell { padding: 0 18px; }
+      .shell { padding-left: 18px; padding-right: 18px; }
       .section { padding: 48px 0; }
       .grid { gap: 16px; }
       .span-6, .span-12 { grid-column: 1 / -1; }
@@ -924,18 +924,18 @@
           <p class="panel-title">Input<small>TextField · DatePicker</small></p>
           <div class="demo-block field-grid">
             <div class="field">
-              <label>이메일</label>
+              <label for="demo-email">이메일</label>
               <div class="text-field is-focus">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M3 7l9 6 9-6"></path></svg>
-                <input type="text" value="hello@example.com">
+                <input id="demo-email" type="text" value="hello@example.com">
               </div>
               <span class="help">포커스 상태 — 테두리가 시그니처 오렌지로 전환</span>
             </div>
             <div class="field">
-              <label class="is-disabled">닉네임</label>
+              <label class="is-disabled" for="demo-nickname">닉네임</label>
               <div class="text-field is-disabled">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M4 21c0-4 4-6 8-6s8 2 8 6"></path></svg>
-                <input type="text" placeholder="비활성 필드" disabled>
+                <input id="demo-nickname" type="text" placeholder="비활성 필드" disabled>
               </div>
               <span class="help">비활성 상태 — 라벨 잉크가 fg-disabled</span>
             </div>

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -935,7 +935,7 @@
               <label for="demo-email">이메일</label>
               <div class="text-field is-focus">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M3 7l9 6 9-6"></path></svg>
-                <input id="demo-email" type="text" value="hello@example.com">
+                <input id="demo-email" type="email" value="hello@example.com">
               </div>
               <span class="help">포커스 상태 — 테두리가 시그니처 오렌지로 전환</span>
             </div>

--- a/public/preview/likelion/preview.html
+++ b/public/preview/likelion/preview.html
@@ -1,0 +1,1173 @@
+<!doctype html>
+<html lang="ko" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>멋쟁이사자처럼 preview</title>
+  <link rel="stylesheet" href="/preview/_runtime/tokens.css">
+  <script src="/preview/_runtime/iframe.js" defer></script>
+  <style>
+    /*
+     * 멋쟁이사자처럼 — LIKELION brand preview. Light-first by spec.
+     * --ll-* tokens carry the published (light) OKLCH palette from design.md
+     * verbatim. design.md publishes NO dark palette at all (Known Gaps), so
+     * every dark value below is this preview's own derivation, never the
+     * source of truth. The brand pairs a warm, high-chroma signature orange
+     * with a deliberately COOL-toned neutral ramp ("차가운 배경 톤" — design.md
+     * Colors) — so the dark surfaces stay on that same cool axis rather than
+     * warming up, and only the orange itself is lifted for dark contrast.
+     * Semantic aliases (--ll-bg-*, --ll-fg-*, --ll-border-*) are the only names
+     * component rules reference, so no rule below needs a [data-theme="dark"]
+     * duplicate — only the alias VALUES are redefined, in the second <style>.
+     */
+    :root {
+      /* ---- Primary — orange ramp (design.md Colors, verbatim OKLCH) ---- */
+      --ll-primary-50: oklch(0.96 0.022 54);
+      --ll-primary-100: oklch(0.93 0.044 52);
+      --ll-primary-200: oklch(0.85 0.089 53);
+      --ll-primary-300: oklch(0.79 0.135 51);
+      --ll-primary-400: oklch(0.73 0.177 48);
+      --ll-primary-500: oklch(0.69 0.209 42);
+      --ll-primary-600: oklch(0.58 0.175 42);
+      --ll-primary-700: oklch(0.48 0.139 44);
+      --ll-primary-800: oklch(0.36 0.102 45);
+      --ll-primary-900: oklch(0.30 0.082 47);
+
+      /* ---- Gray — cool neutral ramp (verbatim OKLCH) ---- */
+      --ll-gray-50: oklch(0.98 0.002 245);
+      --ll-gray-100: oklch(0.97 0.003 270);
+      --ll-gray-200: oklch(0.93 0.005 255);
+      --ll-gray-300: oklch(0.87 0.010 253);
+      --ll-gray-400: oklch(0.78 0.014 252);
+      --ll-gray-500: oklch(0.67 0.021 251);
+      --ll-gray-600: oklch(0.56 0.025 257);
+      --ll-gray-700: oklch(0.46 0.027 256);
+      --ll-gray-800: oklch(0.35 0.029 261);
+      --ll-gray-850: oklch(0.30 0.027 257);
+      --ll-gray-900: oklch(0.24 0.024 262);
+      --ll-gray-950: oklch(0.22 0.007 247);
+      --ll-white: oklch(1 0 0);
+
+      /* ---- Semantic (design.md names, light values) ---- */
+      --ll-bg-white: var(--ll-white);
+      --ll-bg-normal: var(--ll-gray-100);
+      --ll-bg-primary: var(--ll-primary-500);
+      --ll-bg-primary-weak: var(--ll-primary-50);
+      --ll-fg-white: var(--ll-white);
+      --ll-fg-primary: var(--ll-primary-500);
+      --ll-fg-normal: var(--ll-gray-800);
+      --ll-fg-disabled: var(--ll-gray-400);
+      --ll-border-primary: var(--ll-primary-500);
+      --ll-border-normal: var(--ll-gray-300);
+      --ll-border-weak: var(--ll-gray-200);
+
+      /* ---- Convenience aliases (not md keys, still light-fixed) ---- */
+      --ll-fg-secondary: var(--ll-gray-600);
+      --ll-bg-primary-hover: var(--ll-primary-600);
+      --ll-primary-foreground: var(--ll-white);
+      --ll-shadow-color: oklch(0 0 0 / 0.14);
+
+      /* ---- Typography (design.md Typography, single Pretendard family) ---- */
+      --ll-fs-display: 52px;
+      --ll-fs-h1: 35px;
+      --ll-fs-h4: 23px;
+      --ll-fs-body1: 17px;
+      --ll-fs-body3: 13px;
+      --ll-fs-body5: 11px;
+
+      /* ---- Spacing (design.md Spacing, 4px base) ---- */
+      --ll-space-1: 4px;
+      --ll-space-2: 8px;
+      --ll-space-3: 12px;
+      --ll-space-4: 16px;
+      --ll-space-5: 20px;
+      --ll-space-6: 24px;
+      --ll-space-8: 32px;
+      --ll-space-10: 40px;
+      --ll-space-12: 48px;
+
+      /* ---- Rounded (design.md Rounded) ---- */
+      --ll-radius-05: 2px;
+      --ll-radius-1: 4px;
+      --ll-radius-2: 8px;
+      --ll-radius-3: 12px;
+      --ll-radius-4: 16px;
+      --ll-radius-5: 20px;
+      --ll-radius-6: 24px;
+      --ll-radius-full: 999px;
+
+      /* ---- Shared runtime tokens, tinted to brand ---- */
+      --background: var(--ll-bg-white);
+      --foreground: var(--ll-fg-normal);
+      --card: var(--ll-bg-white);
+      --card-foreground: var(--ll-fg-normal);
+      --primary: var(--ll-bg-primary);
+      --primary-foreground: var(--ll-primary-foreground);
+      --muted-foreground: var(--ll-fg-secondary);
+      --border: var(--ll-border-normal);
+      --accent-glow: var(--ll-bg-primary);
+      --rule-strong: var(--ll-border-normal);
+    }
+
+    body { overflow-x: hidden; }
+
+    .shell { max-width: 1180px; margin: 0 auto; padding: 0 24px; }
+
+    /* ============ Hero ============ */
+    .hero { background: var(--ll-bg-normal); border-bottom: 1px solid var(--ll-border-weak); }
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.85fr);
+      gap: 48px;
+      align-items: center;
+      padding: 72px 24px 64px;
+    }
+    .hero-visual { min-width: 0; }
+
+    .hero-brand { display: flex; align-items: center; gap: 12px; margin-bottom: 30px; }
+    .hero-logo { height: 56px; width: auto; display: block; }
+    .hero-name {
+      padding-left: 12px;
+      border-left: 1px solid var(--ll-border-normal);
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--ll-fg-normal);
+    }
+
+    .eyebrow {
+      margin: 0 0 14px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--ll-fg-primary);
+    }
+
+    .hero-copy h1 {
+      margin: 0;
+      font-size: var(--ll-fs-display);
+      font-weight: 800;
+      line-height: 1.2;
+      letter-spacing: -0.3px;
+      color: var(--ll-fg-normal);
+      word-break: keep-all;
+    }
+    .hero-copy h1 .accent {
+      display: block;
+      margin-top: 8px;
+      font-size: 18px;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      color: var(--ll-fg-primary);
+    }
+
+    .hero-desc {
+      margin: 22px 0 0;
+      max-width: 520px;
+      font-size: var(--ll-fs-body1);
+      line-height: 1.5;
+      color: var(--ll-fg-secondary);
+      word-break: keep-all;
+    }
+
+    .hero-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+    .meta-chip {
+      display: inline-flex;
+      align-items: center;
+      height: 30px;
+      padding: 0 14px;
+      border: 1px solid var(--ll-border-normal);
+      border-radius: var(--ll-radius-full);
+      background: var(--ll-bg-white);
+      color: var(--ll-fg-secondary);
+      font-size: 12px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .hero-cta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
+
+    .quote-card {
+      padding: var(--ll-space-8) var(--ll-space-6);
+      border-radius: var(--ll-radius-6);
+      background: var(--ll-bg-primary);
+      color: var(--ll-primary-foreground);
+      box-shadow: 0 30px 60px var(--ll-shadow-color);
+      min-width: 0;
+    }
+    .quote-card .mark { font-size: 40px; font-weight: 800; line-height: 1; opacity: 0.5; }
+    .quote-card p {
+      margin: 10px 0 0;
+      font-size: var(--ll-fs-h4);
+      font-weight: 600;
+      line-height: 1.35;
+      word-break: keep-all;
+    }
+    .quote-card cite {
+      display: block;
+      margin-top: var(--ll-space-5);
+      font-style: normal;
+      font-size: var(--ll-fs-body3);
+      font-weight: 600;
+      opacity: 0.85;
+    }
+
+    @media (max-width: 860px) {
+      .hero-grid { grid-template-columns: minmax(0, 1fr); padding: 48px 20px 40px; }
+      .hero-visual { max-width: 420px; }
+    }
+
+    /* ============ Action button (ActionButton component) ============ */
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      height: 48px;
+      padding: 0 22px;
+      border-radius: var(--ll-radius-3);
+      border: 1.5px solid transparent;
+      font-family: inherit;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.15s ease, opacity 0.15s ease;
+    }
+    .action-btn.sm { height: 40px; padding: 0 16px; font-size: 13px; border-radius: var(--ll-radius-2); }
+    .action-btn.primary { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); }
+    .action-btn.primary:hover,
+    .action-btn.primary.is-hover { background: var(--ll-bg-primary-hover); }
+    .action-btn.primary.is-disabled,
+    .action-btn.primary[disabled] { background: var(--ll-border-weak); color: var(--ll-fg-disabled); cursor: not-allowed; }
+    .action-btn.ghost { background: transparent; border-color: var(--ll-border-normal); color: var(--ll-fg-normal); }
+    .action-btn.ghost:hover { background: var(--ll-bg-white); border-color: var(--ll-fg-normal); }
+
+    /* ============ Icon button (IconButton component) ============ */
+    .icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
+      border: none;
+      border-radius: var(--ll-radius-full);
+      background: var(--ll-bg-normal);
+      color: var(--ll-fg-secondary);
+      cursor: pointer;
+      flex: none;
+    }
+    .icon-btn svg { width: 20px; height: 20px; }
+    .icon-btn:hover,
+    .icon-btn.is-hover { background: var(--ll-bg-primary-weak); color: var(--ll-fg-primary); }
+    .icon-btn.is-active { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); }
+
+    /* ============ Badge / Chip / Tag ============ */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      height: 22px;
+      padding: 0 8px;
+      border-radius: var(--ll-radius-1);
+      font-size: var(--ll-fs-body5);
+      font-weight: 700;
+      white-space: nowrap;
+    }
+    .badge.solid { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); }
+    .badge.soft { background: var(--ll-bg-primary-weak); color: var(--ll-fg-primary); }
+    .badge.outline { border: 1px solid var(--ll-border-normal); color: var(--ll-fg-secondary); }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      height: 34px;
+      padding: 0 14px;
+      border-radius: var(--ll-radius-full);
+      border: 1px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+      color: var(--ll-fg-secondary);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .chip.selected { background: var(--ll-bg-primary-weak); border-color: var(--ll-border-primary); color: var(--ll-fg-primary); }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      height: 26px;
+      padding: 0 10px;
+      border-radius: var(--ll-radius-2);
+      background: var(--ll-bg-primary-weak);
+      color: var(--ll-fg-primary);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+    .tag.pill { border-radius: var(--ll-radius-full); }
+    .tag.removable { padding-right: 6px; gap: 4px; }
+    .tag .x {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 15px;
+      height: 15px;
+      border-radius: 50%;
+      background: oklch(0 0 0 / 0.08);
+    }
+    .tag .x svg { width: 8px; height: 8px; }
+
+    /* ============ Checkbox / Radio / Toggle ============ */
+    .form-row { display: flex; flex-wrap: wrap; gap: 18px; align-items: center; }
+    .checkbox, .radio { display: inline-flex; align-items: center; gap: 8px; font-size: 14px; color: var(--ll-fg-normal); }
+    .checkbox .box {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      flex: none;
+      border-radius: var(--ll-radius-05);
+      border: 1.5px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+    }
+    .checkbox .box svg { width: 13px; height: 13px; color: var(--ll-primary-foreground); opacity: 0; }
+    .checkbox.checked .box { background: var(--ll-bg-primary); border-color: var(--ll-border-primary); }
+    .checkbox.checked .box svg { opacity: 1; }
+    .checkbox.disabled { color: var(--ll-fg-disabled); }
+    .checkbox.disabled .box { border-color: var(--ll-border-weak); background: var(--ll-bg-normal); }
+
+    .radio .dot {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      flex: none;
+      border-radius: 50%;
+      border: 1.5px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+    }
+    .radio .dot i { width: 10px; height: 10px; border-radius: 50%; background: var(--ll-bg-primary); opacity: 0; }
+    .radio.checked .dot { border-color: var(--ll-border-primary); }
+    .radio.checked .dot i { opacity: 1; }
+
+    .toggle {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      width: 44px;
+      height: 26px;
+      flex: none;
+      border-radius: var(--ll-radius-full);
+      background: var(--ll-border-normal);
+      cursor: pointer;
+    }
+    .toggle .knob {
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--ll-bg-white);
+      box-shadow: 0 1px 3px oklch(0 0 0 / 0.25);
+      transition: transform 0.15s ease;
+    }
+    .toggle.on { background: var(--ll-bg-primary); }
+    .toggle.on .knob { transform: translateX(18px); }
+    .toggle-row { display: inline-flex; align-items: center; gap: 10px; font-size: 14px; color: var(--ll-fg-normal); }
+
+    /* ============ TextField / DatePicker ============ */
+    .field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--ll-space-4); }
+    .field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+    .field > label {
+      font-size: var(--ll-fs-body5);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--ll-fg-secondary);
+    }
+    .field > label.is-disabled { color: var(--ll-fg-disabled); }
+    .text-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      height: 46px;
+      min-width: 0;
+      padding: 0 14px;
+      border-radius: var(--ll-radius-2);
+      border: 1.5px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+      color: var(--ll-fg-normal);
+    }
+    .text-field svg { width: 18px; height: 18px; flex: none; color: var(--ll-fg-secondary); }
+    .text-field input {
+      flex: 1;
+      min-width: 0;
+      width: 100%;
+      border: none;
+      outline: none;
+      background: transparent;
+      font: inherit;
+      font-size: 14px;
+      color: inherit;
+    }
+    .text-field input::placeholder { color: var(--ll-fg-disabled); }
+    .text-field.is-focus { border-color: var(--ll-border-primary); }
+    .text-field.is-disabled { background: var(--ll-bg-normal); color: var(--ll-fg-disabled); }
+    .text-field.is-disabled svg { color: var(--ll-fg-disabled); }
+    .field .help { font-size: var(--ll-fs-body5); color: var(--ll-fg-secondary); }
+
+    .datepicker-pop {
+      margin-top: 8px;
+      padding: var(--ll-space-4);
+      border-radius: var(--ll-radius-3);
+      border: 1px solid var(--ll-border-weak);
+      background: var(--ll-bg-white);
+      box-shadow: 0 16px 32px var(--ll-shadow-color);
+    }
+    .dp-head { display: flex; align-items: center; justify-content: space-between; font-size: 13px; font-weight: 700; color: var(--ll-fg-normal); margin-bottom: 10px; }
+    .dp-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 4px; text-align: center; }
+    .dp-grid span { font-size: var(--ll-fs-body5); color: var(--ll-fg-secondary); padding: 4px 0; }
+    .dp-grid .day { border-radius: var(--ll-radius-1); color: var(--ll-fg-normal); cursor: pointer; }
+    .dp-grid .day.today { border: 1px solid var(--ll-border-primary); color: var(--ll-fg-primary); font-weight: 700; }
+    .dp-grid .day.sel { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); font-weight: 700; }
+    .dp-grid .day.muted { color: var(--ll-fg-disabled); }
+
+    /* ============ SelectBox / SelectHeader / SelectMenu ============ */
+    .select-menu {
+      margin-top: 8px;
+      padding: 6px;
+      border-radius: var(--ll-radius-3);
+      border: 1px solid var(--ll-border-weak);
+      background: var(--ll-bg-white);
+      box-shadow: 0 16px 32px var(--ll-shadow-color);
+    }
+    .select-menu .opt {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      border-radius: var(--ll-radius-2);
+      font-size: 14px;
+      color: var(--ll-fg-normal);
+      cursor: pointer;
+    }
+    .select-menu .opt.hover { background: var(--ll-bg-normal); }
+    .select-menu .opt.sel { background: var(--ll-bg-primary-weak); color: var(--ll-fg-primary); font-weight: 700; }
+    .select-menu .opt svg { width: 16px; height: 16px; }
+
+    /* ============ Tab (segmented control) — atomic group guard ============ */
+    .tabbar {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      max-width: 100%;
+      min-width: 0;
+      padding: 4px;
+      border-radius: var(--ll-radius-full);
+      background: var(--ll-bg-normal);
+      overflow-x: auto;
+    }
+    .tab-btn {
+      flex: 0 1 auto;
+      min-width: 0;
+      max-width: 140px;
+      padding: 8px 16px;
+      border: none;
+      border-radius: var(--ll-radius-full);
+      background: transparent;
+      color: var(--ll-fg-secondary);
+      font: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: pointer;
+    }
+    .tab-btn.active { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); }
+
+    /* ============ Pagination ============ */
+    .pagination { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
+    .page-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 32px;
+      height: 32px;
+      padding: 0 6px;
+      border-radius: var(--ll-radius-1);
+      color: var(--ll-fg-secondary);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .page-btn svg { width: 16px; height: 16px; }
+    .page-btn.active { background: var(--ll-bg-primary); color: var(--ll-primary-foreground); }
+    .page-btn.disabled { color: var(--ll-fg-disabled); cursor: not-allowed; }
+
+    /* ============ Dialog ============ */
+    .dialog-stage {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--ll-space-6);
+      border-radius: var(--ll-radius-4);
+      background: var(--ll-bg-normal);
+      min-width: 0;
+    }
+    .dialog {
+      width: 100%;
+      max-width: 320px;
+      padding: var(--ll-space-6);
+      border-radius: var(--ll-radius-4);
+      background: var(--ll-bg-white);
+      box-shadow: 0 24px 48px var(--ll-shadow-color);
+    }
+    .dialog h4 { margin: 0 0 10px; font-size: var(--ll-fs-h4); font-weight: 600; color: var(--ll-fg-normal); word-break: keep-all; }
+    .dialog p { margin: 0 0 20px; font-size: var(--ll-fs-body3); line-height: 1.5; color: var(--ll-fg-secondary); word-break: keep-all; }
+    .dialog .actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+
+    /* ============ Toast / Tooltip ============ */
+    .toast {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 18px;
+      border-radius: var(--ll-radius-3);
+      background: var(--ll-bg-primary-weak);
+      color: var(--ll-fg-primary);
+      font-size: 13px;
+      font-weight: 600;
+      box-shadow: 0 16px 32px var(--ll-shadow-color);
+      max-width: 100%;
+    }
+    .toast svg { width: 16px; height: 16px; flex: none; color: var(--ll-fg-primary); }
+
+    .tooltip-demo { position: relative; display: inline-flex; margin-top: 30px; }
+    .tooltip {
+      position: absolute;
+      bottom: calc(100% + 10px);
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 6px 10px;
+      border-radius: var(--ll-radius-1);
+      background: var(--ll-gray-800);
+      color: var(--ll-white);
+      font-size: var(--ll-fs-body5);
+      font-weight: 600;
+      white-space: nowrap;
+      box-shadow: 0 8px 16px var(--ll-shadow-color);
+    }
+    .tooltip::after {
+      content: "";
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: var(--ll-fg-normal);
+    }
+
+    /* ============ Showcase shell (section / grid / panel) ============ */
+    .section { padding: 64px 0; }
+    .section-head {
+      max-width: 720px;
+      margin: 0 auto 34px;
+      padding-bottom: 22px;
+      border-bottom: 2px solid var(--rule-strong);
+    }
+    .kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--ll-fg-secondary);
+    }
+    .section-head h2 {
+      margin: 10px 0 0;
+      font-size: var(--ll-fs-h1);
+      font-weight: 700;
+      line-height: 1.3;
+      letter-spacing: -0.3px;
+      color: var(--ll-fg-normal);
+      word-break: keep-all;
+    }
+    .section-desc { margin: 10px 0 0; font-size: var(--ll-fs-body3); line-height: 1.6; color: var(--ll-fg-secondary); word-break: keep-all; }
+
+    .grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 20px; }
+    .span-6 { grid-column: span 6; }
+    .span-12 { grid-column: 1 / -1; }
+
+    .panel {
+      min-width: 0;
+      padding: var(--ll-space-6);
+      border-radius: var(--ll-radius-4);
+      border: 1px solid var(--ll-border-weak);
+      background: var(--ll-bg-white);
+    }
+    .panel-title {
+      margin: 0 0 var(--ll-space-5);
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--ll-fg-normal);
+    }
+    .panel-title small { display: block; margin-top: 2px; font-size: var(--ll-fs-body5); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ll-fg-secondary); }
+
+    .demo-block + .demo-block { margin-top: var(--ll-space-5); padding-top: var(--ll-space-5); border-top: 1px dashed var(--ll-border-weak); }
+    .demo-label { margin: 0 0 10px; font-size: var(--ll-fs-body5); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ll-fg-secondary); }
+    .demo-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; min-width: 0; }
+
+    /* ============ Community-home screen mock ============ */
+    .app-mock {
+      width: 100%;
+      max-width: 380px;
+      margin: 0 auto;
+      min-width: 0;
+      border-radius: var(--ll-radius-6);
+      border: 1px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+      box-shadow: 0 30px 60px var(--ll-shadow-color);
+      overflow: hidden;
+    }
+    .app-topbar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 16px 18px; border-bottom: 1px solid var(--ll-border-weak); }
+    .app-topbar .name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 15px; font-weight: 800; color: var(--ll-fg-normal); }
+    .app-tabs { padding: 12px 18px; border-bottom: 1px solid var(--ll-border-weak); }
+    .post { display: flex; flex-direction: column; gap: 8px; padding: 16px 18px; border-bottom: 1px solid var(--ll-border-weak); }
+    .post:last-child { border-bottom: none; }
+    .post-top { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .avatar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      flex: none;
+      border-radius: 50%;
+      background: var(--ll-bg-primary-weak);
+      color: var(--ll-fg-primary);
+      font-size: 10px;
+      font-weight: 800;
+    }
+    .post-author { font-size: 12px; font-weight: 700; color: var(--ll-fg-normal); }
+    .post-title { margin: 0; font-size: 15px; font-weight: 700; line-height: 1.4; color: var(--ll-fg-normal); word-break: keep-all; }
+    .post-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 12px; color: var(--ll-fg-secondary); }
+    .toast-dock { padding: 0 18px 18px; display: flex; justify-content: center; }
+
+    /* ============ Page mock (desktop page layout) ============ */
+    .page-mock {
+      border-radius: var(--ll-radius-6);
+      border: 1px solid var(--ll-border-normal);
+      background: var(--ll-bg-white);
+      box-shadow: 0 30px 60px var(--ll-shadow-color);
+      overflow: hidden;
+      margin-bottom: var(--ll-space-8);
+    }
+    .page-nav {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      padding: 16px 28px;
+      border-bottom: 1px solid var(--ll-border-weak);
+      flex-wrap: wrap;
+      min-width: 0;
+    }
+    .page-nav-brand { display: flex; align-items: center; gap: 8px; min-width: 0; flex: none; }
+    .page-nav-brand img { height: 24px; width: auto; display: block; flex: none; }
+    .page-nav-brand span { font-size: 15px; font-weight: 800; color: var(--ll-fg-normal); white-space: nowrap; }
+    .page-nav-links { display: flex; align-items: center; gap: 20px; min-width: 0; flex: 1 1 160px; overflow: hidden; }
+    .page-nav-links a { font-size: 14px; font-weight: 600; color: var(--ll-fg-secondary); text-decoration: none; white-space: nowrap; }
+    .page-nav-links a.active { color: var(--ll-fg-primary); }
+    .page-nav-actions { display: flex; align-items: center; gap: 8px; flex: none; margin-left: auto; }
+
+    .page-hero-strip {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 24px 28px 0;
+      min-width: 0;
+    }
+    .page-hero-strip h3 { margin: 0; font-size: 20px; font-weight: 800; color: var(--ll-fg-normal); word-break: keep-all; }
+
+    .page-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: var(--ll-space-5);
+      padding: 20px 28px 28px;
+    }
+    .page-card {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: var(--ll-space-5);
+      border-radius: var(--ll-radius-4);
+      border: 1px solid var(--ll-border-weak);
+      background: var(--ll-bg-normal);
+      min-width: 0;
+    }
+    .page-card-thumb {
+      height: 96px;
+      border-radius: var(--ll-radius-3);
+      background: var(--ll-bg-primary-weak);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--ll-fg-primary);
+      font-weight: 800;
+      font-size: 24px;
+      flex: none;
+    }
+    .page-card h4 { margin: 0; font-size: 15px; font-weight: 700; line-height: 1.4; color: var(--ll-fg-normal); word-break: keep-all; }
+    .page-card p { margin: 0; font-size: var(--ll-fs-body5); color: var(--ll-fg-secondary); word-break: keep-all; }
+    .page-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
+
+    .page-foot { display: flex; justify-content: center; padding: 0 28px 28px; }
+
+    @media (max-width: 720px) {
+      .shell { padding: 0 18px; }
+      .section { padding: 48px 0; }
+      .grid { gap: 16px; }
+      .span-6, .span-12 { grid-column: 1 / -1; }
+      .field-grid { grid-template-columns: minmax(0, 1fr); }
+      .hero-copy h1 { font-size: 38px; }
+      .page-nav { padding: 12px 18px; }
+      .page-nav-links { display: none; }
+      .page-hero-strip { padding: 20px 18px 0; }
+      .page-grid { grid-template-columns: minmax(0, 1fr); padding: 16px 18px 20px; }
+    }
+    @media (min-width: 721px) and (max-width: 1024px) {
+      .page-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+  </style>
+  <style>
+    /*
+     * Dark adaptation. Nothing here is published — design.md has no dark
+     * palette. Surfaces stay on the brand's own cool axis (hue ~250-260,
+     * matching the light gray ramp above); the signature orange is lifted
+     * ~+6 L for AA contrast on the darker surfaces, and ink placed on a
+     * colored fill always comes from --ll-primary-foreground /
+     * --ll-fg-white, never a hardcoded white, so the lift never collapses
+     * text contrast.
+     */
+    [data-theme="dark"] {
+      --ll-bg-white: oklch(0.21 0.012 258);
+      --ll-bg-normal: oklch(0.15 0.010 258);
+      --ll-bg-primary: oklch(0.75 0.190 44);
+      --ll-bg-primary-weak: oklch(0.28 0.060 44);
+      --ll-bg-primary-hover: oklch(0.80 0.170 45);
+
+      --ll-fg-primary: oklch(0.79 0.175 44);
+      --ll-fg-normal: oklch(0.93 0.006 258);
+      --ll-fg-secondary: oklch(0.72 0.012 258);
+      --ll-fg-disabled: oklch(0.46 0.014 258);
+
+      --ll-border-primary: oklch(0.75 0.190 44);
+      --ll-border-normal: oklch(0.32 0.016 258);
+      --ll-border-weak: oklch(0.26 0.014 258);
+
+      --ll-primary-foreground: oklch(0.17 0.020 45);
+      --ll-shadow-color: oklch(0 0 0 / 0.55);
+
+      --background: var(--ll-bg-white);
+      --foreground: var(--ll-fg-normal);
+      --card: var(--ll-bg-white);
+      --card-foreground: var(--ll-fg-normal);
+      --primary: var(--ll-bg-primary);
+      --primary-foreground: var(--ll-primary-foreground);
+      --muted-foreground: var(--ll-fg-secondary);
+      --border: var(--ll-border-normal);
+      --accent-glow: var(--ll-bg-primary);
+      --rule-strong: var(--ll-border-normal);
+    }
+  </style>
+</head>
+<body>
+<div class="catalog-disclaimer" role="note"><b>ko/design.md 카탈로그 프리뷰</b> — 이 카탈로그는 어떤 브랜드와도 제휴·후원 관계가 없습니다. 이 화면은 공식 배포본이 아닌 공개 자료 기반 비공식 재현이며, 표시된 상품·가격·평점·거래·채용 정보는 레이아웃 시연용 더미 데이터입니다.</div>
+
+<section class="hero">
+  <div class="shell hero-grid">
+    <div class="hero-copy">
+      <div class="hero-brand">
+        <img class="hero-logo" src="/logos/likelion.svg" alt="멋쟁이사자처럼 심볼 마크" width="112" height="56">
+        <span class="hero-name">멋쟁이사자처럼</span>
+      </div>
+      <p class="eyebrow">Coding Education Community · Since 2013</p>
+      <h1>가능성을 현실로<span class="accent">POSSIBILITY TO REALITY</span></h1>
+      <p class="hero-desc">서울대 학생 프로그래밍 동아리로 출발해 전국 단위 커뮤니티로 자란 코딩 교육 브랜드. 채도 높은 시그니처 오렌지를 차분한 쿨톤 그레이 위에 얹어, 비전공자도 부담 없이 다가설 수 있는 친근하고 에너지 있는 인상을 만든다.</p>
+      <div class="hero-meta">
+        <span class="meta-chip">시그니처 오렌지 #FF6000</span>
+        <span class="meta-chip">쿨톤 그레이 뉴트럴</span>
+        <span class="meta-chip">Pretendard</span>
+      </div>
+      <div class="hero-cta">
+        <button class="action-btn primary" type="button">컴포넌트 살펴보기</button>
+        <button class="action-btn ghost" type="button">브랜드 소개</button>
+      </div>
+    </div>
+    <div class="hero-visual">
+      <div class="quote-card">
+        <span class="mark">“</span>
+        <p>완벽한 시작을 하려고 하지 마세요.</p>
+        <cite>공식 Brunch 채널 게시물 중</cite>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main>
+  <section class="section" id="components">
+    <div class="shell">
+      <div class="section-head">
+        <span class="kicker"><span class="hangul-idx">01</span> Components</span>
+        <h2>18개 재사용 컴포넌트를 시그니처 오렌지 + 쿨톤 그레이 팔레트로 렌더링했다</h2>
+        <p class="section-desc">Storybook 매니페스트가 문서화한 18개 컴포넌트를 각각 기본 변형과 최소 한 개 이상의 상태(hover·active·disabled·open)로 보여준다. 브랜드 색은 1차 행동에만 채워 쓰고, 12~24px대 중~대형 반경을 소형 코너와 나란히 섞는다.</p>
+      </div>
+
+      <div class="grid">
+        <!-- ActionButton + IconButton -->
+        <div class="panel span-6">
+          <p class="panel-title">Button<small>ActionButton · IconButton</small></p>
+          <div class="demo-block">
+            <p class="demo-label">ActionButton — primary · hover · disabled</p>
+            <div class="demo-row">
+              <button class="action-btn primary" type="button">신청하기</button>
+              <button class="action-btn primary is-hover" type="button">신청하기</button>
+              <button class="action-btn primary is-disabled" type="button" disabled>신청하기</button>
+              <button class="action-btn ghost" type="button">더 알아보기</button>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">IconButton — default · hover · active</p>
+            <div class="demo-row">
+              <button class="icon-btn" type="button" aria-label="검색">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg>
+              </button>
+              <button class="icon-btn is-hover" type="button" aria-label="알림">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.7 21a2 2 0 01-3.4 0"></path></svg>
+              </button>
+              <button class="icon-btn is-active" type="button" aria-label="즐겨찾기">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3 6.3 6.9 1-5 4.9 1.2 6.8L12 17.8 5.9 21l1.2-6.8-5-4.9 6.9-1z"></path></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Badge / Chip / Tag -->
+        <div class="panel span-6">
+          <p class="panel-title">Label<small>Badge · Chip · Tag</small></p>
+          <div class="demo-block">
+            <p class="demo-label">Badge — solid · soft · outline</p>
+            <div class="demo-row">
+              <span class="badge solid">신규</span>
+              <span class="badge soft">이벤트</span>
+              <span class="badge outline">커뮤니티</span>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">Chip — default · selected</p>
+            <div class="demo-row">
+              <span class="chip selected">전체</span>
+              <span class="chip">공지</span>
+              <span class="chip">스터디</span>
+              <span class="chip">행사</span>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">Tag — default · removable</p>
+            <div class="demo-row">
+              <span class="tag">커뮤니티</span>
+              <span class="tag pill">온라인</span>
+              <span class="tag removable">오프라인<span class="x"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"></path></svg></span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Checkbox / Radio / Toggle -->
+        <div class="panel span-6">
+          <p class="panel-title">Selection<small>Checkbox · RadioButton · Toggle</small></p>
+          <div class="demo-block">
+            <p class="demo-label">Checkbox — unchecked · checked · disabled</p>
+            <div class="form-row">
+              <label class="checkbox"><span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg></span>알림 수신 동의</label>
+              <label class="checkbox checked"><span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg></span>이용약관 동의</label>
+              <label class="checkbox disabled"><span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg></span>선택 불가 항목</label>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">RadioButton — unselected · selected</p>
+            <div class="form-row">
+              <label class="radio"><span class="dot"><i></i></span>온라인</label>
+              <label class="radio checked"><span class="dot"><i></i></span>오프라인</label>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">Toggle — off · on</p>
+            <div class="form-row">
+              <span class="toggle-row"><span class="toggle"><span class="knob"></span></span>야간 알림</span>
+              <span class="toggle-row"><span class="toggle on"><span class="knob"></span></span>주간 다이제스트</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- TextField / DatePicker -->
+        <div class="panel span-6">
+          <p class="panel-title">Input<small>TextField · DatePicker</small></p>
+          <div class="demo-block field-grid">
+            <div class="field">
+              <label>이메일</label>
+              <div class="text-field is-focus">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="M3 7l9 6 9-6"></path></svg>
+                <input type="text" value="hello@example.com">
+              </div>
+              <span class="help">포커스 상태 — 테두리가 시그니처 오렌지로 전환</span>
+            </div>
+            <div class="field">
+              <label class="is-disabled">닉네임</label>
+              <div class="text-field is-disabled">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"></circle><path d="M4 21c0-4 4-6 8-6s8 2 8 6"></path></svg>
+                <input type="text" placeholder="비활성 필드" disabled>
+              </div>
+              <span class="help">비활성 상태 — 라벨 잉크가 fg-disabled</span>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">DatePicker — trigger · open</p>
+            <div class="field" style="max-width: 260px;">
+              <div class="text-field">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>
+                <input type="text" value="2026.08.30" readonly>
+              </div>
+              <div class="datepicker-pop">
+                <div class="dp-head"><span>‹</span><span>2026년 8월</span><span>›</span></div>
+                <div class="dp-grid">
+                  <span>일</span><span>월</span><span>화</span><span>수</span><span>목</span><span>금</span><span>토</span>
+                  <span class="day muted">26</span><span class="day muted">27</span><span class="day muted">28</span><span class="day muted">29</span><span class="day muted">30</span><span class="day muted">31</span><span class="day">1</span>
+                  <span class="day">2</span><span class="day">3</span><span class="day">4</span><span class="day">5</span><span class="day">6</span><span class="day">7</span><span class="day">8</span>
+                  <span class="day">9</span><span class="day">10</span><span class="day">11</span><span class="day">12</span><span class="day">13</span><span class="day">14</span><span class="day">15</span>
+                  <span class="day">16</span><span class="day">17</span><span class="day">18</span><span class="day">19</span><span class="day">20</span><span class="day">21</span><span class="day">22</span>
+                  <span class="day">23</span><span class="day">24</span><span class="day">25</span><span class="day">26</span><span class="day">27</span><span class="day">28</span><span class="day">29</span>
+                  <span class="day today sel">30</span><span class="day">31</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- SelectBox / SelectHeader / SelectMenu -->
+        <div class="panel span-6">
+          <p class="panel-title">Dropdown<small>SelectBox · SelectHeader · SelectMenu</small></p>
+          <div class="demo-block">
+            <p class="demo-label">SelectHeader trigger · SelectMenu open</p>
+            <div class="field" style="max-width: 280px;">
+              <div class="text-field is-focus">
+                <input type="text" value="스터디" readonly>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>
+              </div>
+              <div class="select-menu">
+                <div class="opt">전체</div>
+                <div class="opt hover">공지</div>
+                <div class="opt sel">스터디<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg></div>
+                <div class="opt">행사</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab / Pagination -->
+        <div class="panel span-6">
+          <p class="panel-title">Navigation<small>Tab · Pagination</small></p>
+          <div class="demo-block">
+            <p class="demo-label">Tab — segmented, active state</p>
+            <div class="tabbar">
+              <button class="tab-btn active" type="button">전체</button>
+              <button class="tab-btn" type="button">공지</button>
+              <button class="tab-btn" type="button">스터디</button>
+              <button class="tab-btn" type="button">행사</button>
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">Pagination — current page 2</p>
+            <div class="pagination">
+              <span class="page-btn disabled"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg></span>
+              <span class="page-btn">1</span>
+              <span class="page-btn active">2</span>
+              <span class="page-btn">3</span>
+              <span class="page-btn">4</span>
+              <span class="page-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"></path></svg></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Dialog -->
+        <div class="panel span-6">
+          <p class="panel-title">Dialog<small>modal, default state</small></p>
+          <div class="demo-block dialog-stage">
+            <div class="dialog">
+              <h4>게시글을 삭제할까요?</h4>
+              <p>삭제한 게시글은 다시 볼 수 없어요. 커뮤니티 이용 가이드를 확인해 주세요.</p>
+              <div class="actions">
+                <button class="action-btn ghost sm" type="button">취소</button>
+                <button class="action-btn primary sm" type="button">삭제</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Toast / Tooltip -->
+        <div class="panel span-6">
+          <p class="panel-title">Feedback<small>Toast · Tooltip</small></p>
+          <div class="demo-block">
+            <p class="demo-label">Toast — transient notice</p>
+            <div class="toast">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg>
+              게시글을 저장했어요
+            </div>
+          </div>
+          <div class="demo-block">
+            <p class="demo-label">Tooltip — visible on hover</p>
+            <div class="tooltip-demo">
+              <button class="icon-btn is-hover" type="button" aria-label="즐겨찾기">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3 6.3 6.9 1-5 4.9 1.2 6.8L12 17.8 5.9 21l1.2-6.8-5-4.9 6.9-1z"></path></svg>
+              </button>
+              <span class="tooltip">즐겨찾기에 담기</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Key screen mock -->
+        <div class="panel span-12">
+          <p class="panel-title">Page mock<small>커뮤니티 홈 — 데스크톱 페이지 레이아웃</small></p>
+          <p class="catalog-dummy">아래 내비게이션 메뉴·게시글 카드 제목/설명·조회수·경과 시간은 모두 레이아웃 시연용 더미 데이터이며, 실제 멋쟁이사자처럼 페이지가 아닙니다.</p>
+          <div class="page-mock" aria-label="멋쟁이사자처럼 커뮤니티 홈 데스크톱 페이지 목업">
+            <div class="page-nav">
+              <div class="page-nav-brand">
+                <img src="/logos/likelion.svg" alt="" aria-hidden="true">
+                <span>멋쟁이사자처럼</span>
+              </div>
+              <nav class="page-nav-links" aria-label="주요 메뉴">
+                <a href="#" class="active">홈</a>
+                <a href="#">커뮤니티</a>
+                <a href="#">이벤트</a>
+                <a href="#">멋사 소개</a>
+              </nav>
+              <div class="page-nav-actions">
+                <button class="icon-btn" type="button" aria-label="알림" style="width:36px;height:36px;">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
+                </button>
+                <button class="action-btn ghost sm" type="button">로그인</button>
+                <button class="action-btn primary sm" type="button">커뮤니티 가입</button>
+              </div>
+            </div>
+            <div class="page-hero-strip">
+              <h3>이번 주 인기 게시글</h3>
+              <button class="action-btn ghost sm" type="button">전체 보기</button>
+            </div>
+            <div class="page-grid">
+              <div class="page-card">
+                <div class="page-card-thumb" aria-hidden="true">멋</div>
+                <h4>8월 정기 오프라인 밋업 후기 공유해 주세요</h4>
+                <p>참여자들의 생생한 후기와 사진을 모았어요.</p>
+                <div class="page-card-meta"><span class="tag pill">행사</span><span class="badge soft">인기</span></div>
+              </div>
+              <div class="page-card">
+                <div class="page-card-thumb" aria-hidden="true">스</div>
+                <h4>이번 주 스터디 모임 안내 게시판이 새로 열렸어요</h4>
+                <p>관심 있는 스터디에 자유롭게 참여해 보세요.</p>
+                <div class="page-card-meta"><span class="tag pill">스터디</span></div>
+              </div>
+              <div class="page-card">
+                <div class="page-card-thumb" aria-hidden="true">멋</div>
+                <h4>커뮤니티 게시판 이용 가이드가 업데이트됐어요</h4>
+                <p>새로 바뀐 카테고리와 태그 규칙을 확인하세요.</p>
+                <div class="page-card-meta"><span class="tag pill">공지</span><span class="badge outline">공지</span></div>
+              </div>
+            </div>
+            <div class="page-foot">
+              <div class="pagination">
+                <button class="page-btn" type="button" aria-label="이전 페이지"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg></button>
+                <button class="page-btn" type="button">1</button>
+                <button class="page-btn active" type="button">2</button>
+                <button class="page-btn" type="button">3</button>
+                <button class="page-btn" type="button">4</button>
+                <button class="page-btn" type="button" aria-label="다음 페이지"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"></path></svg></button>
+              </div>
+            </div>
+          </div>
+          <div class="app-mock" aria-label="멋쟁이사자처럼 커뮤니티 홈 화면 목업">
+            <div class="app-topbar">
+              <span class="name">멋쟁이사자처럼 커뮤니티</span>
+              <button class="icon-btn" type="button" aria-label="검색" style="width:36px;height:36px;">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg>
+              </button>
+            </div>
+            <div class="app-tabs">
+              <div class="tabbar">
+                <button class="tab-btn active" type="button">전체</button>
+                <button class="tab-btn" type="button">공지</button>
+                <button class="tab-btn" type="button">스터디</button>
+                <button class="tab-btn" type="button">행사</button>
+              </div>
+            </div>
+            <div class="app-list">
+              <div class="post">
+                <div class="post-top">
+                  <span class="avatar">멋</span>
+                  <span class="post-author">멋사 운영팀</span>
+                  <span class="badge soft">인기</span>
+                </div>
+                <p class="post-title">8월 정기 오프라인 밋업 후기 공유해 주세요</p>
+                <div class="post-meta"><span class="tag pill">행사</span><span>2시간 전 · 조회 214</span></div>
+              </div>
+              <div class="post">
+                <div class="post-top">
+                  <span class="avatar">스</span>
+                  <span class="post-author">커뮤니티 매니저</span>
+                </div>
+                <p class="post-title">이번 주 스터디 모임 안내 게시판이 새로 열렸어요</p>
+                <div class="post-meta"><span class="tag pill">스터디</span><span>어제 · 조회 98</span></div>
+              </div>
+              <div class="post">
+                <div class="post-top">
+                  <span class="avatar">멋</span>
+                  <span class="post-author">멋사 운영팀</span>
+                  <span class="badge outline">공지</span>
+                </div>
+                <p class="post-title">커뮤니티 게시판 이용 가이드가 업데이트됐어요</p>
+                <div class="post-meta"><span class="tag pill">공지</span><span>3일 전 · 조회 512</span></div>
+              </div>
+            </div>
+            <div class="toast-dock">
+              <div class="toast">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg>
+                게시글을 저장했어요
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer style="border-top: 1px solid var(--ll-border-weak); padding: 28px 0;">
+  <div class="shell" style="display:flex; flex-wrap:wrap; align-items:center; gap: 12px; justify-content: space-between;">
+    <div style="display:flex; align-items:center; gap:10px; min-width:0;">
+      <img src="/logos/likelion.svg" alt="멋쟁이사자처럼 심볼 마크" style="height:20px;width:auto;display:block;">
+      <span style="font-size:13px; font-weight:700; color:var(--ll-fg-normal);">멋쟁이사자처럼</span>
+    </div>
+    <p class="catalog-attribution" style="margin:0; font-size:11px; line-height:1.5; color:var(--ll-fg-secondary); word-break:keep-all;">이 프리뷰는 ko-design-md 카탈로그가 공개된 토큰·컴포넌트 정보를 바탕으로 재구성한 비공식 문서이며, 멋쟁이사자처럼이 직접 배포한 화면이 아닙니다.</p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/services/likelion.md
+++ b/services/likelion.md
@@ -1,0 +1,269 @@
+---
+name: 멋쟁이사자처럼
+design_system_name: LIKELION Design System
+slug: likelion
+category: education
+last_updated: 2026-08-30
+created_at: 2026-08-30
+sources:
+  - https://likelion.net/
+  - https://designsystem.likelion.net
+  - https://designsystem.likelion.net/index.json
+  - https://designsystem.likelion.net/assets/iframe-CXUH1Zgo.css
+  - https://designsystem.likelion.net/assets/Logo-dx0Jf8eZ.js
+  - https://designsystem.likelion.net/LICENSE
+  - https://registry.npmjs.org/@likelion-design/ui
+  - https://registry.npmjs.org/@likelion-design/docs-mcp
+  - https://designsystem.likelion.net/robots.txt
+  - https://designsystem.likelion.net/sitemap.xml
+  - https://brunch.co.kr/@likelion/59
+  - https://ko.wikipedia.org/wiki/멋쟁이사자처럼
+  - https://designsystem.likelion.net/img/BrandLogo/03_Clearspace.png
+lang: ko
+logo: https://getdesign.kr/logos/likelion.svg
+colors:
+  ## Primary (오렌지 시그니처)
+  primary-50: oklch(0.96 0.022 54)    # #FFEFE5
+  primary-100: oklch(0.93 0.044 52)   # #FFDFCC
+  primary-200: oklch(0.85 0.089 53)   # #FFBF99
+  primary-300: oklch(0.79 0.135 51)   # #FFA066
+  primary-400: oklch(0.73 0.177 48)   # #FF8033
+  primary-500: oklch(0.69 0.209 42)   # #FF6000 브랜드 시그니처
+  primary-600: oklch(0.58 0.175 42)   # #CC4D00
+  primary-700: oklch(0.48 0.139 44)   # #993A00
+  primary-800: oklch(0.36 0.102 45)   # #662600
+  primary-900: oklch(0.30 0.082 47)   # #4D1D00
+  ## Gray (쿨톤 뉴트럴)
+  gray-50: oklch(0.98 0.002 245)      # #F9FAFB
+  gray-100: oklch(0.97 0.003 270)     # #F3F4F6
+  gray-200: oklch(0.93 0.005 255)     # #E5E7EA
+  gray-300: oklch(0.87 0.010 253)     # #D1D6DC
+  gray-400: oklch(0.78 0.014 252)     # #B1B8C0
+  gray-500: oklch(0.67 0.021 251)     # #8A95A0
+  gray-600: oklch(0.56 0.025 257)     # #6B7583
+  gray-700: oklch(0.46 0.027 256)     # #4E5967
+  gray-800: oklch(0.35 0.029 261)     # #333D4B
+  gray-850: oklch(0.30 0.027 257)     # #262F3C
+  gray-900: oklch(0.24 0.024 262)     # #191F28
+  gray-950: oklch(0.22 0.007 247)     # #191C1F
+  ## Semantic (bg/fg/border)
+  white: oklch(1 0 0)                 # #FFFFFF
+  bg-white: "{colors.white}"
+  bg-normal: "{colors.gray-100}"
+  bg-primary: "{colors.primary-500}"
+  bg-primary-weak: "{colors.primary-50}"
+  fg-white: "{colors.white}"
+  fg-primary: "{colors.primary-500}"
+  fg-normal: "{colors.gray-800}"
+  fg-disabled: "{colors.gray-400}"
+  border-primary: "{colors.primary-500}"
+  border-normal: "{colors.gray-300}"
+  border-weak: "{colors.gray-200}"
+typography:
+  display-d1: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 52px
+    fontWeight: 800
+    lineHeight: 1.2
+    letterSpacing: -0.3px
+  heading-h1: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 35px
+    fontWeight: 700
+    lineHeight: 1.3
+    letterSpacing: -0.3px
+  heading-h4: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 23px
+    fontWeight: 600
+    lineHeight: 1.35
+    letterSpacing: 0px
+  body-p1: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 17px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0px
+  body-p3: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0px
+  body-p5: # 미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합
+    fontSize: 11px
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: 0px
+spacing:
+  space-1: 4px
+  space-2: 8px
+  space-3: 12px
+  space-4: 16px
+  space-5: 20px
+  space-6: 24px
+  space-8: 32px
+  space-10: 40px
+  space-12: 48px
+rounded:
+  radius-05: 2px
+  radius-1: 4px
+  radius-2: 8px
+  radius-3: 12px
+  radius-4: 16px
+  radius-5: 20px
+  radius-6: 24px
+  radius-full: 999px
+---
+
+# 멋쟁이사자처럼 — design.md
+
+## Brand & Style
+
+멋쟁이사자처럼은 코딩 교육 커뮤니티이자 취업·전직 부트캠프 브랜드다. 채도 높은 시그니처 오렌지 `oklch(0.69 0.209 42)`(#FF6000)와 쿨톤 그레이 뉴트럴을 맞세워 에너지 넘치는 색 인상을 만들고 [src:4], 부담을 낮추는 격려형 어조로 친근함을 더한다 [src:11].
+
+브랜드는 2013년 서울대 학생 프로그래밍 동아리로 출발해 전국 단위 조직으로 성장했고, 현재 두 개의 트랙을 함께 운영한다 — 48개 대학이 참여하는 대학 컨소시엄 커뮤니티 "멋사 대학"(2025년 13기)과, 프론트엔드·백엔드·앱·게임·클라우드·데이터·UX/UI·그로스마케팅을 아우르는 취업준비생·이직희망자 대상 전문 부트캠프다 [src:12]. 슬로건 "POSSIBILITY TO REALITY, 가능성을 현실로"는 비전공자·입문자도 기술 장벽 없이 아이디어를 서비스로 만들 수 있다는 브랜드 미션을 요약한다 [src:12].
+
+톤앤보이스는 공식 Brunch 채널에서 직접 확인된다 — "완벽한 시작을 하려고 하지 마세요"처럼 부담을 낮추는 도입부와 "여러분을 기다리겠습니다" 같은 다정한 마무리를 함께 쓰며, "좋은 프로덕트는 철학이 담긴 프로덕트다"라는 문장으로 실무적 자부심도 드러낸다 [src:11]. 즉 기업/엔터프라이즈向 격식체가 아니라, 학생·취준생에게 말을 거는 직접적이고 격려하는 어조다.
+
+디자인 시스템(designsystem.likelion.net)은 Storybook 기반으로 7개 Foundation 토큰 그룹과 18개 재사용 컴포넌트를 문서화하며 [src:3], 외부 AI 코딩 어시스턴트가 토큰·컴포넌트를 조회할 수 있는 자체 MCP 서버(`@likelion-design/docs-mcp`, MIT)까지 배포한다 — 국내 브랜드 디자인 시스템 중에서는 이례적으로 AI 툴링에 적극적인 태도다 [src:8]. 이 draft의 시각 서술은 렌더링된 화면 스크린샷이 아니라 컴파일된 토큰 CSS 번들에서 역추출한 값에 근거한다 — likelion.net과 designsystem.likelion.net 둘 다 클라이언트 렌더 SPA 셸이라 자동 추출 도구에는 페이지 타이틀만 노출됐고(robots.txt[src:9]·sitemap.xml[src:10]도 소스로 함께 확인했다), 실제 렌더 화면 확인은 후속 스크린샷 패스가 필요하다 [src:1][src:2].
+
+## Colors
+
+시그니처는 10단계 오렌지 램프로, 500 단계 `oklch(0.69 0.209 42)`(#FF6000)을 중심으로 밝은 배경용(50~200)과 어두운 강조용(600~900)이 대칭적으로 갈린다 [src:4]. 뉴트럴은 순수 무채색이 아니라 미세하게 푸른 기운이 도는 "gray" 램프(`#F9FAFB`→`#191F28`)로, 오렌지 액센트와 대비되는 차가운 배경 톤을 만든다 [src:4]. 시맨틱 레이어는 배경(`bg-*`)·전경(`fg-*`)·테두리(`border-*`) 세 축으로 나뉘며, `-primary` 접미사가 붙은 토큰은 모두 오렌지 500을 그대로 참조한다 [src:4].
+
+공개 코퍼스는 `--color-*` 커스텀 프로퍼티 199개를 grep으로 확인했고, Foundation 매니페스트가 Primitive/Semantic/Style/Palette 하위 페이지를 추가로 문서화한다고 밝히고 있어 이 수치는 하한선이다 [src:2][src:3].
+
+| 역할 | 토큰 | 용도 |
+| --- | --- | --- |
+| Primary bg/fg/border | `{colors.bg-primary}` / `{colors.fg-primary}` / `{colors.border-primary}` | 1차 CTA, 강조 텍스트, 포커스 테두리 [src:4] |
+| Primary weak bg | `{colors.bg-primary-weak}` | 오렌지 톤 위 배경(배지·태그 배경 등) [src:4] |
+| Normal fg | `{colors.fg-normal}` | 본문 텍스트 [src:4] |
+| Disabled fg | `{colors.fg-disabled}` | 비활성 라벨 [src:4] |
+| Normal / weak border | `{colors.border-normal}` / `{colors.border-weak}` | 입력 필드 기본 테두리 / 구분선 [src:4] |
+
+값은 위 frontmatter `colors:` 맵이 유일한 정본이다 — 표에 다시 옮겨 적지 않는다.
+
+## Typography
+
+전 스케일이 단일 서체 **Pretendard** 하나로 통일돼 있다 — display 단계와 heading/body 단계가 모두 같은 `pretendard` 패밀리를 참조하며, 별도의 브랜드 전용 디스플레이 서체는 확인되지 않았다 [src:4]. 토큰 번들은 `pretendard.css` CDN을 직접 `@import`하므로, 프리뷰 런타임이 이미 번들링한 Pretendard와 겹쳐 별도의 `font-display-src`가 필요 없다 [src:4].
+
+사이즈 스케일은 양 끝이 넓다 — body-p5 11px부터 display-d1 52px까지, 5단계 굵기(400/500/600/700/800)와 3단계 자간(`-tight -0.3px` · `-normal 0px` · `-loose 1px`)이 공개돼 있다 [src:4]. 다만 이 세 축(사이즈/굵기/자간)이 각 명명된 스타일에 정확히 어떻게 짝지어지는지는 코퍼스에서 개별 확인되지 않아, 위 frontmatter의 `fontWeight` 값은 문서화된 굵기 스케일 범위 안에서 고른 예시 조합이다 — Known Gaps 참고. `lineHeight`는 한 걸음 더 나아가 코퍼스에 스케일 자체가 공개돼 있지 않아, 스타일 크기별로 통상적인 비율을 적용한 완전한 추정값이다. 큰 사이즈일수록 굵고 좁은 자간(`-tight`), 본문 사이즈는 400 굵기·`normal` 자간을 쓰는 것이 스케일 구조상 자연스러운 짝짓기다 [src:4].
+
+Foundation 매니페스트에 `foundation-typography--docs` 페이지가 별도로 존재해, Typography가 추정이 아니라 1급 문서화 그룹임은 확인된다 [src:3].
+
+## Spacing
+
+기준 단위는 4px다. `--spacing-primitive-*` 네임스페이스가 이 배수로 14개 토큰을 이루고, 그 위에 `gap-semantic`(13개)·`padding-semantic`(11개) 두 시맨틱 네임스페이스가 얹혀 총 24개의 시맨틱 spacing 토큰을 구성한다 [src:2][src:4]. Primitive 14개 중 9개(4~48px 구간)만 코퍼스에서 개별 재확인됐고, 나머지 단계는 Known Gaps에 남긴다.
+
+## Rounded
+
+`--radius-primitive-*` 스케일은 2px에서 24px까지 8개 단계를 거쳐 999px "full" 필 단계로 끝난다(총 11개 중 8개 재확인) [src:2][src:4]. 12~24px 같은 중~대형 반경이 소형 단계와 나란히 1급 스텝으로 존재한다는 점이 특징으로, 날카로운 기하학적 언어나 순수 필 형태 한 가지로만 수렴하지 않는 부드럽고 절제된 둥근 코너 체계를 시사한다 [src:4].
+
+## Elevation & Depth
+
+공개된 브랜드 고유 그림자/elevation 토큰이 없다 — 번들에는 Tailwind 자체의 내부 인프라 변수(`--tw-shadow` 등)만 존재하고, 별도로 이름 붙은 elevation 스텝은 확인되지 않았다 [src:2].
+
+## Shapes
+
+12~24px대 반경이 소형 단계와 함께 1급으로 존재하는 rounded 스케일과, 조밀하고 Hangul 가독성에 최적화된 Pretendard 단일 서체 스케일을 종합하면 각지고 기하학적이기보다는 부드럽게 둥근, 그러나 순수 필(pill) 하나로만 수렴하지 않는 절제된 곡률 언어로 읽힌다 [src:4]. 여기에 채도 높은 시그니처 오렌지가 얹혀, 교육/커뮤니티 브랜드다운 접근성과 에너지를 동시에 전달하는 조합이다 [src:4][src:12].
+
+## Components
+
+Storybook 매니페스트(`index.json`, 총 135 엔트리)는 각각 문서 페이지와 라이브 스토리를 갖춘 18개 컴포넌트를 나열한다: Badge, ActionButton, IconButton, Chip, Checkbox, RadioButton, Toggle, DatePicker, Dialog, Pagination, SelectBox, SelectHeader, SelectMenu, Tab, Tag, TextField, Toast, Tooltip [src:3]. 컴포넌트와 별도로 Brand Logo, Colors, Radius, Screen, Screen Grid, Space, Typography가 Foundation 그룹으로 문서화돼 있다 [src:3].
+
+라이선스 참고: 컴포넌트 코드가 배포되는 npm 패키지 `@likelion-design/ui`(최신 `1.0.32`)는 `license` 필드가 비어 있고(null) [src:7], 문서 사이트 자체도 `/LICENSE` 요청에 403을 반환하며 [src:6], ~100개 이상의 JS/CSS 청크와 index.html을 grep해도 명시적 저작권/재배포 금지 문구는 발견되지 않았다 [src:2]. 즉 컴포넌트/토큰 콘텐츠 자체에는 명시적 허용도 명시적 금지도 없다 — 유일하게 명문화된 사용 제한은 아래 Brand Logo 규정뿐이다.
+
+개별 컴포넌트가 정확히 어떤 토큰을 쓰는지는 렌더링된 화면이 아니라 시맨틱 토큰의 이름 자체에서 유추한 것이며(예: `border-primary`는 포커스/강조용으로 명명돼 있다), 컴포넌트별 실측 매핑은 아니다 [src:4].
+
+### action-button
+
+1차 CTA 버튼 계열. 시맨틱 토큰 이름 구조상 `{colors.bg-primary}` 채움과 `{colors.fg-white}` 라벨 잉크, `{rounded.radius-3}` 코너를 쓰는 것이 스케일과 정합적이다 [src:3][src:4].
+
+```tsx
+<ActionButton variant="primary">확인</ActionButton>
+```
+
+### icon-button
+
+아이콘 전용 컴팩트 버튼. `{rounded.radius-full}` 원형 코너와 `{colors.gray-600}` 기본 아이콘 잉크, 활성/호버 시 `{colors.fg-primary}`로 전환되는 구조가 토큰 명명과 정합적이다 [src:3][src:4].
+
+### text-field
+
+입력 필드. 기본 상태 `{colors.border-normal}`, 포커스/강조 상태 `{colors.border-primary}`, 비활성 라벨 `{colors.fg-disabled}`를 쓰는 것이 시맨틱 토큰 이름 구조상 자연스럽다 — 정확한 상태별 매핑은 렌더링 확인이 필요하다 [src:3][src:4].
+
+```tsx
+<TextField placeholder="이메일" disabled={false} />
+```
+
+### select-box
+
+SelectBox·SelectHeader·SelectMenu 세 엔트리가 나란히 문서화돼 있다 [src:3] — 이름 구조상 트리거 헤더 + 오버레이 메뉴로 조합되는 선택형 패턴으로 추정되나, 세 엔트리를 하나의 패턴으로 묶어 설명하는 문서 자체가 확인된 것은 아니다. 오버레이 표면에는 `{colors.bg-white}`, 구분선에는 `{colors.border-weak}`가 정합적이다 [src:4].
+
+### dialog / toast
+
+Dialog(모달)와 Toast(일시적 알림)는 각각 별도 스토리로 문서화된 피드백 컴포넌트다 [src:3]. 표면 배경은 `{colors.bg-white}`, 강조가 필요한 경우 `{colors.bg-primary-weak}` 배경에 `{colors.fg-primary}` 텍스트 조합을 쓰는 것이 팔레트 구조와 맞는다 [src:4].
+
+### tag / chip
+
+Tag와 Chip은 별도 컴포넌트로 각각 문서화돼 있다 [src:3]. 라벨류 컴포넌트답게 `{colors.bg-primary-weak}` 배경에 `{colors.fg-primary}` 텍스트, `{rounded.radius-full}` 또는 `{rounded.radius-2}` 코너를 쓰는 조합이 팔레트·radius 스케일과 정합적이다 [src:4].
+
+### brand-logo
+
+Foundation의 Brand Logo 그룹은 컴포넌트가 아니라 자산 규정이지만, 이 카탈로그에서 유일하게 명문화된 사용 제한을 담고 있어 함께 기록한다. 컴파일된 `Logo.mdx` 청크에서 직접 인용하면 [src:5]:
+
+- "로고의 형태나 비율을 임의로 변경하거나 왜곡하여 사용하는 것은 금지합니다."
+- "임의로 로고의 색상 / 형태 / 비례를 변형하거나 삭제하는 행위는 허용하지 않습니다."
+- "다른 요소들로부터 8.2배 이상의 여백 공간을 확보해야 합니다."
+
+위 여백 배수는 컴파일된 `Logo.mdx` 청크의 본문 텍스트를 그대로 옮긴 것이나 [src:5], 같은 문서의 Clear space 다이어그램은 로고 사방 여백을 "0.2X"로 표기하고 있어 [src:13] 본문 텍스트와 정확히 40배 어긋난다 — 브랜드 원본 자체의 내부 불일치로 보인다(다이어그램의 "0.2"가 본문에서 "8.2"로 오기됐을 가능성이 높다). 이 카탈로그는 두 값 중 하나를 임의로 정본화하지 않고 원문 그대로 병기한다.
+
+심볼 마크는 오렌지(`oklch(0.69 0.209 42)` ≈ #FF6000)·블랙(`oklch(0 0 0)` ≈ #000000)·화이트 세 색상 변형으로만 존재하며, 공개 서빙 형태는 PNG 래스터(`/img/BrandLogo/04_Symbol.png` 등)뿐이다 — 순수 벡터는 JS 스토리 청크 안 data-URI로만 존재하고 독립 SVG 파일로는 공개되지 않는다 [src:5].
+
+## Do's and Don'ts
+
+**Do** 시그니처 오렌지 `{colors.bg-primary}`를 쿨톤 그레이 `{colors.gray-*}` 위에 얹어 에너지 있는 에듀테크 색 인상을 유지하고 [src:4], 카피 톤은 격려형 어조로 친근함을 더한다 [src:11].
+
+**Do** 12~24px대의 중~대형 반경(`{rounded.radius-3}`~`{rounded.radius-6}`)을 소형 코너와 나란히 써서, 날카로운 기하학이나 순수 필 하나로 수렴하지 않는 절제된 둥근 코너 언어를 지킨다 [src:4].
+
+**Don't** 브랜드가 다루는 부트캠프 커리큘럼명·수강신청/코호트 모집 플로우·트랙별 카피(프론트엔드/백엔드/데이터 등)를 그대로 재현하지 말 것 — 소비자가 빌려야 할 것은 오렌지+쿨그레이+절제된 라운드 코너라는 시각 언어이지, 교육/부트캠프 도메인의 제품 개념이나 모집 플로우가 아니다 [src:12].
+
+**Don't** Brand Logo 자산을 임의로 리컬러·왜곡하거나 최소한의 여백 없이 배치하지 말 것 — 이는 브랜드가 명문화한 유일한 사용 제한이다(정확한 여백 배수는 본문 텍스트 "8.2배"와 다이어그램 "0.2X"가 서로 어긋나 확정할 수 없다 — Components/brand-logo 참고) [src:5][src:13].
+
+**Don't** `LIKELION Design System` 워드마크·`@likelion-design/ui`·`@likelion-design/docs-mcp` 패키지명을 소비자가 생성하는 UI의 카피·헤더·타이틀·라벨·클래스명에 노출하지 말 것 — 차용할 것은 오렌지+쿨그레이 팔레트와 절제된 라운드 코너라는 시각 언어이지, 이 디자인 시스템의 이름이나 패키지 정체성이 아니다.
+
+## Responsive Behavior
+
+이 절은 렌더링된 제품 화면이 아니라 디자인 시스템 문서 사이트(Storybook 셸)의 번들 CSS `@media` 규칙에서 역추출한 것이라는 단서를 달아 읽어야 한다 [src:4].
+
+| 폭 | 값 | Key Changes |
+| --- | --- | --- |
+| xs | 375px | 관찰된 가장 좁은 기준폭 [src:4] |
+| sm | 640px | Tailwind 스톡 기본값 — 브랜드 고유 `--screen-*` 토큰 없음 [src:4] |
+| (비표준) | 744px | 640/768 사이 추가 스텝, 이름 붙은 토큰 없음 [src:4] |
+| md | 768px | Tailwind 스톡 기본값 [src:4] |
+| lg | 1024px | Tailwind 스톡 기본값 [src:4] |
+| xl | 1280px | 그리드가 2열 → 3열로 확장 (`repeat(2, minmax(0,1fr))` → `repeat(3, minmax(0,1fr))`) [src:4] |
+| 2xl | 1536px | Tailwind 스톡 기본값 [src:4] |
+
+터치 타깃 최소 크기, 컴포넌트별 축소 전략, 이미지/종횡비 처리 방식은 공개 코퍼스에서 확인되지 않았다(no published touch-target or per-component collapsing rule surfaced) — SPA 셸이 자동 추출 도구에 실제 렌더 콘텐츠를 내주지 않았기 때문이다 [src:1][src:2]. Foundation 매니페스트에 "Screen"(Specification 전용)과 "Screen Grid"(Docs 페이지 있음) 항목이 별도로 존재해 반응형/그리드 가이드 자체는 공식적으로 문서화돼 있음은 확인되지만, 구체적인 컬럼 수·거터·마진 값은 캡처되지 않았다 [src:3].
+
+## Known Gaps
+
+- 스크린샷/렌더 화면이 확보되지 않아 위 시각 서술은 대부분 컴파일된 토큰 CSS에서 역추출한 값이며, 실제 렌더 화면 확인이 필요하다 [src:1][src:2].
+- 브랜드 고유 그림자/elevation 토큰과 모션(duration/easing) 토큰이 공개돼 있지 않다 — Tailwind 기본 인프라 변수만 존재한다 [src:2].
+- Typography frontmatter의 `fontWeight` 값은 사이즈·굵기·자간 세 스케일이 각 스타일명에 정확히 어떻게 짝지어지는지가 개별 문서화돼 있지 않아 고른 예시 조합이다 [src:4] — 실제 값은 스타일별로 다를 수 있다. `lineHeight`는 코퍼스에 스케일 자체가 공개돼 있지 않아 관례적 비율을 적용한 추정값이며, 각 head row의 `# 미확인` 주석으로 표시해 뒀다.
+- 18개 컴포넌트의 사이즈/색상 변형, 호버·비활성 등 상태별 세부값이 이름 목록 외에는 개별 확인되지 않았다 [src:3].
+- Spacing 14개 중 9개, Radius 11개 중 8개만 코퍼스에서 개별 재확인됐다 — 나머지 스텝 값은 미확인이다 [src:2][src:4].
+- `@likelion-design/ui`·`@likelion-design/docs-mcp`의 라이선스 상태가 모호하다 — `license` 필드 null, 별도 LICENSE 파일 미게시, 명시적 금지 문구도 미발견으로, 명시적 허용도 명시적 금지도 없는 상태다 [src:6][src:7][src:2].
+
+## References
+
+1. https://likelion.net/ — SPA 셸. fetch로는 페이지 타이틀("홈 : 멋쟁이사자처럼")만 노출, 본문 콘텐츠는 자동 추출되지 않는다.
+2. https://designsystem.likelion.net — Storybook 문서 사이트 루트. ~100개 이상 JS/CSS 청크·index.html grep의 대상.
+3. https://designsystem.likelion.net/index.json — Storybook 매니페스트(135 엔트리). 컴포넌트 18개·Foundation 7개 그룹 목록의 1차 근거.
+4. https://designsystem.likelion.net/assets/iframe-CXUH1Zgo.css — 컴파일된 토큰 CSS 번들(39,477 bytes). 색상·타이포·spacing·radius·breakpoint 값의 1차 근거.
+5. https://designsystem.likelion.net/assets/Logo-dx0Jf8eZ.js — Brand Logo 사용 규정이 담긴 컴파일된 `Logo.mdx` 청크.
+6. https://designsystem.likelion.net/LICENSE — 403 응답. 문서 사이트에 별도 LICENSE 파일이 게시돼 있지 않음을 확인하는 근거.
+7. https://registry.npmjs.org/@likelion-design/ui — npm 레지스트리. 컴포넌트 패키지의 `license` 필드가 비어 있음(null)을 확인.
+8. https://registry.npmjs.org/@likelion-design/docs-mcp — npm 레지스트리. MIT 라이선스의 MCP 서버 패키지, 5개 tool 노출.
+9. https://designsystem.likelion.net/robots.txt — 크롤 접근 정책 확인용.
+10. https://designsystem.likelion.net/sitemap.xml — 문서 사이트 구조 확인용.
+11. https://brunch.co.kr/@likelion/59 — 공식 Brunch 채널 게시물. 톤앤보이스 샘플의 근거.
+12. https://ko.wikipedia.org/wiki/멋쟁이사자처럼 — 브랜드 연혁·트랙 구성·슬로건 개요.
+13. https://designsystem.likelion.net/img/BrandLogo/03_Clearspace.png — Brand Logo 문서의 Clear space 다이어그램 이미지. 여백 사방을 "0.2X"로 표기해, 같은 문서 본문 텍스트의 "8.2배" 서술과 어긋남을 확인하는 근거.

--- a/services/likelion.tokens.json
+++ b/services/likelion.tokens.json
@@ -1,0 +1,281 @@
+{
+  "colors": [
+    {
+      "name": "primary-50",
+      "value": "oklch(0.96 0.022 54)",
+      "note": "#FFEFE5",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-100",
+      "value": "oklch(0.93 0.044 52)",
+      "note": "#FFDFCC",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-200",
+      "value": "oklch(0.85 0.089 53)",
+      "note": "#FFBF99",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-300",
+      "value": "oklch(0.79 0.135 51)",
+      "note": "#FFA066",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-400",
+      "value": "oklch(0.73 0.177 48)",
+      "note": "#FF8033",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-500",
+      "value": "oklch(0.69 0.209 42)",
+      "note": "#FF6000 브랜드 시그니처",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-600",
+      "value": "oklch(0.58 0.175 42)",
+      "note": "#CC4D00",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-700",
+      "value": "oklch(0.48 0.139 44)",
+      "note": "#993A00",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-800",
+      "value": "oklch(0.36 0.102 45)",
+      "note": "#662600",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "primary-900",
+      "value": "oklch(0.30 0.082 47)",
+      "note": "#4D1D00",
+      "group": "Primary (오렌지 시그니처)"
+    },
+    {
+      "name": "gray-50",
+      "value": "oklch(0.98 0.002 245)",
+      "note": "#F9FAFB",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-100",
+      "value": "oklch(0.97 0.003 270)",
+      "note": "#F3F4F6",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-200",
+      "value": "oklch(0.93 0.005 255)",
+      "note": "#E5E7EA",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-300",
+      "value": "oklch(0.87 0.010 253)",
+      "note": "#D1D6DC",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-400",
+      "value": "oklch(0.78 0.014 252)",
+      "note": "#B1B8C0",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-500",
+      "value": "oklch(0.67 0.021 251)",
+      "note": "#8A95A0",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-600",
+      "value": "oklch(0.56 0.025 257)",
+      "note": "#6B7583",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-700",
+      "value": "oklch(0.46 0.027 256)",
+      "note": "#4E5967",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-800",
+      "value": "oklch(0.35 0.029 261)",
+      "note": "#333D4B",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-850",
+      "value": "oklch(0.30 0.027 257)",
+      "note": "#262F3C",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-900",
+      "value": "oklch(0.24 0.024 262)",
+      "note": "#191F28",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "gray-950",
+      "value": "oklch(0.22 0.007 247)",
+      "note": "#191C1F",
+      "group": "Gray (쿨톤 뉴트럴)"
+    },
+    {
+      "name": "white",
+      "value": "oklch(1 0 0)",
+      "note": "#FFFFFF",
+      "group": "Semantic (bg/fg/border)"
+    }
+  ],
+  "typography": [
+    {
+      "name": "display-d1",
+      "size": "52px",
+      "weight": 800,
+      "lineHeight": "1.2",
+      "tracking": "-0.3px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    },
+    {
+      "name": "heading-h1",
+      "size": "35px",
+      "weight": 700,
+      "lineHeight": "1.3",
+      "tracking": "-0.3px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    },
+    {
+      "name": "heading-h4",
+      "size": "23px",
+      "weight": 600,
+      "lineHeight": "1.35",
+      "tracking": "0px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    },
+    {
+      "name": "body-p1",
+      "size": "17px",
+      "weight": 400,
+      "lineHeight": "1.5",
+      "tracking": "0px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    },
+    {
+      "name": "body-p3",
+      "size": "13px",
+      "weight": 400,
+      "lineHeight": "1.5",
+      "tracking": "0px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    },
+    {
+      "name": "body-p5",
+      "size": "11px",
+      "weight": 400,
+      "lineHeight": "1.4",
+      "tracking": "0px",
+      "note": "미확인 — fontWeight/lineHeight는 스케일 범위 안에서 고른 예시 조합"
+    }
+  ],
+  "spacing": [
+    {
+      "name": "space-1",
+      "value": "4px",
+      "px": 4
+    },
+    {
+      "name": "space-2",
+      "value": "8px",
+      "px": 8
+    },
+    {
+      "name": "space-3",
+      "value": "12px",
+      "px": 12
+    },
+    {
+      "name": "space-4",
+      "value": "16px",
+      "px": 16
+    },
+    {
+      "name": "space-5",
+      "value": "20px",
+      "px": 20
+    },
+    {
+      "name": "space-6",
+      "value": "24px",
+      "px": 24
+    },
+    {
+      "name": "space-8",
+      "value": "32px",
+      "px": 32
+    },
+    {
+      "name": "space-10",
+      "value": "40px",
+      "px": 40
+    },
+    {
+      "name": "space-12",
+      "value": "48px",
+      "px": 48
+    }
+  ],
+  "radius": [
+    {
+      "name": "radius-05",
+      "value": "2px",
+      "px": 2
+    },
+    {
+      "name": "radius-1",
+      "value": "4px",
+      "px": 4
+    },
+    {
+      "name": "radius-2",
+      "value": "8px",
+      "px": 8
+    },
+    {
+      "name": "radius-3",
+      "value": "12px",
+      "px": 12
+    },
+    {
+      "name": "radius-4",
+      "value": "16px",
+      "px": 16
+    },
+    {
+      "name": "radius-5",
+      "value": "20px",
+      "px": 20
+    },
+    {
+      "name": "radius-6",
+      "value": "24px",
+      "px": 24
+    },
+    {
+      "name": "radius-full",
+      "value": "999px",
+      "px": 999
+    }
+  ]
+}

--- a/src/lib/google-designmd-corpus.test.ts
+++ b/src/lib/google-designmd-corpus.test.ts
@@ -143,6 +143,7 @@ describe("catalog → Google DESIGN.md", () => {
       "greeting",
       "krds",
       "kyobobook",
+      "likelion",
       "line-design-system",
       "seed-design",
       "socar",

--- a/src/lib/oklch-drift-corpus.test.ts
+++ b/src/lib/oklch-drift-corpus.test.ts
@@ -117,6 +117,7 @@ const MATCH_FLOOR: Partial<Record<string, number>> = {
   greeting: 13,
   krds: 33,
   kyobobook: 41,
+  likelion: 23,
   "line-design-system": 24,
   "seed-design": 27,
   socar: 40,

--- a/src/lib/oklch-drift.ts
+++ b/src/lib/oklch-drift.ts
@@ -200,6 +200,7 @@ const PREVIEW_TOKEN_ALIASES: Partial<
   ],
   krds: [["", "krds-"]],
   kyobobook: [["", "kds-"]],
+  likelion: [["", "ll-"]],
   "line-design-system": [
     ["ldsg-color-", "ldsg-"],
     ["", "ldsg-"],

--- a/src/lib/token-coverage.test.ts
+++ b/src/lib/token-coverage.test.ts
@@ -66,7 +66,7 @@ describe("token gate coverage", () => {
       annotated += c.annotated
       judged += c.judged
     }
-    expect({ annotated, judged }).toEqual({ annotated: 927, judged: 918 })
+    expect({ annotated, judged }).toEqual({ annotated: 950, judged: 941 })
   })
 
   it("keeps the drift gate resolving the definitions it compares", () => {
@@ -80,7 +80,8 @@ describe("token gate coverage", () => {
     // Scoping the reader to the frontmatter block is what stops those — and
     // stops `wanted`'s Components `bg:`/`fg:` rows from manufacturing
     // duplicate-name conflicts the catalog does not have.
-    expect(total).toBe(1263)
+    // 1286 after likelion's 23 colors joined the catalog.
+    expect(total).toBe(1286)
   })
 
   it("keeps every entry contributing definitions to the drift gate", () => {


### PR DESCRIPTION
## 변경 요약

멋쟁이사자처럼(LIKELION Design System)을 카탈로그에 추가한다. `designsystem.likelion.net`(Storybook)을 근거로 `services/likelion.md`·`tokens.json`·`preview.html`·로고 SVG를 작성했고, 다차원 리뷰(코드 정확성·인용 신뢰성·토큰 정합성·시각 검수)로 19건을 찾아 18건을 함께 수정했다.

## 변경 종류

- [x] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 카탈로그 PR 체크 (해당 시)

- [x] `/design-md` 스킬로 생성
- [x] frontmatter 필수 필드 검증 완료 (`name`, `slug`, `category`, `last_updated`, `created_at`, `sources`, `lang`)
- [x] `public/preview/{slug}/preview.html` 생성·확인 (라이트·다크 한 파일, 375/768/976/1440px 오버플로 없음 확인)
- [x] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
- [x] 브랜드 자산 라이선스/상표 우려 검토 ([NOTICE](https://github.com/CaesiumY/ko-design-md/blob/main/NOTICE) 정책) — 로고 자산 행 추가, 컴포넌트 코드(`@likelion-design/ui`)는 license 필드 없음(null)을 design.md 본문에 명시적으로 기록
- [x] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 상세

**카탈로그가 공유하는 고정 카운트 테스트 3개를 함께 맞춤** — 새 항목 추가는 필연적으로 이 랫칫들을 건드린다:
- `google-designmd-corpus.test.ts`의 `missing-primary` 슬러그 목록에 `likelion` 추가
- `NOTICE`의 자산 인벤토리에 `likelion.svg` 행 추가
- `token-coverage.test.ts`의 OKLCH 정의 카운트 랫칫을 likelion의 색상 23개만큼 상향
- `oklch-drift.ts`(`PREVIEW_TOKEN_ALIASES`)·`oklch-drift-corpus.test.ts`(`MATCH_FLOOR`)에 likelion 전용 프리뷰 별칭 규칙(`ll-` 접두, 23개 매칭) 추가

**xhigh 강도 리뷰로 잡아 고친 것들:**
- CI를 실제로 깨던 랫칫 불일치 4건(위 항목)
- 다크 모드에서 Toast/Tooltip 텍스트 대비가 1.23:1(WCAG AA 기준 4.5:1)까지 떨어지던 접근성 버그 — 배경으로 재사용한 잉크 토큰이 다크 테마에서 밝은 값으로 뒤집히는데 텍스트는 흰색으로 고정돼 있었음
- 로고 SVG가 실제 비율(120×60)을 무시하고 정사각 캔버스에 패딩돼 히어로/푸터에서 절반 크기로 렌더되던 문제
- `services/likelion.md`가 `research.md`와 어긋나던 인용 6건(citation-fidelity) — 소스 번호 오귀속, 근거 없는 결론 서술, 색상 소스로 감성적 특성을 뒷받침한 것 등
- CSS 정리 3건(죽은 커스텀 프로퍼티 2개, 로고 크기 3중 선언)

**의도적으로 정정하지 않고 병기만 한 것:** 로고 사용 규정의 "클리어스페이스" 값이 브랜드 원본 자체에서 본문 텍스트("8.2배")와 다이어그램("0.2X")이 40배 어긋난다 — 임의로 정본화하지 않고 두 값을 그대로 인용하며 불일치를 design.md에 기록했다.

**이번 범위에서 제외한 것:** 타이포그래피(fontWeight/lineHeight) 드리프트를 검증하는 게이트가 카탈로그 전체에 구조적으로 없다는 아키텍처 지적 — likelion만의 문제가 아니라 17개 항목이 공유하는 인프라 한계라 별도 논의가 필요하다고 판단해 이번 PR에서는 다루지 않았다.

**검증:** `pnpm test`(824/824)·`typecheck`·`lint`·`validate:catalog`·`validate:previews`·`tokens:check`·`audit:oklch`·`check:last-updated`·`validate:spec`·`build` 전부 통과 확인.
