### PR TITLE
test: 토큰 커버리지 래칫을 카탈로그 합계에서 항목별 정확값 표로 바꾼다

### DIFF
--- a/.claude/skills/design-md/SKILL.md
+++ b/.claude/skills/design-md/SKILL.md
@@ -452,6 +452,18 @@ If the test fails with `these slugs have no entry in MATCH_FLOOR`, add the rule,
 
 Both files are outside this skill's write scope, so this does not route back to Stage 9a — a human operator running the skill by hand makes these two edits directly. Skipping them does not corrupt the entry; it leaves the drift gate blind to it, and CI fails on the pull request rather than here.
 
+### Token coverage row
+
+The same moment creates a row this entry owes to `src/lib/token-coverage.test.ts`. Run it:
+
+```bash
+cd "${repo_root}" && pnpm test src/lib/token-coverage.test.ts
+```
+
+That file pins, per entry, how many `name: oklch(…)` definitions each token gate can see — exact in both directions, because a count that rises can mean a reader widened, not that tokens were added. A new entry fails it with `these entries have no row in TOKEN_COVERAGE`, and the message prints the row itself: paste that line into `TOKEN_COVERAGE` at its sorted position, then read it. `drift: 0` is refused (the drift gate would have no md-side name to compare for the whole entry — fix the frontmatter token map instead), while `annotated: 0` can be right (an entry that comments its colours in prose with no hex, as baemin and toss do). Nothing else in the repo prints these numbers, so do not guess them. A row per entry is what lets two catalogue pull requests be open at once without the second one failing on the first one's merge (#324).
+
+This file is outside the skill's write scope too: the operator makes the edit by hand, next to the `MATCH_FLOOR` row above.
+
 ## Stage 11 — Build OG image
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,10 @@ Google Labs 가 발행한 DESIGN.md 명세(`github.com/google-labs-code/design.m
   그라디언트다. 준수하려면 실제 발행값을 버려야 하므로 고치지 않고 기록한다 —
   `src/lib/google-designmd-corpus.test.ts` 의 `KNOWN_SPEC_LIMITATIONS` 가 슬러그별 개수를
   **양방향 래칫**으로 고정한다(새 에러도, 조용한 수정도 실패시킨다).
+- **새 항목은 슬러그별 표 세 곳에 자기 줄을 적는다.** `MATCH_FLOOR`(`oklch-drift-corpus.test.ts`,
+  하한) · `TOKEN_COVERAGE`(`token-coverage.test.ts`, 양방향 정확값 — 실패 메시지가 붙여넣을 줄을
+  출력한다) · `KNOWN_SPEC_LIMITATIONS`(해당할 때만). 셋 다 총계가 아니라 슬러그 단위라 동시에
+  열린 카탈로그 PR 끼리 서로를 깨지 않는다 — 합계 하드코딩은 그랬다(#324).
 - **`primary` 라는 이름의 토큰을 지어내지 말 것.** 명세가 없으면 경고하지만, 어느 브랜드
   색이 primary 인지는 의미 판단이다. 같은 코퍼스 테스트가 현재 14개 슬러그 목록을 고정해
   둬서, 붙이려면 근거와 함께 명시적으로 해야 한다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ author→reviewer 사이 기계 게이트(Stage 6a2/9a2)로 실행한다.
   `dark-` 접두다(codeit 78개·seed-design 109개). `wanted`가 21개를 충돌시켜 대조 22건을
   잃고 있었다.
 - **Dimension 값은 0이어도 단위를 붙인다** — `tracking: 0` 이 아니라 `0em`.
+- **새 항목은 슬러그별 표 세 곳에 자기 줄을 적는다.** `MATCH_FLOOR`(`oklch-drift-corpus.test.ts`,
+  하한) · `TOKEN_COVERAGE`(`token-coverage.test.ts`, 양방향 정확값 — 실패 메시지가 붙여넣을 줄을
+  출력한다) · `KNOWN_SPEC_LIMITATIONS`(해당할 때만). 셋 다 총계가 아니라 슬러그 단위라 동시에
+  열린 카탈로그 PR 끼리 서로를 깨지 않는다 — 합계 하드코딩은 그랬다(#324).
 
 ## Google DESIGN.md 표준 (`pnpm validate:spec`)
 
@@ -91,10 +95,6 @@ Google Labs 가 발행한 DESIGN.md 명세(`github.com/google-labs-code/design.m
   그라디언트다. 준수하려면 실제 발행값을 버려야 하므로 고치지 않고 기록한다 —
   `src/lib/google-designmd-corpus.test.ts` 의 `KNOWN_SPEC_LIMITATIONS` 가 슬러그별 개수를
   **양방향 래칫**으로 고정한다(새 에러도, 조용한 수정도 실패시킨다).
-- **새 항목은 슬러그별 표 세 곳에 자기 줄을 적는다.** `MATCH_FLOOR`(`oklch-drift-corpus.test.ts`,
-  하한) · `TOKEN_COVERAGE`(`token-coverage.test.ts`, 양방향 정확값 — 실패 메시지가 붙여넣을 줄을
-  출력한다) · `KNOWN_SPEC_LIMITATIONS`(해당할 때만). 셋 다 총계가 아니라 슬러그 단위라 동시에
-  열린 카탈로그 PR 끼리 서로를 깨지 않는다 — 합계 하드코딩은 그랬다(#324).
 - **`primary` 라는 이름의 토큰을 지어내지 말 것.** 명세가 없으면 경고하지만, 어느 브랜드
   색이 primary 인지는 의미 판단이다. 같은 코퍼스 테스트가 현재 14개 슬러그 목록을 고정해
   둬서, 붙이려면 근거와 함께 명시적으로 해야 한다.

--- a/src/lib/design-md-skill-machine-gate.test.ts
+++ b/src/lib/design-md-skill-machine-gate.test.ts
@@ -128,6 +128,20 @@ describe("/design-md machine gates", () => {
     )
   })
 
+  // Issue #324: the token gates' coverage ratchet is a row per entry now, and
+  // a new entry owes it one the same way it owes MATCH_FLOOR one. Same wiring,
+  // same failure mode if the pointer goes missing — the message lands in CI on
+  // a person who never saw the table. Pinned at both ends, in its own test so
+  // a failure names which of the two tables the skill stopped mentioning.
+  it("tells onboarding to record the entry's token coverage", () => {
+    const skill = readRepoFile(".claude/skills/design-md/SKILL.md")
+    expect(skill).toContain("TOKEN_COVERAGE")
+    expect(skill).toContain("token-coverage.test.ts")
+    expect(readRepoFile("src/lib/token-coverage.test.ts")).toContain(
+      "TOKEN_COVERAGE"
+    )
+  })
+
   // created_at is the catalog's sort key, but nothing in the pipeline would
   // notice its absence: an entry missing it still renders, just pinned to the
   // bottom of the list. Four entries shipped that way before the field became

--- a/src/lib/token-coverage.test.ts
+++ b/src/lib/token-coverage.test.ts
@@ -29,6 +29,22 @@ import { findFontDisplaySrc } from "./preview-validator"
 // seen first. A number that legitimately changes — a new catalog entry, a token
 // added — moves UP; a number that drops is the failure this file exists to
 // catch.
+//
+// PER ENTRY, NOT A CATALOG TOTAL (issue #324). Two exact totals used to live
+// here, and every catalog PR had to rewrite the same two lines for its own
+// base — so of two PRs open at once, whichever merged second failed, and its
+// author then re-counted the whole catalog to get green. That re-count is
+// where a drop elsewhere hides: the number that lands is "what makes the test
+// pass", not "what this entry contributed". A row per entry means a PR touches
+// only its own row, and the diff of that row IS the claim.
+//
+// EXACT IN BOTH DIRECTIONS, unlike `MATCH_FLOOR` next door. A floor is right
+// there because more coverage is strictly better; here a number that RISES can
+// mean the reader widened. Measured with the real reader, not a regex of this
+// file's own: dropping the frontmatter scope in `allDefinitions` moves the
+// catalog from 1472 to 1474 — teamsparta 28 → 29 (`input-focus-ring`) and
+// wanted 111 → 112 (`fg`), the two body-fence rows the scope exists to
+// exclude. A floor passes that. This table does not.
 
 const SERVICES_DIR = path.resolve(process.cwd(), "services")
 
@@ -46,8 +62,81 @@ function readAll(): Array<{ slug: string; raw: string }> {
   }))
 }
 
+interface Coverage {
+  /** `name: oklch(…)  # #hex` pairs `countDefinitions` sees — what feeds `audit:oklch`. */
+  annotated: number
+  /** The subset it can actually judge: one hex on the line. */
+  judged: number
+  /** Names `readDefinitions` resolves for the drift gate, self-conflicts dropped. */
+  drift: number
+  /** The entry names a display face through a `font-display-src` webfont. */
+  webfont?: true
+}
+
+// One row per entry. Update only the row for the entry your change touches;
+// the failure messages below print the measured numbers, and nothing else in
+// the repo does.
+//
+// `annotated: 0` is a fact about the entry, not a broken regex: baemin,
+// bezier, teamsparta and toss comment their colours in prose with no hex, so
+// `audit:oklch` has nothing to judge there. `drift: 0` is a different claim
+// and is refused below.
+const TOKEN_COVERAGE: Partial<Record<string, Coverage>> = {
+  "11st": { annotated: 31, judged: 31, drift: 33 },
+  baemin: { annotated: 0, judged: 0, drift: 37 },
+  bezier: { annotated: 0, judged: 0, drift: 43 },
+  class101: { annotated: 34, judged: 33, drift: 34 },
+  codeit: { annotated: 166, judged: 159, drift: 166, webfont: true },
+  gmarket: { annotated: 85, judged: 85, drift: 89 },
+  greeting: { annotated: 56, judged: 56, drift: 65 },
+  "gs-retail": { annotated: 23, judged: 23, drift: 23 },
+  "gs-shop": { annotated: 52, judged: 52, drift: 52 },
+  krds: { annotated: 44, judged: 44, drift: 55 },
+  kyobobook: { annotated: 26, judged: 26, drift: 56 },
+  likelion: { annotated: 23, judged: 23, drift: 23 },
+  "line-design-system": { annotated: 24, judged: 24, drift: 24 },
+  "seed-design": { annotated: 229, judged: 229, drift: 241 },
+  socar: { annotated: 56, judged: 56, drift: 59 },
+  teamsparta: { annotated: 0, judged: 0, drift: 28 },
+  toss: { annotated: 0, judged: 0, drift: 37 },
+  "vapor-ui": { annotated: 223, judged: 223, drift: 223 },
+  wanted: { annotated: 13, judged: 12, drift: 111, webfont: true },
+  yeogi: { annotated: 51, judged: 51, drift: 73, webfont: true },
+}
+// Column sums when the table was written (2026-09-12): annotated 1136, judged
+// 1127, drift 1472. Deliberately not asserted — a total is the shared line
+// this table exists to remove.
+
 describe("token gate coverage", () => {
   const docs = readAll()
+
+  // Measured once, through the real readers. Never re-derive these with a
+  // regex of this file's own: a hand-written proxy over-counted the scope-drop
+  // figure above by one, because it kept a name `readDefinitions` drops as a
+  // self-conflict.
+  const measured = new Map<string, Coverage>(
+    docs.map(({ slug, raw }) => {
+      const c = countDefinitions(raw)
+      const row: Coverage = {
+        annotated: c.annotated,
+        judged: c.judged,
+        drift: readDefinitions(raw).size,
+      }
+      if (findFontDisplaySrc(raw) !== null) row.webfont = true
+      return [slug, row]
+    })
+  )
+
+  function moved(field: "annotated" | "judged" | "drift"): Array<string> {
+    const out: Array<string> = []
+    for (const [slug, m] of measured) {
+      const row = TOKEN_COVERAGE[slug]
+      if (row === undefined) continue // the accounting test reports it
+      if (m[field] !== row[field])
+        out.push(`${slug} ${field} ${row[field]} → ${m[field]}`)
+    }
+    return out
+  }
 
   it("reads the whole catalog", () => {
     // A glob that silently matched nothing would make every assertion below
@@ -55,48 +144,70 @@ describe("token gate coverage", () => {
     expect(docs.length).toBeGreaterThan(10)
   })
 
+  it("accounts for every entry in the catalog", () => {
+    // Both directions. A new entry has to be recorded on purpose; a row that
+    // outlives its entry means the table has stopped describing the catalog.
+    const unrecorded = [...measured].filter(
+      ([slug]) => !(slug in TOKEN_COVERAGE)
+    )
+    // Print the row itself, not just the name: nothing else in the repo
+    // reports these numbers, so a message that only says "record them" leaves
+    // no way to obtain them.
+    const rows = unrecorded
+      .map(
+        ([slug, m]) =>
+          `  "${slug}": { annotated: ${m.annotated}, judged: ${m.judged}, drift: ${m.drift}${m.webfont ? ", webfont: true" : ""} },`
+      )
+      .join("\n")
+    expect(
+      unrecorded.map(([slug]) => slug),
+      `these entries have no row in TOKEN_COVERAGE — paste, then read (a drift of 0 is refused; an annotated of 0 can be right):\n${rows}`
+    ).toEqual([])
+
+    const stale = Object.keys(TOKEN_COVERAGE).filter((s) => !measured.has(s))
+    expect(
+      stale,
+      `TOKEN_COVERAGE records entries services/ no longer has: ${stale.join(", ")}. Delete the row in the same change that removes the entry, so the table cannot keep vouching for a file nobody reads.`
+    ).toEqual([])
+  })
+
   it("keeps audit:oklch comparing the annotated definitions it can see", () => {
     // `countDefinitions` feeds `pnpm audit:oklch`. `annotated` is every
     // `name: oklch(…)  # #hex` pair; `judged` is the subset it can actually
     // compare (the rest name more than one hex on the line and are skipped).
-    let annotated = 0
-    let judged = 0
-    for (const { raw } of docs) {
-      const c = countDefinitions(raw)
-      annotated += c.annotated
-      judged += c.judged
-    }
-    expect({ annotated, judged }).toEqual({ annotated: 1136, judged: 1127 })
+    const diffs = [...moved("annotated"), ...moved("judged")]
+    expect(
+      diffs,
+      `recorded → measured: ${diffs.join(", ")}. DOWN means OKLCH_ANNOTATED_DEFINITION or OKLCH_DEFINITION stopped seeing lines it used to judge — read oklch-sync.ts before touching this table. UP is legitimate only if THIS change added those definitions; a rise on an entry you did not edit is the pattern widening. Edit only the row for the entry you touched.`
+    ).toEqual([])
   })
 
   it("keeps the drift gate resolving the definitions it compares", () => {
     // `readDefinitions` is what `findPreviewDrift` compares a preview against.
-    // It drops names that disagree with themselves, so this total is also a
-    // check that no entry has reintroduced a duplicate-value collision.
-    const total = docs.reduce((n, { raw }) => n + readDefinitions(raw).size, 0)
-    // 1265 before tokens moved into frontmatter, 1263 after. The two that left
-    // were never token definitions: `teamsparta`'s `input-focus-ring` and
-    // `wanted`'s `fg`, both written at column 0 inside a `## Components` fence.
-    // Scoping the reader to the frontmatter block is what stops those — and
-    // stops `wanted`'s Components `bg:`/`fg:` rows from manufacturing
-    // duplicate-name conflicts the catalog does not have.
-    // 1286 after likelion's 23 colors joined the catalog.
-    // 1361 after gs-shop (52) and gs-retail (23) joined.
-    // 1472 after vapor-ui published its dark ramp (111): upstream redefines the
-    // whole palette per theme, so the dark half is its own set of names.
-    expect(total).toBe(1472)
+    // It drops names that disagree with themselves, so a row that drops is also
+    // how a reintroduced duplicate-value collision shows up.
+    const diffs = moved("drift")
+    expect(
+      diffs,
+      `recorded → measured: ${diffs.join(", ")}. DOWN with no token deleted usually means a name now disagrees with itself and readDefinitions dropped it — \`pnpm validate:catalog\` names each one. UP with no token added means the reader is matching outside the frontmatter token maps (measured once at +2: teamsparta 29, wanted 112).`
+    ).toEqual([])
   })
 
   it("keeps every entry contributing definitions to the drift gate", () => {
-    // A per-slug floor catches the case the total hides: one entry going to
-    // zero while another grows.
-    const empty = docs
-      .filter(({ raw }) => readDefinitions(raw).size === 0)
-      .map((d) => d.slug)
-    expect(empty).toEqual([])
+    // Equivalent to measuring live, because the assertion above pins measured
+    // to recorded — and stated here it is refused while the author is typing
+    // the row. That equivalence holds only while `drift` stays exact; loosen it
+    // to a floor and this has to go back to reading the files.
+    const zero = Object.entries(TOKEN_COVERAGE)
+      .filter(([, c]) => c?.drift === 0)
+      .map(([slug]) => slug)
+    expect(
+      zero,
+      `these entries are recorded as contributing nothing to the drift gate: ${zero.join(", ")}. A 0 here means findPreviewDrift has no md-side name to compare for the whole entry — fix the frontmatter token map instead of recording the zero. (\`annotated: 0\` is a different claim and is allowed.)`
+    ).toEqual([])
   })
 
-  it("keeps the three webfont sources reachable to the preview validator", () => {
+  it("keeps every webfont source reachable to the preview validator", () => {
     // `findFontDisplaySrc` is how a brand's own display face reaches the
     // preview `<head>`. When it stops matching, the preview silently falls back
     // to Pretendard and nothing fails — the gap that shipped on `wanted`.
@@ -105,10 +216,22 @@ describe("token gate coverage", () => {
     // raw file. An earlier version of this assertion did the latter, and would
     // have stayed green through exactly the breakage it was written to catch:
     // moving the webfont line into frontmatter makes the function return null
-    // for all three entries while a raw-text regex still finds three matches.
-    const resolved = docs
-      .filter(({ raw }) => findFontDisplaySrc(raw) !== null)
-      .map((d) => d.slug)
-    expect(resolved).toEqual(["codeit", "wanted", "yeogi"])
+    // for every entry while a raw-text regex still finds the same matches.
+    //
+    // Compared as a set derived from the table, not as a literal list. The
+    // list was the last line every webfont-bearing entry had to edit — the
+    // same shared line the totals were.
+    const recorded = Object.entries(TOKEN_COVERAGE)
+      .filter(([, c]) => c?.webfont === true)
+      .map(([slug]) => slug)
+      .sort()
+    const resolved = [...measured]
+      .filter(([, m]) => m.webfont === true)
+      .map(([slug]) => slug)
+      .sort()
+    expect(
+      resolved,
+      `entries whose font-display-src the validator resolves differ from the rows marked \`webfont: true\` — if the function stopped matching, the preview silently falls back to Pretendard; if an entry gained a display face, mark its row.`
+    ).toEqual(recorded)
   })
 })


### PR DESCRIPTION
## 변경 요약

`token-coverage.test.ts` 의 카탈로그 전역 합계 두 줄(annotated/judged · readDefinitions 총합)을 **슬러그별 양방향 정확값 표 `TOKEN_COVERAGE`** 로 바꾼다. 카탈로그 항목 PR 은 자기 줄 하나만 추가하므로 동시에 열린 PR 끼리 서로를 깨지 않는다(#324). 이번 작업 중에도 재현됐다 — 세션 사이 #328 이 vapor-ui 다크 램프 111개를 발행해 총합이 1361 → 1472 로 바뀌었고, 같은 파일을 만지는 PR 은 전부 재계산 대상이 됐다.

## 왜 하한선·스냅샷이 아니라 정확값인가

실제 reader 로 쟀다(손정규식 프록시는 +3 으로 오측했었다): `allDefinitions` 의 frontmatter 스코프를 풀면 총합이 **1472 → 1474 로 올라간다** — teamsparta 28 → 29(`input-focus-ring`), wanted 111 → 112(`fg`), 스코프가 배제하려던 본문 펜스 두 행. 하한선(`toBeGreaterThanOrEqual`)과 `-u` 스냅샷은 이 확대를 통과시키고, 정확값 표는 두 슬러그를 이름으로 지목한다. 파일 헤더가 "위로 움직이는 건 정당"이라 적어 두었지만, 위로 움직이는 **오매칭**이 실재하므로 양방향으로 잡는다.

웹폰트 목록 `["codeit","wanted","yeogi"]` 도 같은 파일의 **마지막 공유 줄**이었다(PR #291 의 diff 가 그 줄과 제목·주석까지 고친다). 표의 `webfont: true` 열로 옮겨, 이 파일에 항목 PR 이 함께 편집해야 하는 줄이 하나도 남지 않게 했다.

## 무엇이 바뀌나

- `src/lib/token-coverage.test.ts` — `TOKEN_COVERAGE: Partial<Record<slug, {annotated, judged, drift, webfont?}>>` 20행 + 단언 6개: 카탈로그 읽음 · **모든 항목이 표에, 표의 모든 행이 항목에**(미기록이면 붙여넣을 줄 자체를 출력) · annotated/judged 정확 대조 · drift 정확 대조(DOWN/UP 진단) · `drift: 0` 거부 · webfont 집합 대조. 총계 단언은 되살리지 않는다.
- `.claude/skills/design-md/SKILL.md` — alias 등록 소절 옆 `### Token coverage row`(테스트 실행 → 실패 메시지의 줄을 붙여넣기; `drift: 0` 거부 · `annotated: 0` 허용 설명). rule id·`SPLIT_MODEL_PHRASES` 부분 문자열 없음(계약 테스트 green).
- `src/lib/design-md-skill-machine-gate.test.ts` — SKILL.md ↔ 테스트 파일 양끝 심볼 핀(`MATCH_FLOOR` 와 같은 배선, 별도 `it`).
- `CLAUDE.md` — 새 항목이 자기 줄을 적어야 하는 슬러그별 표 세 곳(`MATCH_FLOOR` · `TOKEN_COVERAGE` · `KNOWN_SPEC_LIMITATIONS`) 한 불릿.

## 래칫이 여전히 잡는 것 — 부정 대조 4종 (각각 실행 후 되돌림)

| 대조 | 조작 | 실패 메시지 |
|---|---|---|
| A 조용한 확대 | `frontmatterBlock` 이 문서 전체를 반환 | `recorded → measured: teamsparta drift 28 → 29, wanted drift 111 → 112` |
| B 부분 하락 | gs-shop `colors:` 에 `primary-default` 를 다른 값으로 재선언 | `recorded → measured: gs-shop drift 52 → 51` |
| C 0 붕괴 | `OKLCH_ANNOTATED_DEFINITION` 의 hex 패턴 훼손 | annotated 가 있는 **16행** 이 동시에 `→ 0` |
| D 항목 소멸 | `services/likelion.md` 를 트리 밖으로 이동 | `TOKEN_COVERAGE records entries services/ no longer has: likelion` |

표의 열 합 1136 / 1127 / 1472 는 종전 합계와 같다(주석으로만 기록, 단언 안 함).

## 검증

| 항목 | 결과 |
|---|---|
| `pnpm typecheck` · `pnpm lint` · 바꾼 파일 `prettier --check` | 통과 |
| `pnpm test` | 통과 (token-coverage 5 → 6, machine-gate +1) |
| `pnpm validate:previews` | 20 slugs · 0 blocking · 49 warning — 이 PR 은 검증기 룰을 건드리지 않는다 |

## PR #291 에 미치는 영향

rebase 후 세 테스트 파일에 `samsung-one-ui` 줄만 추가하면 된다(`TOKEN_COVERAGE` 의 숫자는 실패 메시지가 출력하는 것을 붙인다). 합계 재계산은 없다. 이 PR 을 먼저 머지하고 #291 이 rebase 하는 순서가 diff 가 작다.

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI (테스트)
- [x] 문서 (CLAUDE.md)
- [x] `/design-md` 스킬 — SKILL.md 소절 1개

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과 (build 는 CI)
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

Closes #324
