### PR TITLE
fix(vapor-ui): 상류 배포본과 재대조해 다크 팔레트를 발행하고 프리뷰 결함을 고친다

### DIFF
--- a/public/preview/vapor-ui/preview.html
+++ b/public/preview/vapor-ui/preview.html
@@ -283,7 +283,7 @@
   .vp-btn-lg { height: 40px; padding: 0 16px; gap: 8px; font-size: 14px; line-height: 22px; border-radius: 8px; }
   .vp-btn-xl { height: 48px; padding: 0 24px; gap: 8px; font-size: 16px; line-height: 24px; border-radius: 8px; }
 
-  .vp-btn-primary { background: var(--vp-blue-500); color: var(--vp-on-fill); }
+  .vp-btn-primary { background: var(--vp-bg-primary-200); color: var(--vp-on-fill); }
   .vp-btn-primary[disabled] { opacity: 0.32; cursor: not-allowed; }
 
   .vp-btn-primary-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-primary-200); box-shadow: inset 0 0 0 1px var(--vp-border-primary); }
@@ -292,11 +292,11 @@
 
   .vp-btn-secondary { background: var(--vp-bg-secondary-200); color: var(--vp-fg-secondary-200); }
 
-  .vp-btn-danger { background: var(--vp-red-500); color: var(--vp-on-fill); }
+  .vp-btn-danger { background: var(--vp-bg-danger-200); color: var(--vp-on-fill); }
 
   .vp-btn-danger-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-danger-200); box-shadow: inset 0 0 0 1px var(--vp-border-danger); }
 
-  .vp-btn-contrast { background: var(--vp-gray-800); color: var(--vp-on-fill); }
+  .vp-btn-contrast { background: var(--vp-bg-contrast-200); color: var(--vp-on-fill); }
 
   .vp-btn svg { width: 16px; height: 16px; flex-shrink: 0; }
 
@@ -636,7 +636,7 @@
     flex-shrink: 0;
     transition: background-color 120ms cubic-bezier(.4, 0, .2, 1);
   }
-  .vp-switch.on { background: var(--vp-blue-500); }
+  .vp-switch.on { background: var(--vp-bg-primary-200); }
   .vp-switch::after {
     content: "";
     position: absolute;
@@ -1495,14 +1495,14 @@
 [data-theme="dark"] .vp-btn-md { height: 32px; padding: 0 12px; gap: 6px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-lg { height: 40px; padding: 0 16px; gap: 8px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-xl { height: 48px; padding: 0 24px; gap: 8px; font-size: 16px; line-height: 24px; border-radius: 8px; }
-[data-theme="dark"] .vp-btn-primary { background: var(--vp-blue-400); color: var(--vp-on-fill); }
+[data-theme="dark"] .vp-btn-primary { background: var(--vp-bg-primary-200); color: var(--vp-on-fill); }
 [data-theme="dark"] .vp-btn-primary[disabled] { opacity: 0.32; cursor: not-allowed; }
 [data-theme="dark"] .vp-btn-primary-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-primary-200); box-shadow: inset 0 0 0 1px var(--vp-border-primary); }
 [data-theme="dark"] .vp-btn-primary-ghost { background: transparent; color: var(--vp-fg-primary-100); }
 [data-theme="dark"] .vp-btn-secondary { background: var(--vp-bg-secondary-200); color: var(--vp-fg-secondary-200); }
-[data-theme="dark"] .vp-btn-danger { background: var(--vp-red-400); color: var(--vp-on-fill); }
+[data-theme="dark"] .vp-btn-danger { background: var(--vp-bg-danger-200); color: var(--vp-on-fill); }
 [data-theme="dark"] .vp-btn-danger-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-danger-200); box-shadow: inset 0 0 0 1px var(--vp-border-danger); }
-[data-theme="dark"] .vp-btn-contrast { background: var(--vp-gray-800); color: var(--vp-gray-050); }
+[data-theme="dark"] .vp-btn-contrast { background: var(--vp-bg-contrast-200); color: var(--vp-on-fill); }
 [data-theme="dark"] .vp-btn svg { width: 16px; height: 16px; flex-shrink: 0; }
 [data-theme="dark"] .btn-group { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }
 /* === Icon button === */
@@ -1824,7 +1824,7 @@
     flex-shrink: 0;
     transition: background-color 120ms cubic-bezier(.4, 0, .2, 1);
   }
-[data-theme="dark"] .vp-switch.on { background: var(--vp-blue-400); }
+[data-theme="dark"] .vp-switch.on { background: var(--vp-bg-primary-200); }
 [data-theme="dark"] .vp-switch::after {
     content: "";
     position: absolute;
@@ -2112,9 +2112,7 @@
     left: 16px;
     width: 8px;
     height: 8px;
-    background: var(--vp-gray-300);
-    border-right: 1px solid var(--vp-gray-200);
-    border-bottom: 1px solid var(--vp-gray-200);
+    background: var(--vp-bg-contrast-200);
     transform: rotate(45deg);
   }
 /* === Popover === */

--- a/public/preview/vapor-ui/preview.html
+++ b/public/preview/vapor-ui/preview.html
@@ -1478,18 +1478,6 @@
                 color 150ms cubic-bezier(.4, 0, .2, 1);
     letter-spacing: -0.1px;
   }
-  .vp-btn::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: var(--vp-gray-900);
-    opacity: 0;
-    transition: opacity 150ms ease;
-    pointer-events: none;
-  }
-[data-theme="dark"] .vp-btn:hover::before, [data-theme="dark"] .vp-btn.is-hover::before { opacity: 0.08; }
-[data-theme="dark"] .vp-btn:active::before, [data-theme="dark"] .vp-btn.is-active::before { opacity: 0.16; }
 
 [data-theme="dark"] .vp-btn-sm { height: 24px; padding: 0 8px; gap: 4px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-md { height: 32px; padding: 0 12px; gap: 6px; font-size: 14px; line-height: 22px; border-radius: 8px; }

--- a/public/preview/vapor-ui/preview.html
+++ b/public/preview/vapor-ui/preview.html
@@ -9,6 +9,7 @@
 <style>
   :root {
     /* Vapor UI base palette — Gray */
+    --vp-canvas: oklch(1.000 0.000 0);
     --vp-gray-050: oklch(0.976 0.000 0);
     --vp-gray-100: oklch(0.910 0.000 0);
     --vp-gray-200: oklch(0.827 0.000 0);
@@ -49,13 +50,13 @@
     --vp-violet-300: oklch(0.733 0.152 299);
 
     /* Semantic alias — light theme */
-    --vp-bg-canvas: oklch(1.000 0.000 0);
+    --vp-bg-canvas: var(--vp-canvas);
     --vp-bg-canvas-200: var(--vp-gray-050);
     --vp-bg-overlay-100: oklch(1.000 0.000 0);
-    --vp-bg-primary-100: var(--vp-blue-050);
+    --vp-bg-primary-100: var(--vp-blue-100);
     --vp-bg-primary-200: var(--vp-blue-500);
-    --vp-bg-secondary-100: var(--vp-gray-100);
-    --vp-bg-secondary-200: var(--vp-gray-200);
+    --vp-bg-secondary-100: var(--vp-gray-050);
+    --vp-bg-secondary-200: var(--vp-gray-100);
     --vp-bg-success-100: var(--vp-green-100);
     --vp-bg-success-200: var(--vp-green-500);
     --vp-bg-warning-100: var(--vp-orange-100);
@@ -67,7 +68,7 @@
     --vp-bg-contrast-100: var(--vp-gray-300);
     --vp-bg-contrast-200: var(--vp-gray-800);
 
-    --vp-fg-primary-100: var(--vp-blue-500);
+    --vp-fg-primary-100: var(--vp-blue-600);
     --vp-fg-primary-200: var(--vp-blue-700);
     --vp-fg-secondary-100: var(--vp-gray-800);
     --vp-fg-secondary-200: var(--vp-gray-900);
@@ -107,7 +108,7 @@
     --primary: var(--vp-blue-500);
     --primary-foreground: oklch(1 0 0);
     --muted: var(--vp-gray-100);
-    --muted-foreground: var(--vp-gray-600);
+    --muted-foreground: var(--vp-fg-hint-100);
     --accent: var(--vp-blue-050);
     --accent-foreground: var(--vp-blue-700);
     --border: var(--vp-gray-200);
@@ -251,6 +252,7 @@
   /* === Buttons === */
   .vp-btn {
     display: inline-flex;
+    position: relative;
     align-items: center;
     justify-content: center;
     gap: 6px;
@@ -263,34 +265,38 @@
                 color 150ms cubic-bezier(.4, 0, .2, 1);
     letter-spacing: -0.1px;
   }
+  .vp-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--vp-gray-900);
+    opacity: 0;
+    transition: opacity 150ms ease;
+    pointer-events: none;
+  }
+  .vp-btn:hover::before, .vp-btn.is-hover::before { opacity: 0.08; }
+  .vp-btn:active::before, .vp-btn.is-active::before { opacity: 0.16; }
+
   .vp-btn-sm { height: 24px; padding: 0 8px; gap: 4px; font-size: 14px; line-height: 22px; border-radius: 8px; }
   .vp-btn-md { height: 32px; padding: 0 12px; gap: 6px; font-size: 14px; line-height: 22px; border-radius: 8px; }
   .vp-btn-lg { height: 40px; padding: 0 16px; gap: 8px; font-size: 14px; line-height: 22px; border-radius: 8px; }
   .vp-btn-xl { height: 48px; padding: 0 24px; gap: 8px; font-size: 16px; line-height: 24px; border-radius: 8px; }
 
   .vp-btn-primary { background: var(--vp-blue-500); color: var(--vp-on-fill); }
-  .vp-btn-primary:hover { background: var(--vp-blue-600); }
-  .vp-btn-primary:active { background: var(--vp-blue-700); }
   .vp-btn-primary[disabled] { opacity: 0.32; cursor: not-allowed; }
 
   .vp-btn-primary-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-primary-200); box-shadow: inset 0 0 0 1px var(--vp-border-primary); }
-  .vp-btn-primary-outline:hover { background: var(--vp-bg-primary-100); }
 
-  .vp-btn-primary-ghost { background: transparent; color: var(--vp-fg-primary-200); }
-  .vp-btn-primary-ghost:hover { background: var(--vp-bg-primary-100); }
+  .vp-btn-primary-ghost { background: transparent; color: var(--vp-fg-primary-100); }
 
   .vp-btn-secondary { background: var(--vp-bg-secondary-200); color: var(--vp-fg-secondary-200); }
-  .vp-btn-secondary:hover { background: var(--vp-gray-200); }
 
   .vp-btn-danger { background: var(--vp-red-500); color: var(--vp-on-fill); }
-  .vp-btn-danger:hover { background: var(--vp-red-600); }
-  .vp-btn-danger:active { background: var(--vp-red-700); }
 
   .vp-btn-danger-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-danger-200); box-shadow: inset 0 0 0 1px var(--vp-border-danger); }
-  .vp-btn-danger-outline:hover { background: var(--vp-bg-danger-100); }
 
   .vp-btn-contrast { background: var(--vp-gray-800); color: var(--vp-on-fill); }
-  .vp-btn-contrast:hover { background: var(--vp-gray-900); }
 
   .vp-btn svg { width: 16px; height: 16px; flex-shrink: 0; }
 
@@ -341,7 +347,7 @@
     padding: 24px;
     min-width: 0;
   }
-  .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+  .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; align-items: start; }
 
   .vp-input {
     width: 100%;
@@ -439,10 +445,8 @@
     box-shadow: inset 0 0 0 1px var(--vp-border-primary);
   }
   .vp-select.disabled {
-    background: var(--vp-gray-100);
-    color: var(--vp-gray-500);
+    opacity: 0.32;
     cursor: not-allowed;
-    box-shadow: inset 0 0 0 1px var(--vp-border-normal);
   }
   .vp-select .chev { width: 16px; height: 16px; flex-shrink: 0; color: var(--vp-fg-hint-100); transition: transform 120ms cubic-bezier(.4,0,.2,1); }
   .vp-select.open .chev { transform: rotate(180deg); }
@@ -450,6 +454,7 @@
 
   .vp-listbox {
     margin-top: 4px;
+    min-width: 200px;
     background: var(--vp-bg-canvas);
     border: 1px solid var(--vp-border-normal);
     border-radius: 8px;
@@ -577,7 +582,7 @@
     flex-direction: column;
     gap: 12px;
   }
-  .control-line { display: flex; align-items: center; gap: 10px; font-size: 14px; line-height: 20px; }
+  .control-line { display: flex; align-items: center; gap: 8px; font-size: 14px; line-height: 22px; }
 
   .vp-checkbox {
     width: 16px;
@@ -626,7 +631,7 @@
     width: 40px;
     height: 24px;
     border-radius: 9999px;
-    background: var(--vp-gray-300);
+    background: var(--vp-gray-400);
     position: relative;
     flex-shrink: 0;
     transition: background-color 120ms cubic-bezier(.4, 0, .2, 1);
@@ -635,19 +640,19 @@
   .vp-switch::after {
     content: "";
     position: absolute;
-    top: 2px;
-    left: 2px;
+    top: 4px;
+    left: 4px;
     width: 16px;
     height: 16px;
     border-radius: 50%;
     background: oklch(1 0 0);
-    box-shadow: var(--vp-shadow-sm);
+    box-shadow: var(--vp-shadow-md);
     transition: transform 120ms cubic-bezier(.4, 0, .2, 1);
   }
   .vp-switch.on::after { transform: translateX(16px); }
 
   /* === Radio card === */
-  .radiocard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+  .radiocard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-items: start; }
   .vp-radio-card {
     display: flex;
     gap: 12px;
@@ -667,12 +672,14 @@
   }
   .vp-radio-card .rc-body { min-width: 0; }
   .vp-radio-card .rc-title {
+    display: block;
     font-size: 14px;
     font-weight: 500;
     color: var(--vp-fg-secondary-200);
     margin: 0 0 2px;
   }
   .vp-radio-card .rc-desc {
+    display: block;
     font-size: 12px;
     line-height: 1.5;
     color: var(--vp-fg-hint-200);
@@ -682,7 +689,7 @@
   /* === Tabs === */
   .vp-tabs {
     display: flex;
-    gap: 4px;
+    gap: 8px;
     border-bottom: 1px solid var(--vp-border-normal);
     flex-wrap: wrap;
   }
@@ -691,7 +698,7 @@
     padding: 0 4px;
     font-size: 14px;
     font-weight: 500;
-    color: var(--vp-fg-hint-100);
+    color: var(--vp-fg-normal-100);
     border: 0;
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
@@ -719,7 +726,7 @@
   .vp-breadcrumb a { color: inherit; text-decoration: none; }
   .vp-breadcrumb a:hover { color: var(--vp-fg-secondary-200); }
   .vp-breadcrumb .sep { opacity: 0.5; }
-  .vp-breadcrumb .current { color: var(--vp-fg-secondary-200); }
+  .vp-breadcrumb .current { color: var(--vp-fg-primary-100); }
 
   /* === Menu (dropdown) === */
   .vp-menu {
@@ -778,7 +785,7 @@
   .vp-nav-item svg { width: 16px; height: 16px; flex-shrink: 0; }
 
   /* === Pagination === */
-  .vp-pagination { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+  .vp-pagination { display: flex; flex-wrap: wrap; gap: 2px; align-items: center; }
   .vp-page {
     min-width: 32px;
     height: 32px;
@@ -786,7 +793,7 @@
     border-radius: 8px;
     border: 1px solid var(--vp-border-normal);
     background: var(--vp-bg-canvas);
-    color: var(--vp-fg-secondary-200);
+    color: var(--vp-fg-normal-100);
     font-size: 14px;
     font-weight: 500;
     font-family: inherit;
@@ -819,8 +826,12 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: var(--vp-bg-secondary-200);
-    color: var(--vp-fg-secondary-200);
+    /* 이니셜은 상류가 foreground-inverse(= white)로 규정한다. 배경은 상류가
+       host 에게 위임(--avatar-fallback-background-color)하므로, 흰 글자가 읽히는
+       contrast-200 을 이 프리뷰의 선택으로 쓴다. */
+    background: var(--vp-bg-contrast-200);
+    color: oklch(1 0 0);
+    border: 1px solid var(--vp-border-normal);
     font-size: 14px;
     font-weight: 500;
     display: inline-flex;
@@ -843,6 +854,7 @@
   .vp-table th, .vp-table td {
     text-align: left;
     padding: 8px 24px;
+    line-height: 22px;
     border-bottom: 1px solid var(--vp-border-normal);
     letter-spacing: -0.1px;
     color: var(--vp-fg-secondary-200);
@@ -866,14 +878,14 @@
     gap: 6px;
     padding: 12px 16px;
     border-radius: 8px;
-    border: none;
+    border: 1px solid transparent;
     align-items: flex-start;
     background: var(--vp-bg-canvas);
   }
-  .vp-callout-primary { background: var(--vp-bg-primary-100); border-color: var(--vp-blue-200); }
-  .vp-callout-success { background: var(--vp-bg-success-100); border-color: var(--vp-green-200); }
-  .vp-callout-warning { background: var(--vp-bg-warning-100); border-color: var(--vp-orange-200); }
-  .vp-callout-danger  { background: var(--vp-bg-danger-100);  border-color: var(--vp-red-200); }
+  .vp-callout-primary { background: var(--vp-bg-primary-100); border-color: var(--vp-border-primary); color: var(--vp-fg-primary-200); }
+  .vp-callout-success { background: var(--vp-bg-success-100); border-color: var(--vp-border-success); color: var(--vp-fg-success-200); }
+  .vp-callout-warning { background: var(--vp-bg-warning-100); border-color: var(--vp-border-warning); color: var(--vp-fg-warning-200); }
+  .vp-callout-danger  { background: var(--vp-bg-danger-100);  border-color: var(--vp-border-danger); color: var(--vp-fg-danger-200); }
   .vp-callout .ico {
     width: 22px; height: 22px;
     border-radius: 50%;
@@ -895,9 +907,9 @@
     display: block;
     margin-bottom: 2px;
     letter-spacing: -0.1px;
-    color: var(--vp-fg-secondary-200);
+    line-height: 22px;
   }
-  .vp-callout span { font-size: 12px; line-height: 1.5; letter-spacing: -0.1px; color: var(--vp-fg-hint-200); }
+  .vp-callout span { font-size: 12px; line-height: 1.5; letter-spacing: -0.1px; }
 
   /* === Tooltip === */
   .vp-tooltip {
@@ -1025,9 +1037,8 @@
     align-items: center;
     gap: 10px;
   }
-  .vp-toast .toast-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-  .vp-toast .toast-dot.success { background: var(--vp-green-400, oklch(0.655 0.117 167)); }
-  .vp-toast .toast-dot.danger { background: var(--vp-red-400, oklch(0.691 0.183 20)); }
+  .vp-toast.success { background: var(--vp-bg-success-200); }
+  .vp-toast.danger { background: var(--vp-bg-danger-200); }
   .vp-toast .toast-msg { flex: 1; font-size: 14px; line-height: 22px; min-width: 0; }
   .vp-toast .toast-x {
     width: 20px; height: 20px;
@@ -1148,6 +1159,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 24px;
+    align-items: start;
   }
 
   .stack { display: flex; flex-direction: column; gap: 24px; min-width: 0; }
@@ -1202,100 +1214,103 @@
 </style>
 <style>
 [data-theme="dark"] {
-    /* Vapor UI base palette — Gray (동일 raw 값) */
-    --vp-gray-050: oklch(0.976 0.000 0);
-    --vp-gray-100: oklch(0.910 0.000 0);
-    --vp-gray-200: oklch(0.827 0.000 0);
-    --vp-gray-300: oklch(0.715 0.000 0);
-    --vp-gray-400: oklch(0.670 0.000 0);
-    --vp-gray-500: oklch(0.566 0.000 0);
-    --vp-gray-600: oklch(0.478 0.000 0);
-    --vp-gray-700: oklch(0.417 0.000 0);
-    --vp-gray-800: oklch(0.345 0.000 0);
-    --vp-gray-900: oklch(0.269 0.000 0);
+    /* 다크 전용 램프 — 라이트 폴백을 막는다 */
+    --vp-canvas: oklch(0.256 0.000 0);
+    --vp-green-050: oklch(0.271 0.069 154);
+    --vp-orange-050: oklch(0.296 0.121 29);
+    --vp-orange-700: oklch(0.812 0.105 45);
+    --vp-red-050: oklch(0.291 0.120 29);
+    /* Vapor UI base palette — 다크는 램프 자체가 재정의된다 (번호가 커질수록 밝다) */
+    --vp-gray-050: oklch(0.277 0.000 0);
+    --vp-gray-100: oklch(0.333 0.000 0);
+    --vp-gray-200: oklch(0.398 0.000 0);
+    --vp-gray-300: oklch(0.489 0.000 0);
+    --vp-gray-400: oklch(0.531 0.000 0);
+    --vp-gray-500: oklch(0.630 0.000 0);
+    --vp-gray-600: oklch(0.728 0.000 0);
+    --vp-gray-700: oklch(0.802 0.000 0);
+    --vp-gray-800: oklch(0.894 0.000 0);
+    --vp-gray-900: oklch(0.985 0.000 0);
 
     /* Blue family */
-    --vp-blue-050: oklch(0.974 0.013 241);
-    --vp-blue-100: oklch(0.910 0.048 242);
-    --vp-blue-200: oklch(0.824 0.096 243);
-    --vp-blue-300: oklch(0.715 0.142 248);
-    --vp-blue-400: oklch(0.669 0.158 252);
-    --vp-blue-500: oklch(0.573 0.189 260);
-    --vp-blue-600: oklch(0.488 0.189 260);
-    --vp-blue-700: oklch(0.428 0.187 261);
-    --vp-blue-800: oklch(0.358 0.185 263);
-    --vp-blue-900: oklch(0.289 0.184 264);
+    --vp-blue-050: oklch(0.296 0.183 264);
+    --vp-blue-100: oklch(0.350 0.184 263);
+    --vp-blue-200: oklch(0.410 0.187 262);
+    --vp-blue-300: oklch(0.497 0.189 260);
+    --vp-blue-400: oklch(0.573 0.189 260);
+    --vp-blue-500: oklch(0.633 0.169 255);
+    --vp-blue-600: oklch(0.724 0.140 248);
+    --vp-blue-700: oklch(0.800 0.110 243);
+    --vp-blue-800: oklch(0.893 0.057 243);
+    --vp-blue-900: oklch(0.983 0.009 248);
 
     /* Status colors */
-    --vp-green-100: oklch(0.903 0.058 167);
-    --vp-green-200: oklch(0.814 0.109 167);
-    --vp-green-300: oklch(0.704 0.120 167);
-    --vp-green-400: oklch(0.655 0.117 167);
-    --vp-green-500: oklch(0.554 0.112 167);
-    --vp-green-600: oklch(0.470 0.101 164);
-    --vp-green-700: oklch(0.407 0.090 162);
+    --vp-green-100: oklch(0.324 0.077 157);
+    --vp-green-200: oklch(0.390 0.088 160);
+    --vp-green-300: oklch(0.477 0.101 164);
+    --vp-green-400: oklch(0.517 0.107 166);
+    --vp-green-500: oklch(0.614 0.114 168);
+    --vp-green-600: oklch(0.710 0.118 168);
+    --vp-green-700: oklch(0.788 0.123 168);
 
-    --vp-orange-100: oklch(0.913 0.048 46);
-    --vp-orange-200: oklch(0.836 0.092 46);
-    --vp-orange-300: oklch(0.731 0.151 46);
-    --vp-orange-400: oklch(0.685 0.177 46);
-    --vp-orange-500: oklch(0.588 0.187 39);
+    --vp-orange-100: oklch(0.353 0.145 29);
+    --vp-orange-200: oklch(0.421 0.173 29);
+    --vp-orange-300: oklch(0.512 0.188 33);
+    --vp-orange-400: oklch(0.554 0.188 36);
+    --vp-orange-500: oklch(0.649 0.185 44);
 
-    --vp-red-100: oklch(0.915 0.044 20);
-    --vp-red-200: oklch(0.838 0.089 20);
-    --vp-red-300: oklch(0.736 0.155 21);
-    --vp-red-400: oklch(0.691 0.183 20);
-    --vp-red-500: oklch(0.591 0.197 22);
-    --vp-red-600: oklch(0.505 0.196 24);
-    --vp-red-700: oklch(0.439 0.180 28);
+    --vp-red-100: oklch(0.353 0.145 29);
+    --vp-red-200: oklch(0.421 0.173 29);
+    --vp-red-300: oklch(0.513 0.197 24);
+    --vp-red-400: oklch(0.557 0.197 23);
+    --vp-red-500: oklch(0.654 0.198 21);
+    --vp-red-600: oklch(0.745 0.150 21);
+    --vp-red-700: oklch(0.815 0.105 20);
 
-    --vp-violet-300: oklch(0.733 0.152 299);
+    --vp-violet-300: oklch(0.511 0.208 290);
+    --vp-violet-600: oklch(0.741 0.147 300);
 
     /* Custom dark soft backgrounds (시맨틱 alias의 ~-100이 다크 모드에서 가져가는 custom dark) */
-    --vp-bg-primary-100-dark: oklch(0.289 0.184 264 / 0.65);
-    --vp-bg-success-100-dark: oklch(0.264 0.069 152 / 0.65);
-    --vp-bg-warning-100-dark: oklch(0.285 0.117 29 / 0.65);
-    --vp-bg-danger-100-dark:  oklch(0.287 0.118 29 / 0.65);
 
     /* === Semantic alias — dark theme === */
-    --vp-bg-canvas: var(--vp-gray-900);
-    --vp-bg-canvas-200: var(--vp-gray-800);
-    --vp-bg-overlay-100: var(--vp-gray-800);
-    --vp-bg-primary-100: var(--vp-bg-primary-100-dark);
+    --vp-bg-canvas: var(--vp-canvas);
+    --vp-bg-canvas-200: var(--vp-gray-050);
+    --vp-bg-overlay-100: var(--vp-gray-100);
+    --vp-bg-primary-100: var(--vp-blue-050);
     --vp-bg-primary-200: var(--vp-blue-500);
-    --vp-bg-secondary-100: var(--vp-gray-800);
-    --vp-bg-secondary-200: var(--vp-gray-700);
-    --vp-bg-success-100: var(--vp-bg-success-100-dark);
+    --vp-bg-secondary-100: var(--vp-gray-050);
+    --vp-bg-secondary-200: var(--vp-gray-200);
+    --vp-bg-success-100: var(--vp-green-050);
     --vp-bg-success-200: var(--vp-green-500);
-    --vp-bg-warning-100: var(--vp-bg-warning-100-dark);
+    --vp-bg-warning-100: var(--vp-orange-050);
     --vp-bg-warning-200: var(--vp-orange-500);
-    --vp-bg-danger-100: var(--vp-bg-danger-100-dark);
+    --vp-bg-danger-100: var(--vp-red-050);
     --vp-bg-danger-200: var(--vp-red-500);
-    --vp-bg-hint-100: var(--vp-gray-800);
+    --vp-bg-hint-100: var(--vp-gray-200);
     --vp-bg-hint-200: var(--vp-gray-600);
-    --vp-bg-contrast-100: var(--vp-gray-700);
-    --vp-bg-contrast-200: var(--vp-gray-100);
+    --vp-bg-contrast-100: var(--vp-gray-800);
+    --vp-bg-contrast-200: var(--vp-gray-300);
 
-    --vp-fg-primary-100: var(--vp-blue-300);
-    --vp-fg-primary-200: var(--vp-blue-400);
-    --vp-fg-secondary-100: var(--vp-gray-200);
-    --vp-fg-secondary-200: var(--vp-gray-100);
-    --vp-fg-success-200: var(--vp-green-200);
-    --vp-fg-warning-200: var(--vp-orange-200);
-    --vp-fg-danger-200: var(--vp-red-200);
-    --vp-fg-hint-100: var(--vp-gray-400);
-    --vp-fg-hint-200: var(--vp-gray-300);
-    --vp-fg-contrast-200: var(--vp-gray-050);
-    --vp-fg-normal-100: var(--vp-gray-300);
-    --vp-fg-normal-200: var(--vp-gray-100);
+    --vp-fg-primary-100: var(--vp-blue-600);
+    --vp-fg-primary-200: var(--vp-blue-700);
+    --vp-fg-secondary-100: var(--vp-gray-700);
+    --vp-fg-secondary-200: var(--vp-gray-900);
+    --vp-fg-success-200: var(--vp-green-700);
+    --vp-fg-warning-200: var(--vp-orange-700);
+    --vp-fg-danger-200: var(--vp-red-700);
+    --vp-fg-hint-100: var(--vp-gray-600);
+    --vp-fg-hint-200: var(--vp-gray-700);
+    --vp-fg-contrast-200: var(--vp-gray-300);
+    --vp-fg-normal-100: var(--vp-gray-700);
+    --vp-fg-normal-200: var(--vp-gray-900);
 
     --vp-border-primary: var(--vp-blue-400);
     --vp-border-normal: var(--vp-gray-300);
     --vp-border-success: var(--vp-green-400);
     --vp-border-warning: var(--vp-orange-400);
     --vp-border-danger: var(--vp-red-400);
-    --vp-border-hint: var(--vp-gray-500);
-    --vp-border-contrast: var(--vp-gray-200);
+    --vp-border-hint: var(--vp-gray-400);
+    --vp-border-contrast: var(--vp-gray-400);
     /* Scrim — Vapor 고정값 */
     --vp-scrim: oklch(0 0 0 / .32);
 
@@ -1316,7 +1331,7 @@
     --primary: var(--vp-blue-500);
     --primary-foreground: oklch(1 0 0);
     --muted: var(--vp-gray-800);
-    --muted-foreground: var(--vp-gray-400);
+    --muted-foreground: var(--vp-fg-hint-100);
     --accent: oklch(0.289 0.184 264);
     --accent-foreground: var(--vp-blue-300);
     --border: var(--vp-gray-700);
@@ -1450,6 +1465,7 @@
 /* === Buttons === */
 [data-theme="dark"] .vp-btn {
     display: inline-flex;
+    position: relative;
     align-items: center;
     justify-content: center;
     gap: 6px;
@@ -1462,27 +1478,31 @@
                 color 150ms cubic-bezier(.4, 0, .2, 1);
     letter-spacing: -0.1px;
   }
+  .vp-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--vp-gray-900);
+    opacity: 0;
+    transition: opacity 150ms ease;
+    pointer-events: none;
+  }
+[data-theme="dark"] .vp-btn:hover::before, [data-theme="dark"] .vp-btn.is-hover::before { opacity: 0.08; }
+[data-theme="dark"] .vp-btn:active::before, [data-theme="dark"] .vp-btn.is-active::before { opacity: 0.16; }
+
 [data-theme="dark"] .vp-btn-sm { height: 24px; padding: 0 8px; gap: 4px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-md { height: 32px; padding: 0 12px; gap: 6px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-lg { height: 40px; padding: 0 16px; gap: 8px; font-size: 14px; line-height: 22px; border-radius: 8px; }
 [data-theme="dark"] .vp-btn-xl { height: 48px; padding: 0 24px; gap: 8px; font-size: 16px; line-height: 24px; border-radius: 8px; }
-[data-theme="dark"] .vp-btn-primary { background: var(--vp-blue-500); color: var(--vp-on-fill); }
-[data-theme="dark"] .vp-btn-primary:hover { background: var(--vp-blue-600); }
-[data-theme="dark"] .vp-btn-primary:active { background: var(--vp-blue-700); }
+[data-theme="dark"] .vp-btn-primary { background: var(--vp-blue-400); color: var(--vp-on-fill); }
 [data-theme="dark"] .vp-btn-primary[disabled] { opacity: 0.32; cursor: not-allowed; }
 [data-theme="dark"] .vp-btn-primary-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-primary-200); box-shadow: inset 0 0 0 1px var(--vp-border-primary); }
-[data-theme="dark"] .vp-btn-primary-outline:hover { background: var(--vp-bg-primary-100); }
-[data-theme="dark"] .vp-btn-primary-ghost { background: transparent; color: var(--vp-fg-primary-200); }
-[data-theme="dark"] .vp-btn-primary-ghost:hover { background: var(--vp-bg-primary-100); }
+[data-theme="dark"] .vp-btn-primary-ghost { background: transparent; color: var(--vp-fg-primary-100); }
 [data-theme="dark"] .vp-btn-secondary { background: var(--vp-bg-secondary-200); color: var(--vp-fg-secondary-200); }
-[data-theme="dark"] .vp-btn-secondary:hover { background: var(--vp-gray-700); }
-[data-theme="dark"] .vp-btn-danger { background: var(--vp-red-500); color: var(--vp-on-fill); }
-[data-theme="dark"] .vp-btn-danger:hover { background: var(--vp-red-600); }
-[data-theme="dark"] .vp-btn-danger:active { background: var(--vp-red-700); }
+[data-theme="dark"] .vp-btn-danger { background: var(--vp-red-400); color: var(--vp-on-fill); }
 [data-theme="dark"] .vp-btn-danger-outline { background: var(--vp-bg-canvas); color: var(--vp-fg-danger-200); box-shadow: inset 0 0 0 1px var(--vp-border-danger); }
-[data-theme="dark"] .vp-btn-danger-outline:hover { background: var(--vp-bg-danger-100); }
-[data-theme="dark"] .vp-btn-contrast { background: var(--vp-gray-100); color: var(--vp-gray-900); }
-[data-theme="dark"] .vp-btn-contrast:hover { background: oklch(1 0 0); }
+[data-theme="dark"] .vp-btn-contrast { background: var(--vp-gray-800); color: var(--vp-gray-050); }
 [data-theme="dark"] .vp-btn svg { width: 16px; height: 16px; flex-shrink: 0; }
 [data-theme="dark"] .btn-group { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }
 /* === Icon button === */
@@ -1515,10 +1535,10 @@
     letter-spacing: -0.1px;
     white-space: nowrap;
   }
-[data-theme="dark"] .vp-badge-primary { background: color-mix(in oklab, var(--vp-blue-500) 30%, var(--vp-bg-canvas)); color: var(--vp-blue-200); }
-[data-theme="dark"] .vp-badge-success { background: color-mix(in oklab, var(--vp-green-500) 28%, var(--vp-bg-canvas)); color: var(--vp-green-200); }
-[data-theme="dark"] .vp-badge-warning { background: color-mix(in oklab, var(--vp-orange-500) 28%, var(--vp-bg-canvas)); color: var(--vp-orange-200); }
-[data-theme="dark"] .vp-badge-danger { background: color-mix(in oklab, var(--vp-red-500) 28%, var(--vp-bg-canvas)); color: var(--vp-red-200); }
+[data-theme="dark"] .vp-badge-primary { background: color-mix(in oklab, var(--vp-blue-400) 30%, var(--vp-bg-canvas)); color: var(--vp-blue-700); }
+[data-theme="dark"] .vp-badge-success { background: color-mix(in oklab, var(--vp-green-400) 28%, var(--vp-bg-canvas)); color: var(--vp-green-700); }
+[data-theme="dark"] .vp-badge-warning { background: color-mix(in oklab, var(--vp-orange-400) 28%, var(--vp-bg-canvas)); color: var(--vp-orange-700); }
+[data-theme="dark"] .vp-badge-danger { background: color-mix(in oklab, var(--vp-red-400) 28%, var(--vp-bg-canvas)); color: var(--vp-red-700); }
 /* === Card / Form / Input === */
 [data-theme="dark"] .vp-card {
     background: var(--vp-bg-overlay-100);
@@ -1527,23 +1547,23 @@
     padding: 24px;
     min-width: 0;
   }
-[data-theme="dark"] .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+[data-theme="dark"] .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; align-items: start; }
 [data-theme="dark"] .vp-input {
     width: 100%;
     height: 32px;
     padding: 0 12px;
     border: none;
-    box-shadow: inset 0 0 0 1px var(--vp-gray-700);
+    box-shadow: inset 0 0 0 1px var(--vp-gray-200);
     border-radius: 8px;
     font-size: 14px;
     line-height: 22px;
     font-family: inherit;
     color: var(--vp-fg-secondary-200);
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     letter-spacing: -0.1px;
   }
 [data-theme="dark"] .vp-input::placeholder { color: var(--vp-fg-hint-100); }
-[data-theme="dark"] .vp-input:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-050) 32%, transparent); }
+[data-theme="dark"] .vp-input:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-900) 32%, transparent); }
 [data-theme="dark"] .vp-input.focused {
     box-shadow: inset 0 0 0 1px var(--vp-border-primary);
   }
@@ -1556,19 +1576,19 @@
     min-height: 88px;
     padding: 6px 12px;
     border: none;
-    box-shadow: inset 0 0 0 1px var(--vp-gray-700);
+    box-shadow: inset 0 0 0 1px var(--vp-gray-200);
     border-radius: 8px;
     font-size: 14px;
     line-height: 22px;
     font-family: inherit;
     color: var(--vp-fg-secondary-200);
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     letter-spacing: -0.1px;
     resize: vertical;
     display: block;
   }
 [data-theme="dark"] .vp-textarea::placeholder { color: var(--vp-fg-hint-100); }
-[data-theme="dark"] .vp-textarea:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-050) 32%, transparent); }
+[data-theme="dark"] .vp-textarea:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-900) 32%, transparent); }
 [data-theme="dark"] .vp-textarea.focused {
     box-shadow: inset 0 0 0 1px var(--vp-border-primary);
     outline: none;
@@ -1603,7 +1623,7 @@
     border: none;
     box-shadow: inset 0 0 0 1px var(--vp-border-normal);
     border-radius: 8px;
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     color: var(--vp-fg-secondary-200);
     font-size: 14px;
     line-height: 20px;
@@ -1614,22 +1634,21 @@
     cursor: pointer;
     letter-spacing: -0.1px;
   }
-[data-theme="dark"] .vp-select:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-050) 32%, transparent); }
+[data-theme="dark"] .vp-select:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-900) 32%, transparent); }
 [data-theme="dark"] .vp-select.placeholder { color: var(--vp-fg-hint-100); }
 [data-theme="dark"] .vp-select.open {
     box-shadow: inset 0 0 0 1px var(--vp-border-primary);
   }
 [data-theme="dark"] .vp-select.disabled {
-    background: var(--vp-gray-800);
-    color: var(--vp-gray-500);
+    opacity: 0.32;
     cursor: not-allowed;
-    box-shadow: inset 0 0 0 1px var(--vp-border-normal);
   }
 [data-theme="dark"] .vp-select .chev { width: 16px; height: 16px; flex-shrink: 0; color: var(--vp-fg-hint-100); transition: transform 120ms cubic-bezier(.4,0,.2,1); }
 [data-theme="dark"] .vp-select.open .chev { transform: rotate(180deg); }
 [data-theme="dark"] .vp-select .val { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 [data-theme="dark"] .vp-listbox {
     margin-top: 4px;
+    min-width: 200px;
     background: var(--vp-bg-overlay-100);
     border: 1px solid var(--vp-border-normal);
     border-radius: 8px;
@@ -1652,7 +1671,7 @@
   }
 [data-theme="dark"] .vp-option:hover { background: var(--vp-bg-secondary-100); }
 [data-theme="dark"] .vp-option.selected { color: var(--vp-fg-primary-200); }
-[data-theme="dark"] .vp-option.selected .check { color: var(--vp-blue-400); display: inline-flex; }
+[data-theme="dark"] .vp-option.selected .check { color: var(--vp-blue-500); display: inline-flex; }
 [data-theme="dark"] .vp-option .check { display: none; width: 16px; height: 16px; }
 /* === Multi-select === */
 [data-theme="dark"] .vp-multiselect {
@@ -1662,13 +1681,13 @@
     border: none;
     box-shadow: inset 0 0 0 1px var(--vp-border-normal);
     border-radius: 8px;
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 4px;
   }
-[data-theme="dark"] .vp-multiselect:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-050) 32%, transparent); }
+[data-theme="dark"] .vp-multiselect:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-900) 32%, transparent); }
 [data-theme="dark"] .vp-tagchip {
     height: 24px;
     padding: 0 4px 0 8px;
@@ -1732,7 +1751,7 @@
     padding: 0 12px;
     border: none;
     box-shadow: inset 0 0 0 1px var(--vp-border-normal);
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     color: var(--vp-fg-secondary-200);
     font-size: 14px;
     font-family: inherit;
@@ -1754,14 +1773,14 @@
     flex-direction: column;
     gap: 12px;
   }
-[data-theme="dark"] .control-line { display: flex; align-items: center; gap: 10px; font-size: 14px; line-height: 20px; }
+[data-theme="dark"] .control-line { display: flex; align-items: center; gap: 8px; font-size: 14px; line-height: 22px; }
 [data-theme="dark"] .vp-checkbox {
     width: 16px;
     height: 16px;
     border-radius: 4px;
     border: none;
-    box-shadow: inset 0 0 0 1px var(--vp-gray-600);
-    background: var(--vp-gray-900);
+    box-shadow: inset 0 0 0 1px var(--vp-gray-300);
+    background: var(--vp-gray-050);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1778,8 +1797,8 @@
     height: 16px;
     border-radius: 50%;
     border: none;
-    box-shadow: inset 0 0 0 1px var(--vp-gray-600);
-    background: var(--vp-gray-900);
+    box-shadow: inset 0 0 0 1px var(--vp-gray-300);
+    background: var(--vp-gray-050);
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
@@ -1800,27 +1819,27 @@
     width: 40px;
     height: 24px;
     border-radius: 9999px;
-    background: var(--vp-gray-700);
+    background: var(--vp-gray-400);
     position: relative;
     flex-shrink: 0;
     transition: background-color 120ms cubic-bezier(.4, 0, .2, 1);
   }
-[data-theme="dark"] .vp-switch.on { background: var(--vp-blue-500); }
+[data-theme="dark"] .vp-switch.on { background: var(--vp-blue-400); }
 [data-theme="dark"] .vp-switch::after {
     content: "";
     position: absolute;
-    top: 2px;
-    left: 2px;
+    top: 4px;
+    left: 4px;
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    background: var(--vp-gray-100);
-    box-shadow: var(--vp-shadow-sm);
+    background: oklch(1 0 0);
+    box-shadow: var(--vp-shadow-md);
     transition: transform 120ms cubic-bezier(.4, 0, .2, 1);
   }
-[data-theme="dark"] .vp-switch.on::after { transform: translateX(16px); background: oklch(1 0 0); }
+[data-theme="dark"] .vp-switch.on::after { transform: translateX(16px); }
 /* === Radio card === */
-[data-theme="dark"] .radiocard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+[data-theme="dark"] .radiocard-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-items: start; }
 [data-theme="dark"] .vp-radio-card {
     display: flex;
     gap: 12px;
@@ -1833,19 +1852,21 @@
     align-items: flex-start;
     min-width: 0;
   }
-[data-theme="dark"] .vp-radio-card:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-050) 32%, transparent); }
+[data-theme="dark"] .vp-radio-card:hover { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vp-gray-900) 32%, transparent); }
 [data-theme="dark"] .vp-radio-card.checked {
     box-shadow: inset 0 0 0 1px var(--vp-border-primary);
     background: var(--vp-bg-primary-100);
   }
 [data-theme="dark"] .vp-radio-card .rc-body { min-width: 0; }
 [data-theme="dark"] .vp-radio-card .rc-title {
+    display: block;
     font-size: 14px;
     font-weight: 500;
     color: var(--vp-fg-secondary-200);
     margin: 0 0 2px;
   }
 [data-theme="dark"] .vp-radio-card .rc-desc {
+    display: block;
     font-size: 12px;
     line-height: 1.5;
     color: var(--vp-fg-hint-200);
@@ -1854,7 +1875,7 @@
 /* === Tabs === */
 [data-theme="dark"] .vp-tabs {
     display: flex;
-    gap: 4px;
+    gap: 8px;
     border-bottom: 1px solid var(--vp-border-normal);
     flex-wrap: wrap;
   }
@@ -1863,7 +1884,7 @@
     padding: 0 4px;
     font-size: 14px;
     font-weight: 500;
-    color: var(--vp-fg-hint-100);
+    color: var(--vp-fg-normal-100);
     border: 0;
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
@@ -1890,7 +1911,7 @@
 [data-theme="dark"] .vp-breadcrumb a { color: inherit; text-decoration: none; }
 [data-theme="dark"] .vp-breadcrumb a:hover { color: var(--vp-fg-secondary-200); }
 [data-theme="dark"] .vp-breadcrumb .sep { opacity: 0.5; }
-[data-theme="dark"] .vp-breadcrumb .current { color: var(--vp-fg-secondary-200); }
+[data-theme="dark"] .vp-breadcrumb .current { color: var(--vp-fg-primary-100); }
 /* === Menu (dropdown) === */
 [data-theme="dark"] .vp-menu {
     background: var(--vp-bg-overlay-100);
@@ -1949,15 +1970,15 @@
   }
 [data-theme="dark"] .vp-nav-item svg { width: 16px; height: 16px; flex-shrink: 0; }
 /* === Pagination === */
-[data-theme="dark"] .vp-pagination { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+[data-theme="dark"] .vp-pagination { display: flex; flex-wrap: wrap; gap: 2px; align-items: center; }
 [data-theme="dark"] .vp-page {
     min-width: 32px;
     height: 32px;
     padding: 0 6px;
     border-radius: 8px;
     border: 1px solid var(--vp-border-normal);
-    background: var(--vp-gray-900);
-    color: var(--vp-fg-secondary-200);
+    background: var(--vp-gray-050);
+    color: var(--vp-fg-normal-100);
     font-size: 14px;
     font-weight: 500;
     font-family: inherit;
@@ -1989,8 +2010,12 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: var(--vp-bg-secondary-200);
-    color: var(--vp-fg-secondary-200);
+    /* 이니셜은 상류가 foreground-inverse(= white)로 규정한다. 배경은 상류가
+       host 에게 위임(--avatar-fallback-background-color)하므로, 흰 글자가 읽히는
+       contrast-200 을 이 프리뷰의 선택으로 쓴다. */
+    background: var(--vp-bg-contrast-200);
+    color: oklch(1 0 0);
+    border: 1px solid var(--vp-border-normal);
     font-size: 14px;
     font-weight: 500;
     display: inline-flex;
@@ -2012,6 +2037,7 @@
 [data-theme="dark"] .vp-table th, [data-theme="dark"] .vp-table td {
     text-align: left;
     padding: 8px 24px;
+    line-height: 22px;
     border-bottom: 1px solid var(--vp-border-normal);
     letter-spacing: -0.1px;
     color: var(--vp-fg-secondary-200);
@@ -2034,14 +2060,14 @@
     gap: 6px;
     padding: 12px 16px;
     border-radius: 8px;
-    border: none;
+    border: 1px solid transparent;
     align-items: flex-start;
     background: var(--vp-bg-overlay-100);
   }
-[data-theme="dark"] .vp-callout-primary { background: var(--vp-bg-primary-100); border-color: var(--vp-blue-700); }
-[data-theme="dark"] .vp-callout-success { background: var(--vp-bg-success-100); border-color: var(--vp-green-600); }
-[data-theme="dark"] .vp-callout-warning { background: var(--vp-bg-warning-100); border-color: var(--vp-orange-500); }
-[data-theme="dark"] .vp-callout-danger { background: var(--vp-bg-danger-100);  border-color: var(--vp-red-500); }
+[data-theme="dark"] .vp-callout-primary { background: var(--vp-bg-primary-100); border-color: var(--vp-border-primary); color: var(--vp-fg-primary-200); }
+[data-theme="dark"] .vp-callout-success { background: var(--vp-bg-success-100); border-color: var(--vp-border-success); color: var(--vp-fg-success-200); }
+[data-theme="dark"] .vp-callout-warning { background: var(--vp-bg-warning-100); border-color: var(--vp-border-warning); color: var(--vp-fg-warning-200); }
+[data-theme="dark"] .vp-callout-danger { background: var(--vp-bg-danger-100);  border-color: var(--vp-border-danger); color: var(--vp-fg-danger-200); }
 [data-theme="dark"] .vp-callout .ico {
     width: 22px; height: 22px;
     border-radius: 50%;
@@ -2052,10 +2078,10 @@
     color: var(--vp-on-fill);
   }
 [data-theme="dark"] .vp-callout .ico svg { width: 14px; height: 14px; }
-[data-theme="dark"] .vp-callout-primary .ico { background: var(--vp-blue-500); }
-[data-theme="dark"] .vp-callout-success .ico { background: var(--vp-green-500); }
-[data-theme="dark"] .vp-callout-warning .ico { background: var(--vp-orange-500); }
-[data-theme="dark"] .vp-callout-danger .ico { background: var(--vp-red-500); }
+[data-theme="dark"] .vp-callout-primary .ico { background: var(--vp-blue-400); }
+[data-theme="dark"] .vp-callout-success .ico { background: var(--vp-green-400); }
+[data-theme="dark"] .vp-callout-warning .ico { background: var(--vp-orange-400); }
+[data-theme="dark"] .vp-callout-danger .ico { background: var(--vp-red-400); }
 [data-theme="dark"] .vp-callout .ct-body { min-width: 0; }
 [data-theme="dark"] .vp-callout strong {
     font-weight: 500;
@@ -2063,17 +2089,13 @@
     display: block;
     margin-bottom: 2px;
     letter-spacing: -0.1px;
-    color: var(--vp-fg-secondary-200);
+    line-height: 22px;
   }
-[data-theme="dark"] .vp-callout span { font-size: 12px; line-height: 1.5; letter-spacing: -0.1px; color: var(--vp-fg-hint-200); }
+[data-theme="dark"] .vp-callout span { font-size: 12px; line-height: 1.5; letter-spacing: -0.1px; }
 /* === Tooltip === */
 [data-theme="dark"] .vp-tooltip {
     display: inline-block;
-    /* 상류의 background-contrast-200 은 이 프리뷰의 다크 매핑에서 gray-100(밝은
-       회색)으로 뒤집혀 흰 텍스트 대비가 무너진다. 상류 다크 실측값이 그보다
-       훨씬 어두워 가장 가까운 gray-600 을 쓴다 — 토스트도 같다. 실측값은
-       services/vapor-ui.md 의 tooltip 항목이 갖는다. */
-    background: var(--vp-gray-600);
+    background: var(--vp-bg-contrast-200);
     color: oklch(1 0 0);
     font-size: 12px;
     line-height: 18px;
@@ -2082,7 +2104,6 @@
     border-radius: 8px;
     position: relative;
     letter-spacing: -0.1px;
-    border: 1px solid var(--vp-gray-700);
   }
 [data-theme="dark"] .vp-tooltip::after {
     content: "";
@@ -2091,9 +2112,9 @@
     left: 16px;
     width: 8px;
     height: 8px;
-    background: var(--vp-gray-600);
-    border-right: 1px solid var(--vp-gray-700);
-    border-bottom: 1px solid var(--vp-gray-700);
+    background: var(--vp-gray-300);
+    border-right: 1px solid var(--vp-gray-200);
+    border-bottom: 1px solid var(--vp-gray-200);
     transform: rotate(45deg);
   }
 /* === Popover === */
@@ -2185,11 +2206,10 @@
   }
 /* === Toast === */
 [data-theme="dark"] .vp-toast {
-    background: var(--vp-gray-600);
+    background: var(--vp-bg-contrast-200);
     color: oklch(1 0 0);
     border-radius: 8px;
     box-shadow: var(--vp-shadow-md);
-    border: 1px solid var(--vp-gray-700);
     width: 400px;
     max-width: 100%;
     padding: 16px;
@@ -2197,9 +2217,8 @@
     align-items: center;
     gap: 10px;
   }
-[data-theme="dark"] .vp-toast .toast-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-[data-theme="dark"] .vp-toast .toast-dot.success { background: var(--vp-green-400); }
-[data-theme="dark"] .vp-toast .toast-dot.danger { background: var(--vp-red-400); }
+[data-theme="dark"] .vp-toast.success { background: var(--vp-bg-success-200); }
+[data-theme="dark"] .vp-toast.danger { background: var(--vp-bg-danger-200); }
 [data-theme="dark"] .vp-toast .toast-msg { flex: 1; font-size: 14px; line-height: 22px; min-width: 0; }
 [data-theme="dark"] .vp-toast .toast-x {
     width: 20px; height: 20px;
@@ -2229,7 +2248,7 @@
     overflow: hidden;
   }
 [data-theme="dark"] .mock-titlebar {
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     border-bottom: 1px solid var(--vp-border-normal);
     padding: 10px 16px;
     display: flex;
@@ -2242,7 +2261,7 @@
 [data-theme="dark"] .mock-titlebar .dots { display: flex; gap: 6px; flex-shrink: 0; }
 [data-theme="dark"] .mock-titlebar .dots span {
     width: 10px; height: 10px; border-radius: 50%;
-    background: var(--vp-gray-700);
+    background: var(--vp-gray-200);
   }
 [data-theme="dark"] .mock-titlebar .path { margin-left: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 [data-theme="dark"] .mock-tabs {
@@ -2262,7 +2281,7 @@
   }
 [data-theme="dark"] .mock-tab.active {
     color: var(--vp-fg-primary-100);
-    border-bottom-color: var(--vp-blue-400);
+    border-bottom-color: var(--vp-blue-500);
     font-weight: 700;
   }
 [data-theme="dark"] .mock-body { padding: 32px; }
@@ -2304,7 +2323,7 @@
     font-size: 12px;
     font-weight: 700;
     color: var(--vp-fg-hint-100);
-    background: var(--vp-gray-900);
+    background: var(--vp-gray-050);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -2318,6 +2337,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 24px;
+    align-items: start;
   }
 [data-theme="dark"] .stack { display: flex; flex-direction: column; gap: 24px; min-width: 0; }
 /* === Top strip === */
@@ -2339,7 +2359,7 @@
     font-size: 18px;
     font-weight: 800;
     letter-spacing: -0.4px;
-    background: linear-gradient(90deg, var(--vp-blue-300) 0%, var(--vp-violet-300) 100%);
+    background: linear-gradient(90deg, var(--vp-blue-600) 0%, var(--vp-violet-600) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -2462,8 +2482,8 @@
         <p class="row-label">STATE · default / hover / active / disabled</p>
         <div class="btn-group">
           <button class="vp-btn vp-btn-md vp-btn-primary" type="button">저장</button>
-          <button class="vp-btn vp-btn-md vp-btn-primary" type="button" style="background: var(--vp-blue-600);">호버</button>
-          <button class="vp-btn vp-btn-md vp-btn-primary" type="button" style="background: var(--vp-blue-700);">눌림</button>
+          <button class="vp-btn vp-btn-md vp-btn-primary is-hover" type="button">호버</button>
+          <button class="vp-btn vp-btn-md vp-btn-primary is-active" type="button">눌림</button>
           <button class="vp-btn vp-btn-md vp-btn-primary" type="button" disabled="">비활성</button>
         </div>
       </div>
@@ -2911,15 +2931,13 @@
           </div>
 
           <div class="vp-card">
-            <p class="row-label"><span data-theme-text="">TOAST — contrast-200 배경 · 상태 점 + 닫기</span><template data-theme-variant="dark" data-theme-op="swap"><span data-theme-text="">TOAST — gray-600 배경 · 상태 점 + 닫기</span></template></p>
+            <p class="row-label">TOAST — 배경이 intent 로 갈린다 (success · danger) · 닫기</p>
             <div class="stack" style="gap: 12px;">
-              <div class="vp-toast">
-                <span class="toast-dot success"></span>
+              <div class="vp-toast success">
                 <span class="toast-msg">컨테이너가 시작되었다.</span>
                 <span class="toast-x" aria-label="닫기"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></span>
               </div>
-              <div class="vp-toast">
-                <span class="toast-dot danger"></span>
+              <div class="vp-toast danger">
                 <span class="toast-msg">빌드에 실패했다. 로그를 확인한다.</span>
                 <span class="toast-x" aria-label="닫기"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></span>
               </div>
@@ -2929,7 +2947,7 @@
 
         <div class="stack">
           <div class="vp-card">
-            <p class="row-label"><span data-theme-text="">TOOLTIP — solid contrast-200 + 흰 텍스트</span><template data-theme-variant="dark" data-theme-op="swap"><span data-theme-text="">TOOLTIP — solid gray-600 + 흰 텍스트</span></template></p>
+            <p class="row-label">TOOLTIP — solid contrast-200 + 흰 텍스트</p>
             <div style="display: flex; flex-wrap: wrap; gap: 32px; align-items: flex-end; padding: 16px 0;">
               <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 8px;">
                 <span class="vp-tooltip">삭제하면 복구할 수 없습니다</span>
@@ -3020,7 +3038,7 @@
       <div class="section-head">
         <span class="num">07.</span>
         <h2>Key screen — goorm 콘솔 / 컨테이너 목록</h2>
-        <span class="caption"><span data-theme-text="">Pretendard 본문 14px · 헤어라인 1px gray-100 · 목업 표 th 12px는 이 프리뷰의 재현</span><template data-theme-variant="dark" data-theme-op="swap"><span data-theme-text="">다크에서 카드는 gray-800 overlay-100 위에 1px gray-300 헤어라인</span></template></span>
+        <span class="caption"><span data-theme-text="">Pretendard 본문 14px · 헤어라인 1px gray-100 · 목업 표 th 12px는 이 프리뷰의 재현</span><template data-theme-variant="dark" data-theme-op="swap"><span data-theme-text="">다크에서 카드는 overlay-100(dark-gray-100) 위에 1px gray-300 헤어라인</span></template></span>
       </div>
 
       <p class="catalog-dummy">콘솔 화면은 레이아웃 시연용 더미 데이터입니다. 컨테이너 이름·상태·메모리와 총 사용량은 발명값이며, 실제 goorm 콘솔의 화면이나 요금제 한도가 아닙니다.</p>

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -288,8 +288,8 @@ colors:
   dark-yellow-900: oklch(0.984 0.016 83)   # #FFF9EE
   # Orange
   dark-orange-050: oklch(0.296 0.121 29)   # #5B0000
-  dark-orange-100: oklch(0.353 0.145 29)   # #750000
-  dark-orange-200: oklch(0.421 0.173 29)   # #950000
+  dark-orange-100: oklch(0.353 0.145 29)   # #750000 · 상류가 dark-red-100 과 같은 값을 발행한다
+  dark-orange-200: oklch(0.421 0.173 29)   # #950000 · 상류가 dark-red-200 과 같은 값을 발행한다
   dark-orange-300: oklch(0.512 0.188 33)   # #BA2500
   dark-orange-400: oklch(0.554 0.188 36)   # #C83800
   dark-orange-500: oklch(0.649 0.185 44)   # #E65F08
@@ -299,8 +299,8 @@ colors:
   dark-orange-900: oklch(0.986 0.008 56)   # #FFF9F5
   # Red
   dark-red-050: oklch(0.291 0.120 29)   # #590000
-  dark-red-100: oklch(0.353 0.145 29)   # #750000
-  dark-red-200: oklch(0.421 0.173 29)   # #950000
+  dark-red-100: oklch(0.353 0.145 29)   # #750000 · 상류가 dark-orange-100 과 같은 값을 발행한다
+  dark-red-200: oklch(0.421 0.173 29)   # #950000 · 상류가 dark-orange-200 과 같은 값을 발행한다
   dark-red-300: oklch(0.513 0.197 24)   # #BE1628
   dark-red-400: oklch(0.557 0.197 23)   # #CE2B38
   dark-red-500: oklch(0.654 0.198 21)   # #F14F5A

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -3,7 +3,7 @@ name: 구름
 design_system_name: Vapor UI
 slug: vapor-ui
 category: developer
-last_updated: "2026-08-24"
+last_updated: "2026-09-08"
 created_at: "2026-05-10"
 sources:
   - https://vapor-ui.goorm.io/
@@ -15,81 +15,85 @@ lang: ko
 logo: https://getdesign.kr/logos/goorm.png
 colors:
   color-background-canvas: "{colors.color-white}"
-  color-background-canvas-dark: "{colors.gray-900}"
+  color-background-canvas-dark: "{colors.dark-canvas}"
   color-background-canvas-200: "{colors.gray-050}"
-  color-background-canvas-200-dark: "{colors.gray-800}"
+  color-background-canvas-200-dark: "{colors.dark-gray-050}"
   color-background-overlay-100: "{colors.color-white}"
-  color-background-overlay-100-dark: "{colors.gray-800}"
-  color-background-primary-100: "{colors.blue-050}"
+  color-background-overlay-100-dark: "{colors.dark-gray-100}"
+  color-background-primary-100: "{colors.blue-100}"
+  color-background-primary-100-dark: "{colors.dark-blue-050}"
   color-background-primary-200: "{colors.blue-500}"
-  color-background-primary-200-dark: "{colors.blue-500}"
-  color-background-secondary-100: "{colors.gray-100}"
-  color-background-secondary-100-dark: "{colors.gray-800}"
-  color-background-secondary-200: "{colors.gray-200}"
-  color-background-secondary-200-dark: "{colors.gray-700}"
+  color-background-primary-200-dark: "{colors.dark-blue-500}"
+  color-background-secondary-100: "{colors.gray-050}"
+  color-background-secondary-100-dark: "{colors.dark-gray-050}"
+  color-background-secondary-200: "{colors.gray-100}"
+  color-background-secondary-200-dark: "{colors.dark-gray-200}"
   color-background-success-100: "{colors.green-100}"
+  color-background-success-100-dark: "{colors.dark-green-050}"
   color-background-success-200: "{colors.green-500}"
-  color-background-success-200-dark: "{colors.green-500}"
+  color-background-success-200-dark: "{colors.dark-green-500}"
   color-background-warning-100: "{colors.orange-100}"
+  color-background-warning-100-dark: "{colors.dark-orange-050}"
   color-background-warning-200: "{colors.orange-500}"
-  color-background-warning-200-dark: "{colors.orange-500}"
+  color-background-warning-200-dark: "{colors.dark-orange-500}"
   color-background-danger-100: "{colors.red-100}"
+  color-background-danger-100-dark: "{colors.dark-red-050}"
   color-background-danger-200: "{colors.red-500}"
-  color-background-danger-200-dark: "{colors.red-500}"
+  color-background-danger-200-dark: "{colors.dark-red-500}"
   color-background-hint-100: "{colors.gray-100}"
-  color-background-hint-100-dark: "{colors.gray-800}"
+  color-background-hint-100-dark: "{colors.dark-gray-200}"
   color-background-hint-200: "{colors.gray-600}"
-  color-background-hint-200-dark: "{colors.gray-600}"
+  color-background-hint-200-dark: "{colors.dark-gray-600}"
   color-background-contrast-100: "{colors.gray-300}"
-  color-background-contrast-100-dark: "{colors.gray-700}"
+  color-background-contrast-100-dark: "{colors.dark-gray-800}"
   color-background-contrast-200: "{colors.gray-800}"
-  color-background-contrast-200-dark: "{colors.gray-100}"
-  color-foreground-primary-100: "{colors.blue-500}"
-  color-foreground-primary-100-dark: "{colors.blue-300}"
+  color-background-contrast-200-dark: "{colors.dark-gray-300}"
+  color-foreground-primary-100: "{colors.blue-600}"
+  color-foreground-primary-100-dark: "{colors.dark-blue-600}"
   color-foreground-primary-200: "{colors.blue-700}"
-  color-foreground-primary-200-dark: "{colors.blue-400}"
+  color-foreground-primary-200-dark: "{colors.dark-blue-700}"
   color-foreground-secondary-100: "{colors.gray-800}"
-  color-foreground-secondary-100-dark: "{colors.gray-200}"
+  color-foreground-secondary-100-dark: "{colors.dark-gray-700}"
   color-foreground-secondary-200: "{colors.gray-900}"
-  color-foreground-secondary-200-dark: "{colors.gray-100}"
+  color-foreground-secondary-200-dark: "{colors.dark-gray-900}"
   color-foreground-success-100: "{colors.green-600}"
-  color-foreground-success-100-dark: "{colors.green-300}"
+  color-foreground-success-100-dark: "{colors.dark-green-600}"
   color-foreground-success-200: "{colors.green-700}"
-  color-foreground-success-200-dark: "{colors.green-200}"
+  color-foreground-success-200-dark: "{colors.dark-green-700}"
   color-foreground-warning-100: "{colors.orange-600}"
-  color-foreground-warning-100-dark: "{colors.orange-300}"
+  color-foreground-warning-100-dark: "{colors.dark-orange-600}"
   color-foreground-warning-200: "{colors.orange-700}"
-  color-foreground-warning-200-dark: "{colors.orange-200}"
+  color-foreground-warning-200-dark: "{colors.dark-orange-700}"
   color-foreground-danger-100: "{colors.red-600}"
-  color-foreground-danger-100-dark: "{colors.red-300}"
+  color-foreground-danger-100-dark: "{colors.dark-red-600}"
   color-foreground-danger-200: "{colors.red-700}"
-  color-foreground-danger-200-dark: "{colors.red-200}"
+  color-foreground-danger-200-dark: "{colors.dark-red-700}"
   color-foreground-hint-100: "{colors.gray-600}"
-  color-foreground-hint-100-dark: "{colors.gray-400}"
+  color-foreground-hint-100-dark: "{colors.dark-gray-600}"
   color-foreground-hint-200: "{colors.gray-700}"
-  color-foreground-hint-200-dark: "{colors.gray-300}"
+  color-foreground-hint-200-dark: "{colors.dark-gray-700}"
   color-foreground-contrast-100: "{colors.gray-800}"
-  color-foreground-contrast-100-dark: "{colors.gray-200}"
+  color-foreground-contrast-100-dark: "{colors.dark-gray-200}"
   color-foreground-contrast-200: "{colors.gray-900}"
-  color-foreground-contrast-200-dark: "{colors.gray-050}"
+  color-foreground-contrast-200-dark: "{colors.dark-gray-300}"
   color-foreground-normal-100: "{colors.gray-700}"
-  color-foreground-normal-100-dark: "{colors.gray-300}"
+  color-foreground-normal-100-dark: "{colors.dark-gray-700}"
   color-foreground-normal-200: "{colors.gray-900}"
-  color-foreground-normal-200-dark: "{colors.gray-100}"
+  color-foreground-normal-200-dark: "{colors.dark-gray-900}"
   color-border-primary: "{colors.blue-500}"
-  color-border-primary-dark: "{colors.blue-400}"
+  color-border-primary-dark: "{colors.dark-blue-400}"
   color-border-secondary: "{colors.gray-200}"
-  color-border-secondary-dark: "{colors.gray-700}"
+  color-border-secondary-dark: "{colors.dark-gray-200}"
   color-border-success: "{colors.green-500}"
-  color-border-success-dark: "{colors.green-400}"
+  color-border-success-dark: "{colors.dark-green-400}"
   color-border-warning: "{colors.orange-500}"
-  color-border-warning-dark: "{colors.orange-400}"
+  color-border-warning-dark: "{colors.dark-orange-400}"
   color-border-danger: "{colors.red-500}"
-  color-border-danger-dark: "{colors.red-400}"
+  color-border-danger-dark: "{colors.dark-red-400}"
   color-border-hint: "{colors.gray-600}"
-  color-border-hint-dark: "{colors.gray-500}"
+  color-border-hint-dark: "{colors.dark-gray-400}"
   color-border-contrast: "{colors.gray-800}"
-  color-border-contrast-dark: "{colors.gray-200}"
+  color-border-contrast-dark: "{colors.dark-gray-400}"
   ## Base palette
   # Gray — 표면·텍스트·디바이더의 기반
   gray-050: oklch(0.976 0.000 0)   # #F7F7F7
@@ -214,6 +218,131 @@ colors:
   violet-900: oklch(0.293 0.170 286)   # #2E007A
   color-white: oklch(1.000 0.000 0)   # #FFFFFF
   color-black: oklch(0.000 0.000 0)   # #000000
+  ## Dark palette
+  # 상류는 다크에서 램프 자체를 재정의한다 — 번호가 커질수록 밝아진다
+  # Gray
+  dark-gray-050: oklch(0.277 0.000 0)   # #282828
+  dark-gray-100: oklch(0.333 0.000 0)   # #363636
+  dark-gray-200: oklch(0.398 0.000 0)   # #474747
+  dark-gray-300: oklch(0.489 0.000 0)   # #606060
+  dark-gray-400: oklch(0.531 0.000 0)   # #6C6C6C
+  dark-gray-500: oklch(0.630 0.000 0)   # #898989
+  dark-gray-600: oklch(0.728 0.000 0)   # #A7A7A7
+  dark-gray-700: oklch(0.802 0.000 0)   # #BEBEBE
+  dark-gray-800: oklch(0.894 0.000 0)   # #DCDCDC
+  dark-gray-900: oklch(0.985 0.000 0)   # #FAFAFA
+  # Blue
+  dark-blue-050: oklch(0.296 0.183 264)   # #001286
+  dark-blue-100: oklch(0.350 0.184 263)   # #002898
+  dark-blue-200: oklch(0.410 0.187 262)   # #003DAD
+  dark-blue-300: oklch(0.497 0.189 260)   # #0E5ACB
+  dark-blue-400: oklch(0.573 0.189 260)   # #2A72E5
+  dark-blue-500: oklch(0.633 0.169 255)   # #368AED
+  dark-blue-600: oklch(0.724 0.140 248)   # #56ACF9
+  dark-blue-700: oklch(0.800 0.110 243)   # #7BC6FF
+  dark-blue-800: oklch(0.893 0.057 243)   # #BCE1FF
+  dark-blue-900: oklch(0.983 0.009 248)   # #F5FAFF
+  # Cyan
+  dark-cyan-050: oklch(0.275 0.063 240)   # #002B43
+  dark-cyan-100: oklch(0.331 0.068 233)   # #003B53
+  dark-cyan-200: oklch(0.395 0.076 227)   # #004E66
+  dark-cyan-300: oklch(0.483 0.090 223)   # #006983
+  dark-cyan-400: oklch(0.526 0.095 219)   # #007790
+  dark-cyan-500: oklch(0.621 0.108 216)   # #0E96B0
+  dark-cyan-600: oklch(0.715 0.120 213)   # #1DB6CF
+  dark-cyan-700: oklch(0.794 0.092 211)   # #6FCCDD
+  dark-cyan-800: oklch(0.891 0.048 213)   # #B8E4EE
+  dark-cyan-900: oklch(0.983 0.008 207)   # #F4FBFC
+  # Green
+  dark-green-050: oklch(0.271 0.069 154)   # #003016
+  dark-green-100: oklch(0.324 0.077 157)   # #003F23
+  dark-green-200: oklch(0.390 0.088 160)   # #005334
+  dark-green-300: oklch(0.477 0.101 164)   # #006E4D
+  dark-green-400: oklch(0.517 0.107 166)   # #007B5A
+  dark-green-500: oklch(0.614 0.114 168)   # #259A77
+  dark-green-600: oklch(0.710 0.118 168)   # #46B993
+  dark-green-700: oklch(0.788 0.123 168)   # #5DD3AA
+  dark-green-800: oklch(0.886 0.065 168)   # #B0E8D1
+  dark-green-900: oklch(0.981 0.009 172)   # #F3FBF8
+  # Lime
+  dark-lime-050: oklch(0.271 0.092 142)   # #003100
+  dark-lime-100: oklch(0.322 0.110 142)   # #004000
+  dark-lime-200: oklch(0.388 0.129 142)   # #095400
+  dark-lime-300: oklch(0.475 0.147 138)   # #296E00
+  dark-lime-400: oklch(0.518 0.156 137)   # #377B00
+  dark-lime-500: oklch(0.616 0.174 134)   # #559A0B
+  dark-lime-600: oklch(0.713 0.189 132)   # #74B91C
+  dark-lime-700: oklch(0.786 0.200 130)   # #8DD126
+  dark-lime-800: oklch(0.885 0.110 130)   # #C2E89A
+  dark-lime-900: oklch(0.982 0.019 130)   # #F5FCEF
+  # Yellow / Amber
+  dark-yellow-050: oklch(0.289 0.093 39)   # #4F1400
+  dark-yellow-100: oklch(0.342 0.096 46)   # #5F2400
+  dark-yellow-200: oklch(0.410 0.104 53)   # #743700
+  dark-yellow-300: oklch(0.497 0.114 62)   # #8F5100
+  dark-yellow-400: oklch(0.539 0.121 65)   # #9D5D00
+  dark-yellow-500: oklch(0.638 0.137 72)   # #BE7B00
+  dark-yellow-600: oklch(0.733 0.153 78)   # #DD9A00
+  dark-yellow-700: oklch(0.808 0.166 83)   # #F4B402
+  dark-yellow-800: oklch(0.895 0.113 85)   # #FFD782
+  dark-yellow-900: oklch(0.984 0.016 83)   # #FFF9EE
+  # Orange
+  dark-orange-050: oklch(0.296 0.121 29)   # #5B0000
+  dark-orange-100: oklch(0.353 0.145 29)   # #750000
+  dark-orange-200: oklch(0.421 0.173 29)   # #950000
+  dark-orange-300: oklch(0.512 0.188 33)   # #BA2500
+  dark-orange-400: oklch(0.554 0.188 36)   # #C83800
+  dark-orange-500: oklch(0.649 0.185 44)   # #E65F08
+  dark-orange-600: oklch(0.740 0.147 46)   # #F58A56
+  dark-orange-700: oklch(0.812 0.105 45)   # #FBAC88
+  dark-orange-800: oklch(0.902 0.056 46)   # #FFD4C0
+  dark-orange-900: oklch(0.986 0.008 56)   # #FFF9F5
+  # Red
+  dark-red-050: oklch(0.291 0.120 29)   # #590000
+  dark-red-100: oklch(0.353 0.145 29)   # #750000
+  dark-red-200: oklch(0.421 0.173 29)   # #950000
+  dark-red-300: oklch(0.513 0.197 24)   # #BE1628
+  dark-red-400: oklch(0.557 0.197 23)   # #CE2B38
+  dark-red-500: oklch(0.654 0.198 21)   # #F14F5A
+  dark-red-600: oklch(0.745 0.150 21)   # #FD8283
+  dark-red-700: oklch(0.815 0.105 20)   # #FFA7A6
+  dark-red-800: oklch(0.902 0.051 21)   # #FFD2D0
+  dark-red-900: oklch(0.985 0.007 17)   # #FFF8F8
+  # Pink
+  dark-pink-050: oklch(0.295 0.118 15)   # #590018
+  dark-pink-100: oklch(0.350 0.140 11)   # #710028
+  dark-pink-200: oklch(0.422 0.169 6)   # #910040
+  dark-pink-300: oklch(0.514 0.195 2)   # #B8185F
+  dark-pink-400: oklch(0.558 0.191 2)   # #C62F6B
+  dark-pink-500: oklch(0.655 0.184 2)   # #E65588
+  dark-pink-600: oklch(0.746 0.150 2)   # #F881A6
+  dark-pink-700: oklch(0.817 0.109 2)   # #FEA5BE
+  dark-pink-800: oklch(0.902 0.055 360)   # #FFD0DD
+  dark-pink-900: oklch(0.985 0.008 358)   # #FFF8FA
+  # Grape
+  dark-grape-050: oklch(0.298 0.148 313)   # #460060
+  dark-grape-100: oklch(0.359 0.176 316)   # #5E0079
+  dark-grape-200: oklch(0.428 0.208 317)   # #7A0097
+  dark-grape-300: oklch(0.520 0.228 319)   # #9D21B9
+  dark-grape-400: oklch(0.562 0.226 319)   # #AA34C6
+  dark-grape-500: oklch(0.658 0.220 319)   # #C859E5
+  dark-grape-600: oklch(0.747 0.168 319)   # #DA87EF
+  dark-grape-700: oklch(0.816 0.122 319)   # #E5A9F5
+  dark-grape-800: oklch(0.903 0.065 319)   # #F2D2FB
+  dark-grape-900: oklch(0.985 0.009 321)   # #FDF8FE
+  # Violet
+  dark-violet-050: oklch(0.301 0.174 286)   # #30007E
+  dark-violet-100: oklch(0.362 0.205 290)   # #45009E
+  dark-violet-200: oklch(0.425 0.208 290)   # #5522B4
+  dark-violet-300: oklch(0.511 0.208 290)   # #6B42D2
+  dark-violet-400: oklch(0.553 0.208 290)   # #7750E0
+  dark-violet-500: oklch(0.649 0.188 293)   # #9672F5
+  dark-violet-600: oklch(0.741 0.147 300)   # #B994FA
+  dark-violet-700: oklch(0.813 0.115 305)   # #D3AFFE
+  dark-violet-800: oklch(0.902 0.060 306)   # #E8D5FF
+  dark-violet-900: oklch(0.983 0.010 305)   # #FBF8FF
+  # Canvas — 다크 전용 표면색 (라이트에서는 color-white 와 같은 값이다)
+  dark-canvas: oklch(0.256 0.000 0)   # #232323
 typography:
   # size → fontSize / lineHeight
   size-025:
@@ -320,23 +449,23 @@ Voice는 "factual, didactic, slightly warm"으로 정의된다 [src:5]. 한국�
 
 ## Colors
 
-> **팔레트 정정(2026-07-29).** 이 절의 값은 원래 핸드오프 번들에서 추출한 것이었고, 공개 발행값과 어긋나 있었다 — 110개 중 ΔE ≤ 0.02로 맞는 건 15개뿐이었고 **46개가 ΔE > 0.05**였다. 어긋남은 계열에 몰려 있었다(violet 8/10, grape 8/10, gray 7/10, pink 7/10인 반면 **cyan은 10/10 일치**). 최대 편차였던 `violet-400`은 번들값이 `oklch(0.494 0.275 295)`, 발행값이 `#A480F7`로 hue만 같고 명도·채도가 크게 달랐다.
+> **팔레트 정정(2026-09-08).** 배포본 `@vapor-ui/core` 1.3.0 의 `dist/styles/themes.css.ts.vanilla.css` 와 재대조해 **다크 절반을 새로 발행하고 시맨틱 alias 44건을 고쳤다** [src:4]. 종전 판본은 라이트 램프만 싣고 다크를 `-dark` alias 가 라이트 램프의 다른 단계를 가리키는 방식으로 근사했는데, 상류는 **다크에서 램프 자체를 재정의한다** — 11 패밀리 × 10단 전부이고 번호가 커질수록 밝아진다(다크 `gray-600` 은 `#A7A7A7` (≈ oklch(0.728 0.000 0)), `gray-900` 은 `#FAFAFA` (≈ oklch(0.985 0.000 0))). 근사는 일관되게 한 단씩 어두웠고, contrast 계열은 방향까지 뒤집혀 있었다 — `foreground-contrast-200-dark` 가 `#F7F7F7` (≈ oklch(0.976 0.000 0), 밝음)인데 발행값은 `#606060` (≈ oklch(0.489 0.000 0), 중간 회색)이다.
 >
-> **frontmatter `colors:` 맵은 이제 goorm 발행값이다.** `@vapor-ui/core` 1.3.0의 `dist/styles/themes.css.ts.vanilla.css`(라이트 테마)를 기준으로 110개를 전량 교체하고, 각 줄에 출처 hex를 병기했다 [src:4]. docs 사이트가 서빙하는 팔레트 CSS 청크도 같은 값이라 두 공식 채널이 서로를 확인해 준다 [src:1]. 버전 요인도 없다 — 1.3.0과 1.4.0의 팔레트 CSS는 바이트 단위로 동일하다.
+> **이제 `dark-` 접두 램프 111개를 함께 발행한다.** 다크 alias 40개가 전부 그 램프를 가리킨다 — 36개는 라이트 램프의 다른 단계를 가리키던 것을 고쳤고, 비어 있던 `color-background-{primary,success,warning,danger}-100-dark` 4개는 새로 채웠다. 라이트도 4건이 어긋나 함께 고쳤다 — `foreground-primary-100` 은 `blue-500` 이 아니라 `blue-600` 이고, `background-primary-100` 은 `blue-100`, `background-secondary-100`·`-200` 은 각각 `gray-050`·`gray-100` 이다.
 >
-> 값을 그대로 두는 대신 교체한 이유는 이 문서만 읽히는 게 아니기 때문이다. 사이드카 `vapor-ui.tokens.json`은 사이트 Tokens 탭과 `use-design-md` 스킬이 그대로 소비하는데, 그 경로에는 이런 단서를 실을 자리가 없다 — 산문에 주석을 달아 두어도 Tailwind 테마를 생성하는 쪽에는 어긋난 값만 전달된다. 전량을 공식값으로 맞추면 "제3의 팔레트"가 아니라 공식 팔레트가 된다.
+> 라이트 램프 110개 자체는 2026-07-29 에 같은 배포본으로 전량 교체한 값 그대로다(그 전에는 핸드오프 번들 추출값이라 46개가 ΔE > 0.05 로 어긋나 있었다). docs 사이트가 서빙하는 팔레트 CSS 청크도 같은 값이라 두 공식 채널이 서로를 확인해 준다 [src:1].
 >
-> 버전 드리프트도 아니다. 본문은 1.3.0 기준으로 쓰였지만 팔레트를 담은 `dist/styles/themes.css.ts.vanilla.css`는 1.3.0과 1.4.0에서 **바이트 단위로 동일**하다 [src:4] — 어느 쪽을 받아 대조해도 같은 결론이 나온다.
->
-> 병기한 hex는 부수 효과가 아니다. 이 토큰들은 원래 hex 주석이 없어 `audit:oklch`가 **하나도 판정하지 못했다**. 이제 110개가 게이트 대상이라 다음 드리프트는 CI가 잡는다.
+> 값을 그대로 두는 대신 교체하는 이유는 이 문서만 읽히는 게 아니기 때문이다. 사이드카 `vapor-ui.tokens.json` 은 사이트 Tokens 탭과 `use-design-md` 스킬이 그대로 소비하는데, 그 경로에는 이런 단서를 실을 자리가 없다. 이번 정정으로 사이드카는 223색(라이트 112 + 다크 111)이 된다.
 
 Vapor는 두 테마(`light`, `dark`) 위에 11-family 베이스 팔레트를 둔다 — Red, Pink, Grape, Violet, Blue, Cyan, Green, Lime, Yellow, Orange, Gray. 각 패밀리는 `050, 100, 200, 300, 400, 500, 600, 700, 800, 900` 10단계 + `color-white`/`color-black` 상수로 구성된다 [src:5]. 브랜드 primary는 **Blue 500**이며, 카노니컬한 violet은 Vapor 워드마크에만 등장한다 [src:5].
 
 product-facing 색은 모두 **시맨틱 alias**로 호출하고 raw 팔레트는 새 role을 만들 때만 직접 노출된다 — 명명 규칙은 `color-{role}-{intent}-{level}`이며 roles는 `background`/`foreground`/`border`, intents는 `primary, secondary, success, warning, danger, hint, contrast, normal`, level은 `100`(soft) / `200`(strong)이다 [src:5].
 
-### Base palette (11 family × 10 step)
+### Base palette (테마별 11 family × 10 step)
 
 위 OKLCH는 `@vapor-ui/core`가 배포하는 hex를 변환한 결과이고, 각 출처 hex는 같은 줄 트레일링 주석에 남겼다 [src:4]. (2026-07-29 이전 리비전은 핸드오프 번들 `colors_and_type.css`의 hex를 옮긴 것이었다 — 위 정정 참조.)
+
+**램프는 테마마다 한 벌씩이다.** 상류는 다크에서 시맨틱 alias 이름을 유지한 채 램프 자체를 다시 정의하므로, frontmatter 도 `dark-` 접두로 두 번째 벌을 발행한다 — `## Base palette` 그룹이 라이트 110개 + `color-white`·`color-black`, `## Dark palette` 그룹이 다크 110개 + `dark-canvas` 다 [src:4]. 다크 램프는 번호가 커질수록 밝아져 라이트의 역순에 가깝다 — 다크 `gray-900` 은 표면이 아니라 본문 글자색 자리이고, 표면은 `dark-gray-050` 쪽이다. `-dark` 접미 alias 는 전부 이 두 번째 벌을 가리킨다. `dark-canvas` 는 상류가 램프와 별개로 두는 `color-canvas` 의 다크 값이다(라이트에서는 `color-white` 와 같은 값이라 따로 발행하지 않는다).
 
 ### Semantic alias (light → dark)
 
@@ -696,8 +825,7 @@ Vapor 시스템은 imagery treatment를 강제하지 않는다. goorm 마케팅 
 ## Known Gaps
 
 - **Responsive breakpoint 토큰** 자체는 1.3.0 배포본에서 surface되지 않았다 [src:4]. host 앱 측에서 정의하도록 위임된 것으로 추정 — 위 Responsive Behavior 섹션의 분기점은 합리적 권장값이며 Vapor 공식 토큰은 아니다.
-- **다크 alias 4개가 아직 비어 있다.** frontmatter `colors:` 의 시맨틱 alias 40개 중 36개가 `-dark` 짝을 갖고, 없는 넷이 `color-background-{primary,success,warning,danger}-100` 이다. (`color-white`·`color-black` 은 이름이 `color-` 로 시작하지만 `## Base palette` 그룹의 프리미티브라 이 집계 밖이다 — 맵 전체를 `color-` 로 훑으면 42가 나와 어긋난다.) 상류는 `dist/styles/themes.css.ts.vanilla.css` 의 `[data-vapor-theme='dark']` 블록에 값을 발행하므로 [src:4] 미공개라서 빈 것이 아니라 아직 옮기지 않은 것이다.
-- **frontmatter `colors:` 의 시맨틱 alias 이름 3건이 상류와 어긋난다** — 배포본은 `color-border-normal`(라이트 `gray-100` / 다크 `gray-300`)과 `color-foreground-inverse` 를 발행하는데 그 맵에는 없고, canvas 는 배포본이 `color-background-canvas-100` 인데 그 맵은 `color-background-canvas` 로 적는다 [src:4]. 값 자체는 2026-07-29 에 공개 발행값으로 대조됐으므로 이 공백은 이름에 한한다. 이 문서의 다른 절은 해당 자리에서 발행돼 있는 팔레트 토큰(`{colors.gray-100}` 등)을 대신 참조한다.
+- **frontmatter `colors:` 의 시맨틱 alias 이름 3건이 상류와 어긋난다** — 배포본은 `color-border-normal`(라이트 `gray-100` / 다크 `gray-300`)과 `color-foreground-inverse` 를 발행하는데 그 맵에는 없고, canvas 는 배포본이 `color-background-canvas-100` 인데 그 맵은 `color-background-canvas` 로 적는다 [src:4]. 값은 2026-09-08 재대조에서 라이트·다크 양쪽 모두 발행값으로 맞췄으므로 이 공백은 이름에 한한다. 이 문서의 다른 절은 해당 자리에서 발행돼 있는 팔레트 토큰(`{colors.gray-100}` 등)을 대신 참조한다.
 - **Form validation states** — `{component.text-input}` · `{component.checkbox}` · `{component.radio}` · `{component.select}` 가 `invalid` 축을 갖고 그 시각 처리는 확인됐으나, helper text · success state 의 토큰화된 정의는 배포본에 없다 [src:4].
 - **철회된 부재 주장 2건 (2026-08-17)** — 종전 판본은 `## Spacing` 이 "컴포넌트 사이징과 border width는 별도 토큰 그룹으로 분리된다"며 `size-component-*` 4개와 `size-borderWidth-*` 2개를 실었고, `## Rounded` 가 `size-borderRadius-circle` 을 12번째 토큰으로 실었다. **셋 다 존재하지 않는다** — 배포본과 문서 사이트 어디에도 그 이름이 없다 [src:4][src:1]. 컨트롤 높이의 실제 출처는 `size-dimension-*` 이고, 1px·2px 과 `9999px` 는 리터럴로 적힌다.
 - **철회된 부재 주장 1건 (2026-08-16)** — 종전 판본은 "카드 padding 기본값은 시스템이 별도 강제하지 않고 콘텐츠 주도로 결정된다"를 적고, 여기에 "host 팀이 자체 padding ladder를 별도 정의해야 한다"는 권고를 달았다. **지금은 거짓이다** — `@vapor-ui/core` 1.3.0의 `card.css`가 `padding: 16px 24px`(헤더·푸터)와 `padding: 24px`(본문)를 강제한다 [src:4]. 부재 주장이 낳은 권고는 그 주장이 철회되면 함께 무너진다.

--- a/services/vapor-ui.md
+++ b/services/vapor-ui.md
@@ -824,6 +824,8 @@ Vapor 시스템은 imagery treatment를 강제하지 않는다. goorm 마케팅 
 
 ## Known Gaps
 
+- **다크 fill 버튼의 흰 텍스트가 AA 에 못 미친다 (2026-09-08)** — 상류 다크 `background-primary-200`(`#368AED`)·`background-danger-200`(`#F14F5A`) 위에 `### button-primary`·`### button-danger` 가 규정한 흰 텍스트를 얹으면 대비가 3.5:1 로 WCAG AA(4.5:1)에 못 미친다 [src:4]. 라이트(각각 `#2A72E5`·`#DA3944`)는 4.5 를 넘으므로 다크 램프에서만 생기는 문제다. 발행값을 그대로 옮긴 결과이고 값을 바꾸면 브랜드 색을 왜곡하므로 고치지 않는다 — 프리뷰도 같은 조합을 시연한다.
+- **다크에서 `contrast` 의 전경·배경이 같은 값이다 (2026-09-08)** — 상류 다크 블록이 `color-background-contrast-200` 과 `color-foreground-contrast-200` 을 모두 `gray-300`(다크 `#606060`)으로 매핑한다 [src:4]. 라이트에서는 `gray-800`/`gray-900` 으로 갈리므로 다크만의 특성이고, 발행값을 그대로 옮긴 것이다. 둘을 겹쳐 쓰면 대비가 1:1 이 되니 다크에서 contrast 표면 위 텍스트는 `{colors.white}` 를 쓴다 — `### button-contrast` 가 그렇게 규정하고 이 문서의 프리뷰도 그 조합을 시연한다.
 - **Responsive breakpoint 토큰** 자체는 1.3.0 배포본에서 surface되지 않았다 [src:4]. host 앱 측에서 정의하도록 위임된 것으로 추정 — 위 Responsive Behavior 섹션의 분기점은 합리적 권장값이며 Vapor 공식 토큰은 아니다.
 - **frontmatter `colors:` 의 시맨틱 alias 이름 3건이 상류와 어긋난다** — 배포본은 `color-border-normal`(라이트 `gray-100` / 다크 `gray-300`)과 `color-foreground-inverse` 를 발행하는데 그 맵에는 없고, canvas 는 배포본이 `color-background-canvas-100` 인데 그 맵은 `color-background-canvas` 로 적는다 [src:4]. 값은 2026-09-08 재대조에서 라이트·다크 양쪽 모두 발행값으로 맞췄으므로 이 공백은 이름에 한한다. 이 문서의 다른 절은 해당 자리에서 발행돼 있는 팔레트 토큰(`{colors.gray-100}` 등)을 대신 참조한다.
 - **Form validation states** — `{component.text-input}` · `{component.checkbox}` · `{component.radio}` · `{component.select}` 가 `invalid` 축을 갖고 그 시각 처리는 확인됐으나, helper text · success state 의 토큰화된 정의는 배포본에 없다 [src:4].

--- a/services/vapor-ui.tokens.json
+++ b/services/vapor-ui.tokens.json
@@ -671,6 +671,672 @@
       "value": "oklch(0.000 0.000 0)",
       "note": "#000000",
       "group": "Base palette"
+    },
+    {
+      "name": "dark-gray-050",
+      "value": "oklch(0.277 0.000 0)",
+      "note": "#282828",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-100",
+      "value": "oklch(0.333 0.000 0)",
+      "note": "#363636",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-200",
+      "value": "oklch(0.398 0.000 0)",
+      "note": "#474747",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-300",
+      "value": "oklch(0.489 0.000 0)",
+      "note": "#606060",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-400",
+      "value": "oklch(0.531 0.000 0)",
+      "note": "#6C6C6C",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-500",
+      "value": "oklch(0.630 0.000 0)",
+      "note": "#898989",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-600",
+      "value": "oklch(0.728 0.000 0)",
+      "note": "#A7A7A7",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-700",
+      "value": "oklch(0.802 0.000 0)",
+      "note": "#BEBEBE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-800",
+      "value": "oklch(0.894 0.000 0)",
+      "note": "#DCDCDC",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-gray-900",
+      "value": "oklch(0.985 0.000 0)",
+      "note": "#FAFAFA",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-050",
+      "value": "oklch(0.296 0.183 264)",
+      "note": "#001286",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-100",
+      "value": "oklch(0.350 0.184 263)",
+      "note": "#002898",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-200",
+      "value": "oklch(0.410 0.187 262)",
+      "note": "#003DAD",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-300",
+      "value": "oklch(0.497 0.189 260)",
+      "note": "#0E5ACB",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-400",
+      "value": "oklch(0.573 0.189 260)",
+      "note": "#2A72E5",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-500",
+      "value": "oklch(0.633 0.169 255)",
+      "note": "#368AED",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-600",
+      "value": "oklch(0.724 0.140 248)",
+      "note": "#56ACF9",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-700",
+      "value": "oklch(0.800 0.110 243)",
+      "note": "#7BC6FF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-800",
+      "value": "oklch(0.893 0.057 243)",
+      "note": "#BCE1FF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-blue-900",
+      "value": "oklch(0.983 0.009 248)",
+      "note": "#F5FAFF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-050",
+      "value": "oklch(0.275 0.063 240)",
+      "note": "#002B43",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-100",
+      "value": "oklch(0.331 0.068 233)",
+      "note": "#003B53",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-200",
+      "value": "oklch(0.395 0.076 227)",
+      "note": "#004E66",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-300",
+      "value": "oklch(0.483 0.090 223)",
+      "note": "#006983",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-400",
+      "value": "oklch(0.526 0.095 219)",
+      "note": "#007790",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-500",
+      "value": "oklch(0.621 0.108 216)",
+      "note": "#0E96B0",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-600",
+      "value": "oklch(0.715 0.120 213)",
+      "note": "#1DB6CF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-700",
+      "value": "oklch(0.794 0.092 211)",
+      "note": "#6FCCDD",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-800",
+      "value": "oklch(0.891 0.048 213)",
+      "note": "#B8E4EE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-cyan-900",
+      "value": "oklch(0.983 0.008 207)",
+      "note": "#F4FBFC",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-050",
+      "value": "oklch(0.271 0.069 154)",
+      "note": "#003016",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-100",
+      "value": "oklch(0.324 0.077 157)",
+      "note": "#003F23",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-200",
+      "value": "oklch(0.390 0.088 160)",
+      "note": "#005334",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-300",
+      "value": "oklch(0.477 0.101 164)",
+      "note": "#006E4D",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-400",
+      "value": "oklch(0.517 0.107 166)",
+      "note": "#007B5A",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-500",
+      "value": "oklch(0.614 0.114 168)",
+      "note": "#259A77",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-600",
+      "value": "oklch(0.710 0.118 168)",
+      "note": "#46B993",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-700",
+      "value": "oklch(0.788 0.123 168)",
+      "note": "#5DD3AA",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-800",
+      "value": "oklch(0.886 0.065 168)",
+      "note": "#B0E8D1",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-green-900",
+      "value": "oklch(0.981 0.009 172)",
+      "note": "#F3FBF8",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-050",
+      "value": "oklch(0.271 0.092 142)",
+      "note": "#003100",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-100",
+      "value": "oklch(0.322 0.110 142)",
+      "note": "#004000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-200",
+      "value": "oklch(0.388 0.129 142)",
+      "note": "#095400",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-300",
+      "value": "oklch(0.475 0.147 138)",
+      "note": "#296E00",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-400",
+      "value": "oklch(0.518 0.156 137)",
+      "note": "#377B00",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-500",
+      "value": "oklch(0.616 0.174 134)",
+      "note": "#559A0B",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-600",
+      "value": "oklch(0.713 0.189 132)",
+      "note": "#74B91C",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-700",
+      "value": "oklch(0.786 0.200 130)",
+      "note": "#8DD126",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-800",
+      "value": "oklch(0.885 0.110 130)",
+      "note": "#C2E89A",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-lime-900",
+      "value": "oklch(0.982 0.019 130)",
+      "note": "#F5FCEF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-050",
+      "value": "oklch(0.289 0.093 39)",
+      "note": "#4F1400",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-100",
+      "value": "oklch(0.342 0.096 46)",
+      "note": "#5F2400",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-200",
+      "value": "oklch(0.410 0.104 53)",
+      "note": "#743700",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-300",
+      "value": "oklch(0.497 0.114 62)",
+      "note": "#8F5100",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-400",
+      "value": "oklch(0.539 0.121 65)",
+      "note": "#9D5D00",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-500",
+      "value": "oklch(0.638 0.137 72)",
+      "note": "#BE7B00",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-600",
+      "value": "oklch(0.733 0.153 78)",
+      "note": "#DD9A00",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-700",
+      "value": "oklch(0.808 0.166 83)",
+      "note": "#F4B402",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-800",
+      "value": "oklch(0.895 0.113 85)",
+      "note": "#FFD782",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-yellow-900",
+      "value": "oklch(0.984 0.016 83)",
+      "note": "#FFF9EE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-050",
+      "value": "oklch(0.296 0.121 29)",
+      "note": "#5B0000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-100",
+      "value": "oklch(0.353 0.145 29)",
+      "note": "#750000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-200",
+      "value": "oklch(0.421 0.173 29)",
+      "note": "#950000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-300",
+      "value": "oklch(0.512 0.188 33)",
+      "note": "#BA2500",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-400",
+      "value": "oklch(0.554 0.188 36)",
+      "note": "#C83800",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-500",
+      "value": "oklch(0.649 0.185 44)",
+      "note": "#E65F08",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-600",
+      "value": "oklch(0.740 0.147 46)",
+      "note": "#F58A56",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-700",
+      "value": "oklch(0.812 0.105 45)",
+      "note": "#FBAC88",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-800",
+      "value": "oklch(0.902 0.056 46)",
+      "note": "#FFD4C0",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-orange-900",
+      "value": "oklch(0.986 0.008 56)",
+      "note": "#FFF9F5",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-050",
+      "value": "oklch(0.291 0.120 29)",
+      "note": "#590000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-100",
+      "value": "oklch(0.353 0.145 29)",
+      "note": "#750000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-200",
+      "value": "oklch(0.421 0.173 29)",
+      "note": "#950000",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-300",
+      "value": "oklch(0.513 0.197 24)",
+      "note": "#BE1628",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-400",
+      "value": "oklch(0.557 0.197 23)",
+      "note": "#CE2B38",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-500",
+      "value": "oklch(0.654 0.198 21)",
+      "note": "#F14F5A",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-600",
+      "value": "oklch(0.745 0.150 21)",
+      "note": "#FD8283",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-700",
+      "value": "oklch(0.815 0.105 20)",
+      "note": "#FFA7A6",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-800",
+      "value": "oklch(0.902 0.051 21)",
+      "note": "#FFD2D0",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-red-900",
+      "value": "oklch(0.985 0.007 17)",
+      "note": "#FFF8F8",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-050",
+      "value": "oklch(0.295 0.118 15)",
+      "note": "#590018",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-100",
+      "value": "oklch(0.350 0.140 11)",
+      "note": "#710028",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-200",
+      "value": "oklch(0.422 0.169 6)",
+      "note": "#910040",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-300",
+      "value": "oklch(0.514 0.195 2)",
+      "note": "#B8185F",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-400",
+      "value": "oklch(0.558 0.191 2)",
+      "note": "#C62F6B",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-500",
+      "value": "oklch(0.655 0.184 2)",
+      "note": "#E65588",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-600",
+      "value": "oklch(0.746 0.150 2)",
+      "note": "#F881A6",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-700",
+      "value": "oklch(0.817 0.109 2)",
+      "note": "#FEA5BE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-800",
+      "value": "oklch(0.902 0.055 360)",
+      "note": "#FFD0DD",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-pink-900",
+      "value": "oklch(0.985 0.008 358)",
+      "note": "#FFF8FA",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-050",
+      "value": "oklch(0.298 0.148 313)",
+      "note": "#460060",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-100",
+      "value": "oklch(0.359 0.176 316)",
+      "note": "#5E0079",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-200",
+      "value": "oklch(0.428 0.208 317)",
+      "note": "#7A0097",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-300",
+      "value": "oklch(0.520 0.228 319)",
+      "note": "#9D21B9",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-400",
+      "value": "oklch(0.562 0.226 319)",
+      "note": "#AA34C6",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-500",
+      "value": "oklch(0.658 0.220 319)",
+      "note": "#C859E5",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-600",
+      "value": "oklch(0.747 0.168 319)",
+      "note": "#DA87EF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-700",
+      "value": "oklch(0.816 0.122 319)",
+      "note": "#E5A9F5",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-800",
+      "value": "oklch(0.903 0.065 319)",
+      "note": "#F2D2FB",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-grape-900",
+      "value": "oklch(0.985 0.009 321)",
+      "note": "#FDF8FE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-050",
+      "value": "oklch(0.301 0.174 286)",
+      "note": "#30007E",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-100",
+      "value": "oklch(0.362 0.205 290)",
+      "note": "#45009E",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-200",
+      "value": "oklch(0.425 0.208 290)",
+      "note": "#5522B4",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-300",
+      "value": "oklch(0.511 0.208 290)",
+      "note": "#6B42D2",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-400",
+      "value": "oklch(0.553 0.208 290)",
+      "note": "#7750E0",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-500",
+      "value": "oklch(0.649 0.188 293)",
+      "note": "#9672F5",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-600",
+      "value": "oklch(0.741 0.147 300)",
+      "note": "#B994FA",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-700",
+      "value": "oklch(0.813 0.115 305)",
+      "note": "#D3AFFE",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-800",
+      "value": "oklch(0.902 0.060 306)",
+      "note": "#E8D5FF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-violet-900",
+      "value": "oklch(0.983 0.010 305)",
+      "note": "#FBF8FF",
+      "group": "Dark palette"
+    },
+    {
+      "name": "dark-canvas",
+      "value": "oklch(0.256 0.000 0)",
+      "note": "#232323",
+      "group": "Dark palette"
     }
   ],
   "typography": [

--- a/services/vapor-ui.tokens.json
+++ b/services/vapor-ui.tokens.json
@@ -1041,13 +1041,13 @@
     {
       "name": "dark-orange-100",
       "value": "oklch(0.353 0.145 29)",
-      "note": "#750000",
+      "note": "#750000 · 상류가 dark-red-100 과 같은 값을 발행한다",
       "group": "Dark palette"
     },
     {
       "name": "dark-orange-200",
       "value": "oklch(0.421 0.173 29)",
-      "note": "#950000",
+      "note": "#950000 · 상류가 dark-red-200 과 같은 값을 발행한다",
       "group": "Dark palette"
     },
     {
@@ -1101,13 +1101,13 @@
     {
       "name": "dark-red-100",
       "value": "oklch(0.353 0.145 29)",
-      "note": "#750000",
+      "note": "#750000 · 상류가 dark-orange-100 과 같은 값을 발행한다",
       "group": "Dark palette"
     },
     {
       "name": "dark-red-200",
       "value": "oklch(0.421 0.173 29)",
-      "note": "#950000",
+      "note": "#950000 · 상류가 dark-orange-200 과 같은 값을 발행한다",
       "group": "Dark palette"
     },
     {

--- a/src/lib/token-coverage.test.ts
+++ b/src/lib/token-coverage.test.ts
@@ -66,7 +66,7 @@ describe("token gate coverage", () => {
       annotated += c.annotated
       judged += c.judged
     }
-    expect({ annotated, judged }).toEqual({ annotated: 1025, judged: 1016 })
+    expect({ annotated, judged }).toEqual({ annotated: 1136, judged: 1127 })
   })
 
   it("keeps the drift gate resolving the definitions it compares", () => {
@@ -82,7 +82,9 @@ describe("token gate coverage", () => {
     // duplicate-name conflicts the catalog does not have.
     // 1286 after likelion's 23 colors joined the catalog.
     // 1361 after gs-shop (52) and gs-retail (23) joined.
-    expect(total).toBe(1361)
+    // 1472 after vapor-ui published its dark ramp (111): upstream redefines the
+    // whole palette per theme, so the dark half is its own set of names.
+    expect(total).toBe(1472)
   })
 
   it("keeps every entry contributing definitions to the drift gate", () => {


### PR DESCRIPTION
## 변경 요약

vapor-ui 프리뷰를 렌더해 시각 검증하다가 **md 자체의 색 정의가 상류와 어긋난 것**을 발견해 전수조사로 넓혔다. `@vapor-ui/core` 1.3.0 배포본과 재대조해 다크 팔레트를 새로 발행하고(램프 111개 + alias 44건), 그 과정에서 드러난 프리뷰 결함들을 함께 고쳤다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [x] 기존 항목 수정
- [ ] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 무엇을 왜 바꿨나

### md — 다크 팔레트가 구조적으로 어긋나 있었다

상류는 다크에서 **시맨틱 alias 이름을 유지한 채 램프 자체를 재정의**한다(11 패밀리 × 10단 전부, 번호가 커질수록 밝아져 다크 `gray-900` 이 `#FAFAFA`). md 는 그것을 라이트 램프의 다른 단계를 가리키는 방식으로 근사하고 있었는데, 근사가 **일관되게 한 단씩 어두웠고** contrast 계열은 방향까지 뒤집혀 있었다 — `foreground-contrast-200-dark` 가 `#F7F7F7`(밝음)인데 발행값은 `#606060`(중간 회색).

- `dark-` 접두 램프 **111개**를 발행(110 + `dark-canvas`). 사이드카는 223색(라이트 112 + 다크 111).
- alias **44건** 정정 — 다크 36 · 라이트 4(`foreground-primary-100` 이 `blue-500` 이 아니라 `blue-600` 등) · 비어 있던 4.
- 정정은 근사가 아니라 **상류의 참조 구조를 그대로 옮긴 것**이라 기계적이다.
- `## Known Gaps` 의 "다크 alias 4개가 비어 있다" 항목은 해소돼 걷어냈다.

### 프리뷰 — md 가 반증하는 결함

기계 게이트는 이 층을 보지 않는다(이 슬러그는 수정 전에도 `validate:previews` 0 block 0 warn 이었다).

- **radio card**: 제목·설명이 `<span>` 이라 세로 마진이 조용히 무시돼 **한 문단으로 합쳐져** 렌더되고 있었다. 레이아웃이 깨지는 게 아니라 합쳐지는 유형이라 오버플로우·대비 검사 어디에도 걸리지 않는다.
- **switch**: 안쪽 padding 2px(md 4px)이라 knob 이 세로 중앙에서 벗어나 있었다. idle 트랙 `gray-300`(→ `gray-400`), knob 그림자 `shadow-sm`(→ `shadow-md`)도 함께.
- **버튼 hover/press**: fill 을 갈아끼우던 18개 규칙을 상류대로 `gray-900` 오버레이(8% / 16%)로 교체했다. **프리뷰 자신의 FOCUS RING 캡션이 이미 그 규약을 적고 있어** 캡션과 시연이 모순이던 상태였다.
- **toast**: 단일 배경 + 상태 점을 상류대로 intent 배경으로(상류 CSS 에 dot 규칙은 없다).
- **select 비활성**: 공통 규약(`opacity: 0.32`) 대신 색 치환이라 다크에서 2.54:1 이었다.
- callout(테두리·intent 텍스트색) · avatar · pagination · tabs · breadcrumb · table 의 색·행간·gap.
- 2열 카드 그리드의 stretch 공백(02번 섹션 TEXTAREA 카드 **422px**, 880px 초과 전 폭이라 976px 임베드에서도 보인다).

값을 바꾼 자리의 캡션도 함께 고쳤다.

## 리뷰어가 알아둘 것

- **다크 램프를 반전시키면서 raw 램프를 직접 참조하던 다크 규칙 65곳의 의미가 뒤집혔다.** 시각 회귀가 없도록 "예전에 렌더되던 색"에 가장 가까운 다크 단계로 기계 재매핑했다(대부분 Δ10 이하, 최대 27). semantic alias 를 쓰던 자리는 자동으로 올바르다.
- 그 재매핑이 `violet-300 → violet-600` 을 만들면서 **다크 워드마크가 사라지는 회귀**를 냈다(미정의 변수 참조 → `background` 무효 → `-webkit-text-fill-color: transparent` 만 남음). 자체 리뷰에서 잡아 고쳤고, 이제 편집 후 **라이트/다크 각각의 미정의 참조와 고아 변수를 검사**한다. CSS 변수는 미정의를 참조해도 경고 없이 선언만 죽어서 기존 게이트가 구조적으로 못 잡는 유형이다.
- `src/lib/token-coverage.test.ts` 래칫을 다크 램프 111개만큼 올렸다(1361 → 1472, annotated 1025 → 1136). 증가분이 정확히 111 이라 다른 회귀는 없다.
- `## Colors` 감사 메모는 규칙대로 **덮어썼다**(섹션당 하나). 이전 2026-07-29 라이트 램프 교체 이력은 그 안에 한 줄로 남겼다.

## 카탈로그 PR 체크

- [ ] `/design-md` 스킬로 생성 — 신규 항목이 아니라 기존 항목 정정이라 해당 없음
- [x] frontmatter 필수 필드 검증 완료
- [x] `public/preview/vapor-ui/preview.html` 확인 (라이트·다크 한 파일)
- [x] `[src:N]` 인용이 frontmatter `sources` 인덱스와 일치
- [x] 브랜드 자산 라이선스/상표 우려 검토 — 로고·이미지 자산 변경 없음. 색값은 공개 배포본(`@vapor-ui/core`, MIT) 에서 대조한 것이고 출처 hex 를 각 줄에 병기했다
- [x] 데모 항목(`_` 접두) 변경 아님

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] CONTRIBUTING.md 가이드라인 준수

추가로 통과한 게이트: `validate:previews`(0 block **0 warn** 유지) · `audit:oklch`(0 mismatch, 1127건 판정) · `validate:catalog`(0 block) · `tokens:check` · `check:last-updated` · 835 tests.

렌더 검증: 오버플로우 375/768/976/1440 × light/dark 전부 0. 대비 미달은 의도된 것만 남았다(라이트 5건 / 다크 9건 — `opacity: 0.32` 비활성, 장식 구분자, 상류 intent 배경 위 흰 텍스트, 다크의 밝은 `gray-900` 오버레이).
