### PR TITLE
chore(deps): 쓰지 않는 gray-matter 와 그것을 위한 Buffer 스텁을 걷어낸다

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "gray-matter": "^4.0.3",
     "jotai": "^2.20.2",
     "lucide-react": "^1.30.0",
     "nitro": "3.0.260603-beta",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       jotai:
         specifier: ^2.20.2
         version: 2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.8)
@@ -1954,9 +1951,6 @@ packages:
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2542,10 +2536,6 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
-  extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -2731,10 +2721,6 @@ packages:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
     engines: {node: '>=20.11.1'}
@@ -2853,10 +2839,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2972,10 +2954,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -3022,10 +3000,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3853,10 +3827,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  section-matter@1.0.0:
-    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
-    engines: {node: '>=4'}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3990,9 +3960,6 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
@@ -4049,10 +4016,6 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
-
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -6311,10 +6274,6 @@ snapshots:
 
   anynum@1.0.1: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -6902,10 +6861,6 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
-
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -7087,13 +7042,6 @@ snapshots:
   graphql@16.14.2:
     optional: true
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.16)):
     dependencies:
       rou3: 0.8.1
@@ -7200,8 +7148,6 @@ snapshots:
 
   is-docker@3.0.0: {}
 
-  is-extendable@0.1.1: {}
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0:
@@ -7269,11 +7215,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -7329,8 +7270,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -8330,11 +8269,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  section-matter@1.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      kind-of: 6.0.3
-
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -8533,8 +8467,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  sprintf-js@1.0.3: {}
-
   srvx@0.11.16: {}
 
   srvx@0.11.22: {}
@@ -8585,8 +8517,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -80,17 +80,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     <html lang="ko" data-theme="light">
       <head>
         <HeadContent />
-        {/* gray-matter (used by content-collection) calls Node's Buffer at
-            client module init. Browsers don't ship Buffer, so without this
-            shim React hydration fails silently with "Buffer is not defined".
-            The shim returns input as-is — sufficient for gray-matter, which
-            only uses Buffer.from(string).toString() round-trips. */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html:
-              "if(typeof window!=='undefined'&&typeof window.Buffer==='undefined'){window.Buffer={isBuffer:function(){return false},from:function(s){return s}}}",
-          }}
-        />
+        {/* No window.Buffer stub here. One used to exist for gray-matter, which
+            the hand-written parser in content-parser.ts replaced. The only
+            client code that still looks for Buffer is @tanstack/router-core's
+            RawStream serializer, and it feature-detects it and falls back to
+            atob/btoa - a stub whose `from` returns its input defeated that
+            check and sent it down the Buffer path with no real encoding. If a
+            dependency ever needs Buffer in the browser, polyfill it properly;
+            do not stub it. */}
       </head>
       <body className="min-h-svh bg-background text-foreground antialiased">
         <JotaiProvider>


### PR DESCRIPTION
## 변경 요약

쓰지 않는 `gray-matter` 런타임 의존성과, 그것을 위해 `__root.tsx` 에 남아 있던 `window.Buffer` 스텁을 제거합니다. 스텁은 필요 없는 수준이 아니라 **@tanstack/router-core 의 RawStream 바이너리 인코딩을 조용히 망가뜨리고 있었습니다**(이 앱은 RawStream 을 안 써서 사용자 영향 없음 — 잠복 결함).

## 변경 종류

- [ ] 새 카탈로그 항목 (`services/*.md`)
- [ ] 기존 항목 수정
- [x] 사이트 코드/UI
- [ ] 문서 (README / CONTRIBUTING / CHANGELOG 등)
- [ ] `/design-md` 스킬

---

## gray-matter 는 어디서도 쓰이지 않았습니다

- `grep -rn gray-matter src scripts` → import 0건, 주석 3곳뿐
- `pnpm why gray-matter` → 루트만 직접 의존, 다른 패키지는 필요로 하지 않음
- 서버 빌드 `.output/server/_libs/` 에 gray-matter/js-yaml 청크 없음
- `src/lib/content-parser.ts` 첫머리가 이유를 기록하고 있습니다 — 브라우저 번들에서 Node `Buffer` 를 요구해 hydration 을 깨서 손수 만든 파서로 대체됨

## Buffer 스텁을 빼기 전에 확인한 것

기준선 빌드의 클라이언트 번들(`.output/public/assets/*.js`)에서 `Buffer` 를 전수 조사했습니다.

| 등장 | 정체 |
|---|---|
| 3건 | 스텁 문자열 자체 (컴포넌트에 인라인) |
| 1건 | `ArrayBuffer` 부분 일치 |
| **1건** | `@tanstack/router-core/dist/esm/ssr/serializer/RawStream.js` — **존재 확인 후 사용** |

유일한 실제 소비자는 이렇게 생겼습니다:

```js
or = globalThis.Buffer, sr = !!or && typeof or.from === "function"
function cr(e) { if (sr) return or.from(e).toString("base64"); /* else btoa 폴백 */ }
function lr(e) { if (sr) { const t = or.from(e, "base64"); return new Uint8Array(t.buffer, t.byteOffset, t.byteLength) } /* else atob 폴백 */ }
```

스텁의 `from` 은 입력을 그대로 돌려주므로 `sr` 을 true 로 만들어 **Buffer 경로로 보냅니다.** 번들과 같은 함수로 왕복을 실측했습니다:

| 환경 | encode (정답 `aGn/AAc=`) | decode |
|---|---|---|
| **스텁 있음 (현재)** | `"104,105,255,0,7"` | `[]` ✗ |
| Buffer 없음 (제거 후 브라우저) | `"aGn/AAc="` | 원본 5바이트 ✓ |
| 실제 Buffer (Node) | `"aGn/AAc="` | 원본 5바이트 ✓ |

앱 코드에 `RawStream` / `createServerFn` / `ReadableStream` 사용처가 없어 지금까지 발현되지 않았습니다. 제거하면 브라우저에서 올바른 `atob`/`btoa` 폴백을 탑니다. 스텁 자리에는 "브라우저에서 Buffer 가 필요해지면 스텁 말고 제대로 된 polyfill" 이라는 이유를 남겼습니다 — 같은 스텁이 다시 들어오는 걸 막기 위해서입니다.

## 의존성 diff 범위

- `package.json`: `gray-matter` 한 줄 삭제
- `pnpm-lock.yaml`: **추가 0줄**, gray-matter 와 전이 의존성 삭제만 (`js-yaml@3` · `argparse` · `section-matter` · `extend-shallow` · `is-extendable` · `kind-of` · `sprintf-js` · `strip-bom-string`)
- CI 의 `draft-validator.ts` 가 쓰는 `yaml` (devDependency) 은 별개 패키지라 그대로입니다

> 로컬 `pnpm remove` 출력에 `@types/jsdom 28.0.3 → 30.0.0` 이 보였지만 lockfile diff 에는 없습니다. 이 워크트리의 node_modules 가 다른 브랜치 기준이었다가 main 이 이미 고정한 30.0.0 으로 맞춰진 것이라 커밋 대상이 아닙니다.

## 검증

```
pnpm typecheck        OK
pnpm lint             OK
pnpm format:check     OK  (.claude/skills/docs-crawler/ CRLF 오탐 14건만 — CLAUDE.md 기록)
pnpm test             OK  835 tests
pnpm validate:catalog OK
pnpm validate:previews OK
pnpm tokens:check     OK
pnpm audit:oklch      OK
pnpm build            OK
```

프로덕션 빌드를 preview 서버로 띄워 **홈 hydration** 을 확인했습니다:

- `window.Buffer` → `undefined`
- 검색 입력 `토스` → 목록 20 → 2, URL `?q=` 갱신 / 지우면 20 복귀
- 카테고리 클릭 → 5건, URL `?cat=commerce`
- 콘솔에 `Buffer is not defined` 없음 (남은 404 는 Vercel 에서만 존재하는 `/_vercel/insights/script.js`)
- 서빙된 HTML(`/`, `/services/toss`)과 `.output` 전체에 스텁 문자열 0건

## 일반 체크

- [x] `pnpm typecheck && pnpm lint && pnpm build` 통과
- [x] DCO 서명 (`git commit -s`)
- [x] [CONTRIBUTING.md](https://github.com/CaesiumY/ko-design-md/blob/main/CONTRIBUTING.md) 가이드라인 준수

## 관련 이슈

PR #329 리뷰 대응 중 발견 (`gray-matter` 가 런타임 파서 후보로 거론됐다가 미사용으로 확인됨).
