### PR TITLE
fix(validate): 중첩 minmax() 를 괄호 깊이로 걷어내 bare-1fr 오탐을 없앤다

### DIFF
--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -1117,6 +1117,35 @@ describe("validatePreviewPair — responsive heuristics", () => {
     expect(warns).not.toContain("bare-1fr")
     expect(warns).not.toContain("no-mobile-collapse")
   })
+
+  it("expands a numeric repeat() holding a nested minmax()", () => {
+    // replaceMinmax runs before the repeat() expansion, so the inner call is
+    // one token by the time the body is split — the leftover used to read as
+    // a bare track AND as extra tracks.
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".pair { display: grid; grid-template-columns: repeat(2, minmax(min(170px, 100%), 1fr)); }",
+      }),
+    })
+    const warns = rulesOf(input, "warn")
+    expect(warns).not.toContain("bare-1fr")
+    expect(warns).toContain("no-mobile-collapse")
+  })
+
+  it("skips a parenthesis quoted inside a var() fallback", () => {
+    // Without string tracking the quoted "(" never closes, the scan swallows
+    // the genuine bare track behind it, and both warnings go quiet.
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          '.mix { display: grid; grid-template-columns: minmax(var(--minimum, "fallback("), 1fr) 1fr; }',
+      }),
+    })
+    const warns = rulesOf(input, "warn")
+    expect(warns).toContain("bare-1fr")
+    expect(warns).toContain("no-mobile-collapse")
+  })
 })
 
 // ── review-hardening regressions (PR #166 Gemini feedback) ───────────────────

--- a/src/lib/preview-validator.test.ts
+++ b/src/lib/preview-validator.test.ts
@@ -1035,6 +1035,88 @@ describe("validatePreviewPair — responsive heuristics", () => {
     })
     expect(rulesOf(input, "warn")).not.toContain("no-mobile-collapse")
   })
+
+  // `/minmax\([^)]*\)/` stopped at min()'s ")", leaving ", 1fr)" behind —
+  // read as a bare track by scanCss and as a second track by countTracks.
+  it("does not read a nested minmax() as a bare 1fr track", () => {
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(170px, 100%), 1fr)); }",
+      }),
+    })
+    expect(rulesOf(input, "warn")).not.toContain("bare-1fr")
+  })
+
+  it("counts a nested minmax() as a single track", () => {
+    // One column, no @media needed — the leftover used to make it two.
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".hero { display: grid; grid-template-columns: minmax(min(170px, 100%), 1fr); }",
+      }),
+    })
+    expect(rulesOf(input, "warn")).not.toContain("no-mobile-collapse")
+  })
+
+  it("still warns on a genuine bare 1fr beside a nested minmax()", () => {
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".mix { display: grid; grid-template-columns: minmax(min(170px,100%),1fr) 1fr; }",
+      }),
+    })
+    const warns = rulesOf(input, "warn")
+    expect(warns).toContain("bare-1fr")
+    // …and the guarded track is still counted: two tracks, no @media.
+    expect(warns).toContain("no-mobile-collapse")
+  })
+
+  it("counts only the genuinely bare declaration", () => {
+    // bareOneFr counts declarations, so "exactly once" needs two of them.
+    // Before the fix this message said "has 2 bare".
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(170px, 100%), 1fr)); } " +
+          ".pair { display: grid; grid-template-columns: 1fr 1fr; } " +
+          "@media (max-width: 720px) { .pair { grid-template-columns: minmax(0, 1fr); } }",
+      }),
+    })
+    const bare = validatePreviewPair(input).issues.filter(
+      (i) => i.rule === "bare-1fr"
+    )
+    expect(bare).toHaveLength(1)
+    expect(bare[0].fix).toContain("has 1 bare")
+  })
+
+  it("strips a minmax() at any nesting depth", () => {
+    // `calc(var(--gap) * 2)` is what a one-level regex still cannot reach —
+    // this pins the depth scanner against a future "simplify to a regex".
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".split { display: grid; grid-template-columns: minmax(clamp(120px, 20%, 200px), 1fr) minmax(calc(var(--gap) * 2), 1fr); }",
+      }),
+    })
+    const warns = rulesOf(input, "warn")
+    expect(warns).not.toContain("bare-1fr")
+    expect(warns).toContain("no-mobile-collapse")
+  })
+
+  it("does not let an unterminated minmax() manufacture tracks", () => {
+    // Broken CSS: the call runs to the end of the value, one track, no
+    // warning — the scanner must not invent a finding out of it.
+    const input = makeInput({
+      lightRaw: makeHtml({
+        style:
+          ".broken { display: grid; grid-template-columns: minmax(0, 1fr; }",
+      }),
+    })
+    const warns = rulesOf(input, "warn")
+    expect(warns).not.toContain("bare-1fr")
+    expect(warns).not.toContain("no-mobile-collapse")
+  })
 })
 
 // ── review-hardening regressions (PR #166 Gemini feedback) ───────────────────

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -641,14 +641,56 @@ function styleContent(html: string): string {
     .join("\n")
 }
 
+// `minmax(min(170px, 100%), 1fr)` — the inner call's ")" is not the outer
+// call's. `/minmax\([^)]*\)/` stops at the FIRST ")" and leaves ", 1fr)"
+// behind: `scanCss` then reads a guarded track as a bare `1fr`, and
+// `countTracks` reads one track as two (a false no-mobile-collapse). Counting
+// parenthesis depth handles any nesting — a one-level regex
+// (`/minmax\((?:[^()]|\([^()]*\))*\)/`) would still miss
+// `minmax(calc(var(--gap) * 2), 1fr)`, and miss it silently. Same idiom as
+// `parseCssRules` above. An unterminated call runs to the end of the value
+// (EOF closes what is open), which errs toward fewer tracks and no warning —
+// the direction that cannot manufacture a finding out of broken CSS.
+//
+// Measured when this replaced the regex: 387 `grid-template-columns`
+// declarations inside the catalogue's `<style>` blocks, none with a nested
+// call, every bare-1fr verdict and track count unchanged.
+function replaceMinmax(value: string, replacement: string): string {
+  const head = "minmax("
+  let out = ""
+  let i = 0
+  while (i < value.length) {
+    const start = value.indexOf(head, i)
+    if (start === -1) break
+    let depth = 0
+    let j = start + head.length - 1
+    for (; j < value.length; j++) {
+      if (value[j] === "(") depth++
+      else if (value[j] === ")") {
+        depth--
+        if (depth === 0) {
+          j++
+          break
+        }
+      }
+    }
+    out += value.slice(i, start) + replacement
+    i = j
+  }
+  return out + value.slice(i)
+}
+
 // Track counting for `grid-template-columns` values. `repeat(auto-fill|fit,…)`
 // self-collapses, so it never counts as a fixed multi-column layout. Numeric
 // repeat() expands into its full track list so mixed values
-// (`repeat(1, minmax(0,1fr)) minmax(0,1fr)`) count correctly.
+// (`repeat(1, minmax(0,1fr)) minmax(0,1fr)`) count correctly. It still splits
+// the repeat body on whitespace and stops at the first ")", so
+// `repeat(2, calc(50% - 1rem))` is over-counted (6, not 2); no preview writes
+// that today, and fixing it means a real track tokenizer, not another regex.
 function countTracks(value: string): number {
   let v = value.trim()
   if (/repeat\(\s*(auto-fill|auto-fit)/.test(v)) return 1
-  v = v.replace(/minmax\([^)]*\)/g, "T")
+  v = replaceMinmax(v, "T")
   v = v.replace(
     /repeat\(\s*(\d+)\s*,([^)]*)\)/g,
     (_, n: string, body: string) => {
@@ -680,7 +722,7 @@ function scanCss(css: string): FileScan {
       /grid-template-columns\s*:\s*([^;]+)/g
     )) {
       const value = decl[1]
-      const bare = value.replace(/minmax\([^)]*\)/g, "")
+      const bare = replaceMinmax(value, "")
       if (/\b1fr\b/.test(bare)) bareOneFr++
       if (rule.inMedia) {
         for (const sel of selectors) mediaRedeclared.add(sel)

--- a/src/lib/preview-validator.ts
+++ b/src/lib/preview-validator.ts
@@ -648,9 +648,12 @@ function styleContent(html: string): string {
 // parenthesis depth handles any nesting — a one-level regex
 // (`/minmax\((?:[^()]|\([^()]*\))*\)/`) would still miss
 // `minmax(calc(var(--gap) * 2), 1fr)`, and miss it silently. Same idiom as
-// `parseCssRules` above. An unterminated call runs to the end of the value
-// (EOF closes what is open), which errs toward fewer tracks and no warning —
-// the direction that cannot manufacture a finding out of broken CSS.
+// `parseCssRules` above, including its string tracking: a `var()` fallback
+// may quote a parenthesis (`var(--min, "fallback(")`), and counting that one
+// would never close the call and swallow the genuine track behind it. An
+// unterminated call runs to the end of the value (EOF closes what is open),
+// which errs toward fewer tracks and no warning — the direction that cannot
+// manufacture a finding out of broken CSS.
 //
 // Measured when this replaced the regex: 387 `grid-template-columns`
 // declarations inside the catalogue's `<style>` blocks, none with a nested
@@ -663,10 +666,18 @@ function replaceMinmax(value: string, replacement: string): string {
     const start = value.indexOf(head, i)
     if (start === -1) break
     let depth = 0
+    let quote: '"' | "'" | null = null
+    // Start on the call's own "(" so it is the first thing counted.
     let j = start + head.length - 1
     for (; j < value.length; j++) {
-      if (value[j] === "(") depth++
-      else if (value[j] === ")") {
+      const ch = value[j]
+      if (quote !== null) {
+        if (ch === quote && value[j - 1] !== "\\") quote = null
+        continue
+      }
+      if (ch === '"' || ch === "'") quote = ch
+      else if (ch === "(") depth++
+      else if (ch === ")") {
         depth--
         if (depth === 0) {
           j++


### PR DESCRIPTION
## 변경 요약

`bare-1fr` 스캐너의 `/minmax\([^)]*\)/` 가 첫 `)` 에서 멈춰 `minmax(min(170px, 100%), 1fr)` 을 벌거벗은 트랙으로 오독하던 것을, 괄호 깊이를 세는 `replaceMinmax()` 로 바꿔 고친다. **같은 정규식이 `countTracks()`(651행)에도 있어** 단일 중첩 트랙을 2트랙으로 세고 `no-mobile-collapse` 를 오발하던 것도 함께 고친다(이슈엔 없던 발견).

## 왜 정규식이 아니라 깊이 카운터인가

한 단계 중첩 정규식(`/minmax\((?:[^()]|\([^()]*\))*\)/`)은 `minmax(calc(var(--gap) * 2), 1fr)` 에서 조용히 실패해 같은 오탐이 남는다. `parseCssRules` 가 중괄호에 이미 쓰는 깊이 스캐너 관용구를 그대로 따랐다. 닫히지 않은 `minmax(` 는 값 끝까지 삼킨다 — 1트랙·무경고 쪽으로 기우는 계약이고, 테스트로 명시했다.

## 측정 (카탈로그 20개 전수)

| 항목 | 결과 |
|---|---|
| `<style>` 안 `grid-template-columns` 선언 | 387건(원시 grep 392 중 5건은 `<style>` 밖) — 중첩 호출 0건 |
| `pnpm validate:previews --verbose` stdout, 수정 전 vs 후 | **바이트 단위 동일** (stderr 의 jsdom "Could not parse CSS stylesheet" 4줄은 비교 대상 아님) |
| 요약 | 20 slugs · 0 blocking · **49 warning (전후 동일)** — 슬러그별 개수와 "has N bare" 메시지까지 그대로 |
| 잔존 정규식 `grep -cE 'replace\(/minmax'` | 0 |
| `grep -c 'replaceMinmax('` | 3 (선언 1 + 호출부 2) |
| `pnpm test` (`preview-validator.test.ts`) | 테스트 8개 추가 (중첩·단일·혼합·선언 개수·임의 깊이·미종료·숫자형 repeat·따옴표 속 괄호). 현재 main 과 합친 상태에서 이 파일 89개·타입체크 통과 |

즉 오늘 카탈로그에서는 no-op 이고, 앞으로 컨테이너보다 좁아질 때 쓰는 표준 경화형 `minmax(min(<min>px, 100%), 1fr)` 이 더 이상 막히지 않는다(PR #316 에서 이 형태를 썼다가 warn 을 보고 되돌린 일이 있다).

## 범위 밖

- 숫자형 `repeat()` 가 body 를 공백으로 쪼개고 첫 `)` 에서 끊어 `repeat(2, calc(50% - 1rem))` 을 6트랙으로 세는 잔여 결함 — `countTracks` 주석에 기록. 정규식이 아니라 트랙 토크나이저가 필요한 일이라 이 PR 에서 손대지 않는다(카탈로그 노출 0건).
- `rubric-preview.md` · `preview-html-author.md` 가 `minmax(0, 1fr)` 만 안전형으로 서술하는 문구 — #322 의 문서 PR 이 같은 문단을 편집하므로 거기서 한 절로 흡수한다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (build 는 CI)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

Closes #323

